### PR TITLE
fix(handlers): skip co-located *.test files in event/slash loaders

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -8,10 +8,13 @@ import { logger } from "../shared/utils/helpers";
 
 // Match the runtime's source file extension: .ts when running via tsx
 // (npm run dev), .js when running compiled output (npm start). Skip
-// .d.ts declaration files in either case.
+// .d.ts declaration files and co-located *.test.* files (Vitest is
+// ESM-only and breaks when required from CJS at runtime).
 const sourceExt = __filename.endsWith(".ts") ? ".ts" : ".js";
 const isLoadable = (file: string) =>
-  file.endsWith(sourceExt) && !file.endsWith(".d.ts");
+  file.endsWith(sourceExt) &&
+  !file.endsWith(".d.ts") &&
+  !file.endsWith(`.test${sourceExt}`);
 
 const checkHandler = (
   type: "Event" | "SlashCommand",


### PR DESCRIPTION
## Summary
- El loader de events y slash commands hacia readdirSync y aceptaba todo .ts/.js, incluyendo los .test.ts co-locados.
- En runtime (npm run ts / npm run dev) el import() dinamico sobre esos archivos disparaba Vitest cannot be imported in a CommonJS module using require() porque Vitest es ESM-only.
- Fix: el predicate isLoadable ahora excluye .test.ts / .test.js ademas de .d.ts.

## Test plan
- [ ] npm run ts arranca sin errores rojos de Vitest
- [ ] Todos los slash commands cargan con check verde
- [ ] Todos los events cargan con check verde
- [ ] npm test sigue corriendo los archivos .test.ts correctamente (Vitest los toma directamente, no pasa por el loader del bot)