### PR TITLE
refactor(i18n): convert user-facing strings to neutral Spanish

### DIFF
--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -28,7 +28,7 @@ const pull: ISlashCommand = {
   name: "ahorcado",
   category: "fun",
   description:
-    "Ahorcado. Vos elegís palabra (DM con menú) o el bot la elige (con bot_picks_word).",
+    "Ahorcado. Tú eliges la palabra (DM con menú) o el bot la elige (con bot_picks_word).",
   ownerOnly: false,
   options: [
     {
@@ -93,7 +93,7 @@ const pull: ISlashCommand = {
       );
       if (users.some((u) => u.bot)) {
         return interaction.reply({
-          content: "No podés meter bots.",
+          content: "No puedes agregar bots.",
           ephemeral: true,
         });
       }
@@ -125,13 +125,13 @@ const pull: ISlashCommand = {
         } catch {
           return interaction.reply({
             content:
-              "No te pude mandar DM. Activá los DMs del servidor o usá `bot_picks_word: true`.",
+              "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word: true`.",
             ephemeral: true,
           });
         }
 
         await interaction.reply({
-          content: `Te mandé un DM para elegir la palabra. Tenés 20s.`,
+          content: `Te envié un DM para elegir la palabra. Tienes 20s.`,
         });
 
         try {

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -83,7 +83,7 @@ const pull: ISlashCommand = {
         const typeName = sub.args?.[0].value as string;
         if (!POKE_TYPES.includes(typeName as (typeof POKE_TYPES)[number])) {
           return interaction.reply({
-            content: `Tipo no encontrado. Probá con: ${POKE_TYPES.join(", ")}`,
+            content: `Tipo no encontrado. Prueba con: ${POKE_TYPES.join(", ")}`,
             ephemeral: true,
           });
         }

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -74,7 +74,7 @@ const pull: ISlashCommand = {
       );
       if (users.some((u) => u.bot)) {
         return interaction.reply({
-          content: "No podés meter bots.",
+          content: "No puedes agregar bots.",
           ephemeral: true,
         });
       }

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -49,7 +49,7 @@ const pull: ISlashCommand = {
         const helpEmbed = new Discord.EmbedBuilder()
           .setTitle(`${client.user?.username} Help`)
           .setDescription(
-            `Hola **<@${interaction.user.id}>** — usá ` +
+            `Hola **<@${interaction.user.id}>** — usa ` +
               "`/help command:<nombre>`" +
               ` para ver el detalle de un slash command.\n` +
               `**Total slash commands:** ${client.slashCommands.size}`

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -41,7 +41,7 @@ const pull: ISlashCommand = {
         )
       ) {
         return interaction.reply({
-          content: "No tenés los permisos requeridos para usar este comando.",
+          content: "No tienes los permisos requeridos para usar este comando.",
           ephemeral: true,
         });
       }


### PR DESCRIPTION
## Summary
- Convierte los strings que el bot manda al usuario en Discord de espanol rioplatense (voseo) a espanol neutral (tuteo).
- Cambios en 5 archivos de src/slashCommands/ (8 strings totales).

## Scope decisions
- Cambiados: ahorcado, ruleta, poke, help, say
- Excluido src/shared/data/words.ts: hermano es vocabulario del juego, no modismo (set: padre, madre, hermano, hermana, hijo, hija, ...)
- Excluido src/shared/utils/goodMorning.ts: easter egg cultural del grupo Gmi2, su gracia ESTA en el tono argentino

## Test plan
- [ ] npm run ts arranca el bot sin errores
- [ ] /ahorcado, /ruleta, /poke type, /help, /say muestran los nuevos strings en castellano neutral
- [ ] El cron de goodMorning los viernes sigue mandando el mensaje argentino sin cambios