### PR TITLE
ci: add GitHub Actions workflow for typecheck + tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,17 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # pnpm/action-setup hasn't shipped a v5 that uses Node 24 yet;
+      # this opts every JS action in this job to Node 24 to silence
+      # the Node 20 deprecation warning until upstream catches up.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, master]
+  push:
+    branches: [dev, master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm exec tsc --noEmit
+
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
## Summary

Single GitHub Actions workflow that runs typecheck (\`tsc --noEmit\`)
and tests (\`pnpm test\`) on every PR and every push to \`dev\` or
\`master\`. After this lands, every PR gets a green/red signal
automatically.

## File

\`\`\`yaml
.github/workflows/ci.yml
\`\`\`

One job, six steps: checkout → setup pnpm → setup node 22 → install with frozen lockfile → typecheck → test.

## Key choices

| Choice | Why |
|---|---|
| Ubuntu only | Railway is Linux; Windows-only issues would only affect local dev, not deploys |
| Node 22 only | \`engines.node >=22.0.0\` is enforced in package.json; testing older versions would be cosmetic |
| \`--frozen-lockfile\` | Fails if \`pnpm-lock.yaml\` is out of sync with \`package.json\` — protects against PRs that forget to commit the lock |
| Typecheck and test as separate steps | If one fails, the failing step is obvious in the run summary |
| \`concurrency.cancel-in-progress\` | New commits to the same PR cancel the in-flight run, saving Actions minutes |
| Triggers PR + push to dev/master | PR runs validate before merge; push runs validate the merge commit itself (in case anything sneaks through) |

## Validation

- This PR itself will trigger the new workflow once merged into the workflow's known triggers (the workflow only takes effect after it's on the default branch — first run will be on the PR triggered after merge)
- pnpm test currently has 14 tests, all passing in ~2.7s locally
- tsc --noEmit currently passes with 0 errors

## What's NOT in this PR

- Lint job (eslint config exists but is on v8, deprecated; modernizing eslint is its own thing)
- Coverage upload (no \`@vitest/coverage-v8\` installed; would need a separate decision)
- Build job — \`tsc --noEmit\` already proves the source compiles; running \`pnpm build\` in CI would also produce \`dist/\` we don't need
- Auto-deploy — Railway already auto-deploys on push to master via its own integration
- Branch protection rules requiring CI to pass — separate config in repo settings, not workflow

## Test plan

- [ ] After merge, the next PR triggers the workflow and reports green
- [ ] If a future PR breaks tsc, the workflow turns red on the typecheck step
- [ ] If a future PR breaks tests, the workflow turns red on the test step
- [ ] If a future PR forgets to update \`pnpm-lock.yaml\`, the install step fails with a clear message