### PR TITLE
refactor: phase 3 — real health check, drop Hello World

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,5 +1,5 @@
 import express, { Application, Response, Request, NextFunction } from "express";
-import "../database";
+import mongoose from "../database";
 import _config from "../config";
 import cors from "cors";
 import morgan from "morgan";
@@ -28,10 +28,15 @@ _app.use((err: ErrorHandler, req: Request, res: Response, _: NextFunction) => {
   });
 });
 
-// _app.use(express.static(path.join(__dirname, "public")));
-_app.get("*", (_: Request, res: Response) => {
-  // res.sendFile(path.resolve(__dirname, "public/index.html"));
-  res.send("Hello World");
+_app.get("/", (_: Request, res: Response) => {
+  const mongoConnected = mongoose.connection.readyState === 1;
+
+  res.status(mongoConnected ? 200 : 503).json({
+    status: mongoConnected ? "ok" : "degraded",
+    uptime: process.uptime(),
+    mongo: mongoConnected ? "connected" : "disconnected",
+    timestamp: new Date().toISOString(),
+  });
 });
 
 _app.listen(_app.get("port"));


### PR DESCRIPTION
## Summary

Phase 3 of the refactor plan: make Express monitorable.
1 commit, 1 file, +10/-5 lines.

## What changed

\`src/api/app.ts\` — \`GET *\` "Hello World" catchall replaced by a meaningful \`GET /\` health check:

- Returns JSON: \`{ status, uptime, mongo, timestamp }\`
- 200 OK if Mongo is connected (\`mongoose.connection.readyState === 1\`)
- 503 if Mongo is disconnected
- Non-\`/api/*\` paths now return Express's default 404 (was: 200 "Hello World")

Also dropped the commented-out static-file mount (dead code from a never-shipped \`public/index.html\`).

## What's NOT in this PR (intentional)

- Phase 4 — discord.js 13 → 14 migration
- Phase 5 — \`b!\` prefix → slash commands
- Phase 6 — TS / Mongoose / Node upgrade
- Bot status in the health check (would require coupling Express boot with Discord client; not worth it now)

## Heads-up

If Railway has a *Healthcheck Path* configured to something other than \`/\` (e.g. \`/health\`), this PR will fail health checks. Verify the Railway config or tell me to add the alias.

## Test plan

- [ ] \`GET /\` returns 200 with valid JSON when Mongo is up
- [ ] \`GET /\` returns 503 when Mongo is down (kill DB, hit endpoint)
- [ ] \`GET /api/user\` still works (auto-loaded routes intact)
- [ ] \`GET /random-path\` returns 404 (no more "Hello World")
- [ ] Railway health check still passes after deploy