### PR TITLE
refactor: phase 7c — modernize mod command perms

### DIFF
--- a/src/shared/types/main.ts
+++ b/src/shared/types/main.ts
@@ -4,6 +4,7 @@ import {
   ChatInputCommandInteraction,
   Message,
   MessageApplicationCommandData,
+  PermissionResolvable,
   UserApplicationCommandData,
 } from "discord.js";
 import ClientDiscord from "../classes/ClientDiscord";
@@ -45,6 +46,7 @@ export type ISlashCommand = {
   description: string;
   options?: SlashCommandsOptions[];
   ownerOnly: boolean;
+  defaultMemberPermissions?: PermissionResolvable;
   run: (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -10,6 +10,7 @@ const pull: ISlashCommand = {
   category: "mod",
   description: "Limpia el chat",
   ownerOnly: false,
+  defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [
     {
       name: "amount",

--- a/src/slashCommands/mod/register.ts
+++ b/src/slashCommands/mod/register.ts
@@ -1,7 +1,8 @@
 import {
   ChatInputCommandInteraction,
   EmbedBuilder,
-  GuildMember,
+  PermissionFlagsBits,
+  PermissionsBitField,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { MoreCommandTypes } from "../../shared/constants/commands";
@@ -9,13 +10,12 @@ import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 import * as userDao from "../../api/dao/user.dao";
 
-const ALLOWED_ROLES = ["Staff", "Admin"] as const;
-
 const pull: ISlashCommand = {
   name: "register",
   category: "mod",
   description: "Agrega un miembro a la base de datos de Gmi2",
   ownerOnly: false,
+  defaultMemberPermissions: PermissionFlagsBits.Administrator,
   options: [
     {
       name: "name",
@@ -48,14 +48,13 @@ const pull: ISlashCommand = {
     args: Argument[]
   ) => {
     try {
-      const member = interaction.member as GuildMember | null;
-      const highestRole = member?.roles.highest.name;
-      if (!highestRole || !ALLOWED_ROLES.includes(highestRole as any)) {
+      if (
+        !(
+          interaction.member?.permissions as Readonly<PermissionsBitField>
+        )?.has(PermissionFlagsBits.Administrator)
+      ) {
         return interaction.reply({
-          content:
-            `No tiene permisos para esta acción\n` +
-            `rol actual: ${highestRole ?? "?"}\n` +
-            `rol requerido: ${ALLOWED_ROLES.join(" o ")}`,
+          content: "Necesitás permiso de Administrator para usar este comando.",
           ephemeral: true,
         });
       }

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -14,6 +14,7 @@ const pull: ISlashCommand = {
   category: "mod",
   description: "Botito repite lo que dices",
   ownerOnly: false,
+  defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [
     {
       name: "message",


### PR DESCRIPTION
## Summary

Phase 7c — modernizes the permission gating on mod commands.
Single fat commit, 4 files touched, no behavior change for users
who already had the right permissions; users without them no longer
see the command in autocomplete.

## What changed

| Command | Before (runtime only) | After |
|---|---|---|
| \`/register\` | role-name === "Staff" \|\| "Admin" | Discord-side: \`Administrator\` + runtime: same flag |
| \`/say\` | runtime: \`ManageMessages\` | Discord-side: \`ManageMessages\` + runtime kept |
| \`/clear\` | runtime: \`ManageMessages\` | Discord-side: \`ManageMessages\` + runtime kept |

## Why both Discord-side AND runtime check

\`default_member_permissions\` is the right UX — the command is hidden in autocomplete for members who can't use it, no error embed needed. But it can be **overridden per-server by an admin via the Integrations settings**, so the runtime check stays as a defensive backup. discord.js's documented best practice for mod commands.

## Files

- \`src/shared/types/main.ts\` — adds optional \`defaultMemberPermissions: PermissionResolvable\` to \`ISlashCommand\`. The loader (\`handlers/index.ts:loadSlashCommands\`) doesn't need any code change — it pushes the entire command object into the array passed to \`client.application.commands.set()\`, and the new field flows through unchanged.
- \`src/slashCommands/mod/register.ts\` — replaces the role-name check with the canonical permissions check. Drops \`ALLOWED_ROLES\` const and \`GuildMember\` import.
- \`src/slashCommands/mod/say.ts\` — adds the field.
- \`src/slashCommands/mod/clear.ts\` — adds the field.

## Test plan

- [ ] After bot reboot, members **without** Administrator no longer see \`/register\` in their autocomplete
- [ ] Member with Administrator can run \`/register\`
- [ ] Member without Administrator who tries to invoke \`/register\` (e.g., from a saved snippet) gets the runtime error reply
- [ ] \`/say\` and \`/clear\` work the same as before for ManageMessages-having members; hidden in autocomplete for everyone else
- [ ] Old behavior (role-name check) is gone — Staff/Admin role NAMES no longer matter, only the permission bit they grant