### PR TITLE
test: cover helpers + DAOs (T1 + T2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.2.4",
     "eslint-plugin-promise": "^6.0.0",
+    "mongodb-memory-server": "^11.1.0",
     "prettier": "^2.7.1",
     "rimraf": "^6.1.3",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       eslint-plugin-promise:
         specifier: ^6.0.0
         version: 6.6.0(eslint@8.57.1)
+      mongodb-memory-server:
+        specifier: ^11.1.0
+        version: 11.1.0
       prettier:
         specifier: ^2.7.1
         version: 2.8.8
@@ -673,6 +676,9 @@ packages:
   '@types/whatwg-url@11.0.5':
     resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
 
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -784,6 +790,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -840,6 +850,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -848,12 +861,61 @@ packages:
     resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
     engines: {node: '>=6.0.0'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
@@ -881,6 +943,13 @@ packages:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
 
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   builtins@5.1.0:
     resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
 
@@ -904,6 +973,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -922,6 +995,9 @@ packages:
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1233,6 +1309,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
@@ -1246,6 +1325,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1285,6 +1367,14 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1295,6 +1385,15 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -1413,6 +1512,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -1670,6 +1773,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1696,6 +1803,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1758,6 +1869,18 @@ packages:
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server-core@11.1.0:
+    resolution: {integrity: sha512-GwpnJVIiUyXdi5BoTsExrvLupSt3sJzCSX5P6fxlr0dCrJkhumiq8SQIqtTBqTu2mMpFMCHdjSS0QMUvFMpbWw==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server@11.1.0:
+    resolution: {integrity: sha512-x9psV1KXRgG5t14AmsrfcWCqlNXvPOzcyroMSeRU5vkAm8jxEF5WiLGdGCONLOgeCNjRnpg6igyDum/eTwiooA==}
+    engines: {node: '>=20.19.0'}
+
   mongodb@6.20.0:
     resolution: {integrity: sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==}
     engines: {node: '>=16.20.1'}
@@ -1769,6 +1892,33 @@ packages:
       mongodb-client-encryption: '>=6.0.0 <7'
       snappy: ^7.3.2
       socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongodb@7.2.0:
+    resolution: {integrity: sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
         optional: true
@@ -1821,6 +1971,10 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  new-find-package-json@2.0.0:
+    resolution: {integrity: sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==}
+    engines: {node: '>=12.22.0'}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
@@ -1887,13 +2041,25 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1947,6 +2113,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1961,6 +2130,10 @@ packages:
   pixelmatch@5.3.0:
     resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
     hasBin: true
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
 
   pngjs@6.0.0:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
@@ -2181,6 +2354,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
     engines: {node: '>= 0.4'}
@@ -2216,6 +2392,15 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -2490,6 +2675,10 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3095,6 +3284,10 @@ snapshots:
     dependencies:
       '@types/webidl-conversions': 7.0.3
 
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
@@ -3239,6 +3432,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3314,15 +3509,53 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
   await-to-js@3.0.0: {}
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.2)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.1(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
 
   basic-auth@2.0.1:
     dependencies:
@@ -3362,6 +3595,10 @@ snapshots:
 
   bson@6.10.4: {}
 
+  bson@7.2.0: {}
+
+  buffer-crc32@0.2.13: {}
+
   builtins@5.1.0:
     dependencies:
       semver: 7.7.4
@@ -3387,6 +3624,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@6.3.0: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -3401,6 +3640,8 @@ snapshots:
   color-name@1.1.4: {}
 
   common-tags@1.8.2: {}
+
+  commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
 
@@ -3822,6 +4063,12 @@ snapshots:
 
   etag@1.8.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   exif-parser@0.1.12: {}
 
   expect-type@1.3.0: {}
@@ -3863,6 +4110,8 @@ snapshots:
       - supports-color
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -3913,6 +4162,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-cache-dir@3.3.2:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -3925,6 +4185,10 @@ snapshots:
       rimraf: 3.0.2
 
   flatted@3.4.2: {}
+
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -4061,6 +4325,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.4.24:
     dependencies:
@@ -4318,6 +4589,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -4337,6 +4612,10 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
 
   math-intrinsics@1.1.0: {}
 
@@ -4382,11 +4661,66 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
 
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb-memory-server-core@11.1.0:
+    dependencies:
+      async-mutex: 0.5.0
+      camelcase: 6.3.0
+      debug: 4.4.3
+      find-cache-dir: 3.3.2
+      follow-redirects: 1.16.0(debug@4.4.3)
+      https-proxy-agent: 7.0.6
+      mongodb: 7.2.0
+      new-find-package-json: 2.0.0
+      semver: 7.7.4
+      tar-stream: 3.2.0
+      tslib: 2.8.1
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
+  mongodb-memory-server@11.1.0:
+    dependencies:
+      mongodb-memory-server-core: 11.1.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
   mongodb@6.20.0:
     dependencies:
       '@mongodb-js/saslprep': 1.4.11
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
+
+  mongodb@7.2.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.11
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
 
   mongoose@8.23.1:
     dependencies:
@@ -4436,6 +4770,12 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  new-find-package-json@2.0.0:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   node-exports-info@1.6.0:
     dependencies:
@@ -4519,13 +4859,23 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -4565,6 +4915,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pend@1.2.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4574,6 +4926,10 @@ snapshots:
   pixelmatch@5.3.0:
     dependencies:
       pngjs: 6.0.0
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
 
   pngjs@6.0.0: {}
 
@@ -4836,6 +5192,15 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string.prototype.trim@1.2.10:
     dependencies:
       call-bind: 1.0.9
@@ -4876,6 +5241,30 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 
@@ -5117,6 +5506,11 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  yauzl@3.3.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/src/api/dao/birthday.dao.test.ts
+++ b/src/api/dao/birthday.dao.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { setupInMemoryMongo } from "../../test-utils/setup-mongo";
+import * as birthdayDao from "./birthday.dao";
+import * as userDao from "./user.dao";
+
+setupInMemoryMongo();
+
+const seedUser = (overrides: {
+  name: string;
+  discordId: string;
+  day: string;
+  month: string;
+}) =>
+  userDao.addUser({
+    name: overrides.name,
+    discordId: overrides.discordId,
+    birthdayDay: overrides.day,
+    birthdayMonth: overrides.month,
+  });
+
+describe("birthday.dao (against in-memory mongo)", () => {
+  describe("getBirthdays", () => {
+    it("returns 200 with empty data when there are no users", async () => {
+      const result = await birthdayDao.getBirthdays();
+      expect(result.statusCode).toBe(200);
+      expect((result as any).data).toEqual({});
+    });
+
+    it("groups users by Spanish month name and respects birthdayMonth ordering", async () => {
+      await seedUser({ name: "Diego", discordId: "1", day: "17", month: "2" });
+      await seedUser({ name: "Carlos", discordId: "2", day: "5", month: "2" });
+      await seedUser({ name: "Ana", discordId: "3", day: "20", month: "5" });
+
+      const result = await birthdayDao.getBirthdays();
+      const data = (result as any).data;
+
+      expect(result.statusCode).toBe(200);
+      expect(Object.keys(data)).toContain("Febrero");
+      expect(Object.keys(data)).toContain("Mayo");
+      expect(data.Febrero).toHaveLength(2);
+      expect(data.Mayo).toHaveLength(1);
+    });
+
+    it("ignores users without a birthdayMonth", async () => {
+      await userDao.addUser({
+        name: "Sin Mes",
+        discordId: "9",
+        birthdayDay: "10",
+        birthdayMonth: "0", // 0 → falsy, gets skipped by getBirthdays' `if (!birthdayMonth)`
+      });
+
+      const result = await birthdayDao.getBirthdays();
+      expect((result as any).data).toEqual({});
+    });
+  });
+
+  describe("getBirthdaysByMonth", () => {
+    it("returns only users matching the requested month", async () => {
+      await seedUser({ name: "Feb1", discordId: "1", day: "5", month: "2" });
+      await seedUser({ name: "Feb2", discordId: "2", day: "10", month: "2" });
+      await seedUser({ name: "May1", discordId: "3", day: "1", month: "5" });
+
+      // getBirthdaysByMonth uses (birthdayMonth - 1 !== month) so we pass 1 (Feb) here
+      const result = await birthdayDao.getBirthdaysByMonth(1);
+      const data = (result as any).data;
+
+      expect(result.statusCode).toBe(200);
+      expect(data.Febrero).toHaveLength(2);
+      expect(Object.keys(data)).not.toContain("Mayo");
+    });
+
+    it("returns empty data when no users match", async () => {
+      await seedUser({ name: "Solo", discordId: "1", day: "5", month: "2" });
+
+      const result = await birthdayDao.getBirthdaysByMonth(11); // December
+      expect((result as any).data).toEqual({});
+    });
+  });
+
+  describe("getNextBirthday", () => {
+    it("returns the earliest upcoming birthday relative to now in Lima time", async () => {
+      // We can't pin the calendar here without mocking dayjs internals,
+      // so we seed a user whose birthday is many months away in both
+      // hemispheres of the year and verify the dao returns SOME user.
+      await seedUser({ name: "FarFuture", discordId: "1", day: "31", month: "12" });
+
+      const result = await birthdayDao.getNextBirthday();
+      expect(result.statusCode).toBe(200);
+      expect((result as any).data).toBeTruthy();
+      expect((result as any).data.name).toBe("FarFuture"); // capitalize only touches first letter
+    });
+
+    it("returns 200 with undefined data when no users have birthday fields", async () => {
+      const result = await birthdayDao.getNextBirthday();
+      // sortedUsers[0] is undefined; ResponseData wraps it
+      expect(result.statusCode).toBe(200);
+      expect((result as any).data).toBeUndefined();
+    });
+  });
+});

--- a/src/api/dao/user.dao.test.ts
+++ b/src/api/dao/user.dao.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import { setupInMemoryMongo } from "../../test-utils/setup-mongo";
+import User from "../models/User";
+import * as userDao from "./user.dao";
+
+setupInMemoryMongo();
+
+const validBody = {
+  name: "Diego",
+  discordId: "111",
+  birthdayDay: "17",
+  birthdayMonth: "2",
+};
+
+describe("user.dao (against in-memory mongo)", () => {
+  describe("addUser", () => {
+    it("returns 200 and persists the user on a complete body", async () => {
+      const result = await userDao.addUser(validBody);
+      expect(result.statusCode).toBe(200);
+
+      const stored = await User.findOne({ name: "Diego" });
+      expect(stored).toBeTruthy();
+      expect(stored?.birthdayDay).toBe(17);
+      expect(stored?.birthdayMonth).toBe(2);
+      expect(stored?.discordId).toBe("111");
+    });
+
+    it("capitalizes the name on insertion", async () => {
+      await userDao.addUser({ ...validBody, name: "diego" });
+      const stored = await User.findOne({ name: "Diego" });
+      expect(stored).toBeTruthy();
+    });
+
+    it("returns 422 when required fields are missing", async () => {
+      const result = await userDao.addUser({
+        name: "",
+        birthdayDay: "17",
+        birthdayMonth: "2",
+      } as any);
+      expect(result.statusCode).toBe(422);
+    });
+  });
+
+  describe("readUsers", () => {
+    it("returns 200 with all inserted users", async () => {
+      await userDao.addUser(validBody);
+      await userDao.addUser({
+        ...validBody,
+        name: "Carlos",
+        discordId: "222",
+      });
+
+      const result = await userDao.readUsers();
+      expect(result.statusCode).toBe(200);
+      expect((result as any).data).toHaveLength(2);
+    });
+
+    it("returns 200 with an empty array when there are no users", async () => {
+      const result = await userDao.readUsers();
+      expect(result.statusCode).toBe(200);
+      expect((result as any).data).toEqual([]);
+    });
+  });
+
+  describe("readUserByName", () => {
+    it("returns 200 with the matching user (case-insensitive)", async () => {
+      await userDao.addUser(validBody);
+
+      const result = await userDao.readUserByName("diego");
+      expect(result.statusCode).toBe(200);
+      expect((result as any).data.name).toBe("Diego");
+    });
+
+    it("returns 400 when the name doesn't match any user", async () => {
+      const result = await userDao.readUserByName("Inexistente");
+      expect(result.statusCode).toBe(400);
+    });
+
+    it("returns 400 when called with an empty name", async () => {
+      const result = await userDao.readUserByName("");
+      expect(result.statusCode).toBe(400);
+    });
+  });
+
+  describe("readUserByDiscordId", () => {
+    it("returns 200 with the matching user", async () => {
+      await userDao.addUser(validBody);
+
+      const result = await userDao.readUserByDiscordId("111");
+      expect(result.statusCode).toBe(200);
+      expect((result as any).data.name).toBe("Diego");
+    });
+
+    it("returns 400 when the discordId doesn't match", async () => {
+      const result = await userDao.readUserByDiscordId("nope");
+      expect(result.statusCode).toBe(400);
+    });
+
+    it("returns 400 when called with an empty discordId", async () => {
+      const result = await userDao.readUserByDiscordId("");
+      expect(result.statusCode).toBe(400);
+    });
+  });
+
+  describe("setDiscordId", () => {
+    it("updates the discordId for a user matched by name", async () => {
+      await userDao.addUser({ ...validBody, discordId: "old" });
+
+      const result = await userDao.setDiscordId({
+        name: "Diego",
+        id: "new",
+      });
+      expect(result.statusCode).toBe(200);
+
+      const stored = await User.findOne({ name: "Diego" });
+      expect(stored?.discordId).toBe("new");
+    });
+
+    it("returns 422 on missing name or id", async () => {
+      const result = await userDao.setDiscordId({ name: "", id: "x" });
+      expect(result.statusCode).toBe(422);
+    });
+  });
+
+  describe("setBirthday", () => {
+    it("updates birthdayDay and birthdayMonth by name", async () => {
+      await userDao.addUser(validBody);
+
+      const result = await userDao.setBirthday({
+        name: "Diego",
+        day: 25,
+        month: 12,
+      });
+      expect(result.statusCode).toBe(200);
+
+      const stored = await User.findOne({ name: "Diego" });
+      expect(stored?.birthdayDay).toBe(25);
+      expect(stored?.birthdayMonth).toBe(12);
+    });
+
+    it("returns 422 on missing fields", async () => {
+      const result = await userDao.setBirthday({
+        name: "",
+        day: 0,
+        month: 0,
+      });
+      expect(result.statusCode).toBe(422);
+    });
+  });
+
+  describe("deleteUser", () => {
+    it("removes the user with the given _id", async () => {
+      await userDao.addUser(validBody);
+      const stored = await User.findOne({ name: "Diego" });
+
+      const result = await userDao.deleteUser(stored!._id.toString());
+      expect(result.statusCode).toBe(200);
+
+      const after = await User.findOne({ name: "Diego" });
+      expect(after).toBeNull();
+    });
+
+    it("returns 422 when called with an empty id", async () => {
+      const result = await userDao.deleteUser("");
+      expect(result.statusCode).toBe(422);
+    });
+  });
+
+  describe("getCurrentMessary / updateMonth", () => {
+    it("updateMonth sets user.month and getCurrentMessary reads it back", async () => {
+      await userDao.addUser(validBody);
+
+      const update = await userDao.updateMonth("111", 7);
+      expect(update.statusCode).toBe(200);
+
+      const read = await userDao.getCurrentMessary("111");
+      expect(read.statusCode).toBe(200);
+      expect((read as any).data).toBe(7);
+    });
+
+    it("getCurrentMessary returns 422 on empty discordId", async () => {
+      const result = await userDao.getCurrentMessary("");
+      expect(result.statusCode).toBe(422);
+    });
+
+    it("getCurrentMessary returns 400 when the user doesn't exist", async () => {
+      const result = await userDao.getCurrentMessary("nope");
+      expect(result.statusCode).toBe(400);
+    });
+
+    it("updateMonth returns 422 on empty discordId or zero month", async () => {
+      const a = await userDao.updateMonth("", 5);
+      expect(a.statusCode).toBe(422);
+
+      const b = await userDao.updateMonth("111", 0);
+      expect(b.statusCode).toBe(422);
+    });
+  });
+});

--- a/src/shared/utils/dayjs.test.ts
+++ b/src/shared/utils/dayjs.test.ts
@@ -1,0 +1,44 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { getDate, getNewDate } from "./dayjs";
+
+const FIXED_UTC = new Date(Date.UTC(2026, 4, 6, 18, 0, 0)); // 2026-05-06 18:00 UTC
+
+describe("dayjs helpers (with fixed system time)", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_UTC);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  describe("getNewDate(city)", () => {
+    it("returns a dayjs in the requested city's timezone", () => {
+      const d = getNewDate("lima");
+      // Lima is UTC-5, so 18:00 UTC → 13:00 Lima
+      expect(d.hour()).toBe(13);
+      expect(d.date()).toBe(6);
+      expect(d.month()).toBe(4); // May (0-indexed)
+      expect(d.year()).toBe(2026);
+    });
+  });
+
+  describe("getDate({...})", () => {
+    it("overrides the fields it's given and keeps the rest from getNewDate", () => {
+      const d = getDate({ city: "lima", hours: 9, minutes: 30 });
+      expect(d.hour()).toBe(9);
+      expect(d.minute()).toBe(30);
+      expect(d.second()).toBe(0); // default override to 0
+      expect(d.millisecond()).toBe(0); // default override to 0
+      expect(d.date()).toBe(6); // unchanged from getNewDate
+    });
+
+    it("supports a custom date number", () => {
+      const d = getDate({ city: "lima", date: 25 });
+      expect(d.date()).toBe(25);
+      expect(d.month()).toBe(4); // unchanged
+    });
+  });
+});

--- a/src/shared/utils/helpers.test.ts
+++ b/src/shared/utils/helpers.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  capitalize,
+  dateToUTC5,
+  mentionUser,
+  random,
+  rangeHandler,
+  setParams,
+  shuffle,
+} from "./helpers";
+
+describe("helpers — pure functions", () => {
+  describe("random(min, max)", () => {
+    it("returns an integer within [min, max] (inclusive)", () => {
+      for (let i = 0; i < 200; i++) {
+        const r = random(3, 7);
+        expect(Number.isInteger(r)).toBe(true);
+        expect(r).toBeGreaterThanOrEqual(3);
+        expect(r).toBeLessThanOrEqual(7);
+      }
+    });
+
+    it("returns the only possible value when min === max", () => {
+      expect(random(5, 5)).toBe(5);
+    });
+  });
+
+  describe("capitalize(str)", () => {
+    it("uppercases the first letter of a single word", () => {
+      expect(capitalize("hola")).toBe("Hola");
+    });
+
+    it("uppercases the first letter of every space-separated word", () => {
+      expect(capitalize("hola mundo cruel")).toBe("Hola Mundo Cruel");
+    });
+
+    it("leaves an already-capitalized word alone", () => {
+      expect(capitalize("Hola")).toBe("Hola");
+    });
+
+    it("returns an empty string when given empty input", () => {
+      expect(capitalize("")).toBe("");
+    });
+  });
+
+  describe("setParams(params)", () => {
+    it("builds a single key=value query string with leading '?'", () => {
+      expect(setParams({ foo: "bar" })).toBe("?foo=bar");
+    });
+
+    it("joins multiple keys with '&'", () => {
+      expect(setParams({ foo: "bar", baz: 42 })).toBe("?foo=bar&baz=42");
+    });
+
+    it("supports boolean values", () => {
+      expect(setParams({ flag: true })).toBe("?flag=true");
+    });
+  });
+
+  describe("dateToUTC5(date)", () => {
+    it("subtracts 5 hours from a UTC date past 05:00", () => {
+      // 2026-01-15 12:00:00 UTC → 2026-01-15 07:00 in UTC-5
+      const utc = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+      const result = dateToUTC5(utc);
+      expect(result.year).toBe(2026);
+      expect(result.month).toBe(1); // january, +1 from getUTCMonth
+      expect(result.day).toBe(15);
+      expect(result.hours).toBe(7);
+    });
+
+    it("rolls back the day when UTC hours < 5 (puts hours into 19-23 range of previous day)", () => {
+      // 2026-01-15 03:00:00 UTC → 2026-01-14 22:00 in UTC-5
+      const utc = new Date(Date.UTC(2026, 0, 15, 3, 0, 0));
+      const result = dateToUTC5(utc);
+      expect(result.day).toBe(14);
+      expect(result.hours).toBe(22); // 3 + 19 = 22
+    });
+  });
+
+  describe("shuffle(array)", () => {
+    it("returns an array with the same length and same elements as the input", () => {
+      const input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+      const result = shuffle([...input]);
+
+      expect(result).toHaveLength(input.length);
+      expect([...result].sort((a, b) => a - b)).toEqual(input);
+    });
+
+    it("handles empty input", () => {
+      expect(shuffle([])).toEqual([]);
+    });
+  });
+
+  describe("mentionUser(id)", () => {
+    it("wraps the id in the bold-mention markdown format", () => {
+      expect(mentionUser("123456789")).toBe("**<@123456789>**");
+    });
+  });
+
+  describe("rangeHandler(value, min, max)", () => {
+    it("returns the value when it's within range", () => {
+      expect(rangeHandler(5, 1, 10)).toBe(5);
+    });
+
+    it("clamps values above max to max", () => {
+      expect(rangeHandler(99, 1, 10)).toBe(10);
+    });
+
+    it("clamps values below min to min", () => {
+      expect(rangeHandler(-5, 1, 10)).toBe(1);
+    });
+
+    it("returns min when value === min and max when value === max", () => {
+      expect(rangeHandler(1, 1, 10)).toBe(1);
+      expect(rangeHandler(10, 1, 10)).toBe(10);
+    });
+  });
+});

--- a/src/test-utils/setup-mongo.ts
+++ b/src/test-utils/setup-mongo.ts
@@ -1,0 +1,32 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import mongoose from "mongoose";
+import { afterAll, beforeAll, beforeEach } from "vitest";
+
+/**
+ * Boots a single in-memory MongoDB instance for the calling test file
+ * and connects mongoose to it. Truncates every collection before each
+ * test so cases are isolated.
+ *
+ * Call once at the top level of a *.test.ts file before any describe()
+ * — the hooks (beforeAll / afterAll / beforeEach) attach to the file's
+ * scope automatically.
+ */
+export const setupInMemoryMongo = () => {
+  let mongo: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri());
+  }, 120000); // first run downloads the mongod binary; CI-friendly
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongo.stop();
+  });
+
+  beforeEach(async () => {
+    for (const collection of Object.values(mongoose.connection.collections)) {
+      await collection.deleteMany({});
+    }
+  });
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
     globals: false,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    // DAO tests boot mongodb-memory-server. Running multiple test files
+    // in parallel makes the Mongo instances race for ports / binary
+    // locks, leading to flaky 60s timeouts. Serializing file execution
+    // costs ~2-3s overall and removes the flakiness entirely.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary

Adds tier-1 (pure helpers) and tier-2 (DAOs) coverage. Builds on
the vitest scaffolding from phase 7f. Suite size: 14 → ~50+ tests
(T2 commit pending).

## Commit progression

| Commit | What | Tests added |
|---|---|---|
| 1 (\`test(utils): ...\`) — landed | Pure helpers + dayjs with fake timers | +21 (35 total) |
| 2 (\`test(dao): ...\`) — coming | birthday + user DAOs against \`mongodb-memory-server\` | +20-25 (~55+ total) |

The PR will update as commit 2 lands.

## What's covered (commit 1, already pushed)

- \`random\`, \`capitalize\`, \`setParams\`, \`dateToUTC5\`, \`shuffle\`, \`mentionUser\`, \`rangeHandler\`
- \`getNewDate\`, \`getDate\` (with \`vi.useFakeTimers()\` to pin a deterministic moment)

Discord-dependent helpers (\`channelSender\`, \`ownerSender\`, \`errorHandler\`) intentionally not covered — wrappers around discord.js with low-value coverage.

## What's coming (commit 2, in progress)

- mongodb-memory-server boot in \`beforeAll\`, mongoose connect, \`beforeEach\` truncate
- \`birthday.dao\`: getBirthdays, getBirthdaysByMonth, getNextBirthday — happy paths + empty-DB cases
- \`user.dao\`: addUser, readUsers, readUserByName, readUserByDiscordId, setDiscordId, setBirthday, deleteUser, getCurrentMessary, updateMonth — happy paths + 422 invalid input cases

## Test plan

- [ ] CI green on commit 1
- [ ] Commit 2 lands and CI stays green
- [ ] \`pnpm test\` reports 50+ tests passing
- [ ] \`pnpm test:watch\` reruns on save