### PR TITLE
feat: /help facelift — ephemeral default, autocomplete, options, brand identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botito",
-  "version": "1.0.0",
+  "version": "0.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/events/client/interactionCreate.test.ts
+++ b/src/events/client/interactionCreate.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType } from "discord.js";
+import { ApplicationCommandOptionType, MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createMockClient } from "../../test-utils/discord-mocks";
@@ -67,7 +67,7 @@ describe("interactionCreate", () => {
     expect(command.run).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("dispatches to command.run with parsed args on the happy path", () => {

--- a/src/events/client/interactionCreate.test.ts
+++ b/src/events/client/interactionCreate.test.ts
@@ -8,6 +8,7 @@ const createInteraction = (overrides: Record<string, any> = {}) => {
   const reply = vi.fn().mockResolvedValue(undefined);
   return {
     reply,
+    isAutocomplete: () => false,
     isChatInputCommand: () => true,
     command: { id: "cmd" },
     commandName: "ping",
@@ -93,6 +94,54 @@ describe("interactionCreate", () => {
     expect(passedClient).toBe(client);
     expect(passedInteraction).toBe(interaction);
     expect(args).toEqual([{ name: "foo", type: 3, value: "bar" }]);
+  });
+
+  describe("autocomplete", () => {
+    it("routes to command.autocomplete when interaction.isAutocomplete() is true", () => {
+      const client = createMockClient();
+      const command = {
+        name: "help",
+        autocomplete: vi.fn().mockResolvedValue(undefined),
+        run: vi.fn(),
+      };
+      client.slashCommands.set("help", command);
+
+      const interaction = createInteraction({
+        isAutocomplete: () => true,
+        commandName: "help",
+      });
+
+      interactionCreate.execute(interaction, client);
+
+      expect(command.autocomplete).toHaveBeenCalledOnce();
+      expect(command.run).not.toHaveBeenCalled();
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the autocompleted command isn't registered", () => {
+      const interaction = createInteraction({
+        isAutocomplete: () => true,
+        commandName: "ghost",
+      });
+
+      interactionCreate.execute(interaction, createMockClient());
+
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the registered command has no autocomplete handler", () => {
+      const client = createMockClient();
+      client.slashCommands.set("plain", { name: "plain", run: vi.fn() });
+
+      const interaction = createInteraction({
+        isAutocomplete: () => true,
+        commandName: "plain",
+      });
+
+      interactionCreate.execute(interaction, client);
+
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
   });
 
   it("expands subcommand option arrays into the args[].args field", () => {

--- a/src/events/client/interactionCreate.ts
+++ b/src/events/client/interactionCreate.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   CommandInteractionOption,
   Interaction,
+  MessageFlags,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { Argument, ISlashCommand } from "../../shared/types";
@@ -39,7 +40,7 @@ export default {
       if (interaction.user.id !== client.config.ownerId) {
         return interaction.reply({
           content: "Este comando es privado",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
     }

--- a/src/events/client/interactionCreate.ts
+++ b/src/events/client/interactionCreate.ts
@@ -10,6 +10,23 @@ export default {
   name: "interactionCreate",
   type: "client",
   execute(interaction: Interaction, client: ClientDiscord) {
+    // Autocomplete interactions: route to the command's autocomplete handler
+    // if it declared one. They MUST respond within 3s with up to 25 choices,
+    // and they cannot reply with messages — only with respond().
+    if (interaction.isAutocomplete()) {
+      const command: ISlashCommand | undefined = client.slashCommands.get(
+        interaction.commandName
+      );
+      if (command?.autocomplete) {
+        try {
+          command.autocomplete(client, interaction);
+        } catch {
+          // Best-effort; autocomplete has no error reply channel.
+        }
+      }
+      return;
+    }
+
     if (!interaction.isChatInputCommand()) return;
     if (!interaction.command) return;
 

--- a/src/shared/constants/branding.ts
+++ b/src/shared/constants/branding.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../../../package.json"), "utf-8")
+) as { version: string };
+
+export const BOT_BRAND_NAME = "Xiza Bot";
+export const BOT_VERSION = `v${packageJson.version}`;
+
+export type CategoryName = "fun" | "info" | "mod";
+
+const CATEGORY_COLOR: Record<CategoryName, number> = {
+  info: 0x5865f2, // Discord blurple
+  fun: 0xfee75c, // Discord yellow
+  mod: 0xed4245, // Discord red
+};
+
+const CATEGORY_EMOJI: Record<CategoryName, string> = {
+  info: "ℹ️",
+  fun: "🎉",
+  mod: "🛡️",
+};
+
+export const DEFAULT_BRAND_COLOR = CATEGORY_COLOR.info;
+
+const isCategoryName = (s: string | null | undefined): s is CategoryName =>
+  s === "fun" || s === "info" || s === "mod";
+
+export const colorForCategory = (cat: string | null | undefined): number =>
+  isCategoryName(cat) ? CATEGORY_COLOR[cat] : DEFAULT_BRAND_COLOR;
+
+export const emojiForCategory = (cat: string | null | undefined): string =>
+  isCategoryName(cat) ? CATEGORY_EMOJI[cat] : "";
+
+export const capitalize = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1);

--- a/src/shared/types/main.ts
+++ b/src/shared/types/main.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationCommandOptionType,
+  AutocompleteInteraction,
   ChatInputApplicationCommandData,
   ChatInputCommandInteraction,
   Message,
@@ -31,6 +32,7 @@ export type SlashCommandsOptions = {
   options?: SlashCommandsOptions[];
   type?: TypeCommandOption;
   required?: boolean;
+  autocomplete?: boolean;
 };
 
 /* UserApplicationCommandData
@@ -46,10 +48,15 @@ export type ISlashCommand = {
   options?: SlashCommandsOptions[];
   ownerOnly: boolean;
   defaultMemberPermissions?: PermissionResolvable;
+  examples?: string[];
   run: (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[],
+  ) => Promise<unknown>;
+  autocomplete?: (
+    client: ClientDiscord,
+    interaction: AutocompleteInteraction,
   ) => Promise<unknown>;
 };
 

--- a/src/slashCommands/fun/ahorcado.test.ts
+++ b/src/slashCommands/fun/ahorcado.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("death-games", () => ({
@@ -75,7 +76,7 @@ describe("/ahorcado", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("rejects when any chosen player is a bot", async () => {
@@ -97,7 +98,7 @@ describe("/ahorcado", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("bots");
   });
 });

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -2,6 +2,7 @@ import {
   ActionRowBuilder,
   ChatInputCommandInteraction,
   ComponentType,
+  MessageFlags,
   StringSelectMenuBuilder,
 } from "discord.js";
 import Death from "death-games";
@@ -71,7 +72,7 @@ const pull: ISlashCommand = {
       if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
       const channel = interaction.channel;
@@ -94,7 +95,7 @@ const pull: ISlashCommand = {
       if (users.some((u) => u.bot)) {
         return interaction.reply({
           content: "No puedes agregar bots.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
       const usernames = users.map((u) => u.username);
@@ -126,7 +127,7 @@ const pull: ISlashCommand = {
           return interaction.reply({
             content:
               "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word: true`.",
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
 

--- a/src/slashCommands/fun/imc.test.ts
+++ b/src/slashCommands/fun/imc.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
 import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -36,6 +37,6 @@ describe("/imc", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/fun/imc.ts
+++ b/src/slashCommands/fun/imc.ts
@@ -2,6 +2,7 @@ import {
   ChatInputCommandInteraction,
   ColorResolvable,
   EmbedBuilder,
+  MessageFlags,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
@@ -58,7 +59,7 @@ const pull: ISlashCommand = {
       if (!weight || !rawHeight || weight <= 0 || rawHeight <= 0) {
         return interaction.reply({
           content: "No seas pendejo, peso y altura tienen que ser > 0.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/fun/poke.test.ts
+++ b/src/slashCommands/fun/poke.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createMockClient, createMockInteraction, subCommandArg } from "../../test-utils/discord-mocks";
@@ -85,7 +86,7 @@ describe("/poke", () => {
 
       expect(interaction.reply).toHaveBeenCalledOnce();
       const payload = interaction.reply.mock.calls[0][0];
-      expect(payload.ephemeral).toBe(true);
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
       expect(global.fetch).not.toHaveBeenCalled();
     });
   });

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction } from "discord.js";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
 import { Argument, ISlashCommand } from "../../shared/types";
@@ -84,7 +84,7 @@ const pull: ISlashCommand = {
         if (!POKE_TYPES.includes(typeName as (typeof POKE_TYPES)[number])) {
           return interaction.reply({
             content: `Tipo no encontrado. Prueba con: ${POKE_TYPES.join(", ")}`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
         await interaction.deferReply();

--- a/src/slashCommands/fun/ruleta.test.ts
+++ b/src/slashCommands/fun/ruleta.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("death-games", () => ({
@@ -62,7 +63,7 @@ describe("/ruleta", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("rejects when any chosen player is a bot", async () => {
@@ -78,6 +79,6 @@ describe("/ruleta", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -1,4 +1,8 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import Death from "death-games";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
@@ -56,7 +60,7 @@ const pull: ISlashCommand = {
       if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
       const channel = interaction.channel;
@@ -75,7 +79,7 @@ const pull: ISlashCommand = {
       if (users.some((u) => u.bot)) {
         return interaction.reply({
           content: "No puedes agregar bots.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/info/gmi2.test.ts
+++ b/src/slashCommands/info/gmi2.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
 import { createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -20,6 +21,6 @@ describe("/gmi2", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/info/gmi2.ts
+++ b/src/slashCommands/info/gmi2.ts
@@ -1,4 +1,8 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
@@ -17,7 +21,7 @@ const pull: ISlashCommand = {
       if (!interaction.guild) {
         return interaction.reply({
           content: "Este comando solo funciona en un servidor.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/info/help.test.ts
+++ b/src/slashCommands/info/help.test.ts
@@ -1,4 +1,4 @@
-import { Collection } from "discord.js";
+import { Collection, MessageFlags } from "discord.js";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -44,7 +44,7 @@ describe("/help — listing", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
-    expect(payload.ephemeral).toBe(true); // default
+    expect(payload.flags).toBe(MessageFlags.Ephemeral); // default
   });
 
   it("becomes public when public:true is passed", async () => {
@@ -54,7 +54,7 @@ describe("/help — listing", () => {
     await help.run(client, interaction, [arg("public", true)]);
 
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(false);
+    expect(payload.flags).toBeUndefined();
   });
 
   it("filters by category when the option is passed", async () => {
@@ -141,7 +141,7 @@ describe("/help — detail view", () => {
     await help.run(client, interaction, [arg("command", "ghost")]);
 
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("ghost");
   });
 
@@ -155,7 +155,7 @@ describe("/help — detail view", () => {
     await help.run(client, interaction, [arg("command", "secret")]);
 
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("secret");
   });
 });

--- a/src/slashCommands/info/help.test.ts
+++ b/src/slashCommands/info/help.test.ts
@@ -1,58 +1,221 @@
 import { Collection } from "discord.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import help from "./help";
 
-const stubCommand = (name: string, category: string | null) => ({
+const stubCommand = (
+  name: string,
+  category: string | null,
+  overrides: Record<string, any> = {}
+) => ({
   name,
   category,
   description: `Test ${name}`,
   ownerOnly: false,
   run: () => Promise.resolve(),
+  ...overrides,
 });
 
-describe("/help", () => {
-  it("lists all categories when no command is given", async () => {
-    const slashCommands = new Collection<string, any>();
-    slashCommands.set("ping", stubCommand("ping", "info"));
-    slashCommands.set("flip", stubCommand("flip", "fun"));
-    slashCommands.set("clear", stubCommand("clear", "mod"));
+const buildClient = (commands: Record<string, any>, ownerId = "owner-1") => {
+  const slashCommands = new Collection<string, any>();
+  for (const [name, cmd] of Object.entries(commands)) slashCommands.set(name, cmd);
+  return createMockClient({
+    slashCommands,
+    config: { ownerId, gmi2Channel: "gmi2" },
+  });
+};
+
+describe("/help — listing", () => {
+  it("lists all categories with their commands by default", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      flip: stubCommand("flip", "fun"),
+      clear: stubCommand("clear", "mod"),
+    });
 
     const interaction = createMockInteraction();
-    await help.run(createMockClient({ slashCommands }), interaction, []);
+    await help.run(client, interaction, []);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(payload.ephemeral).toBe(true); // default
   });
 
-  it("returns the detail embed when given a known command name", async () => {
-    const slashCommands = new Collection<string, any>();
-    slashCommands.set("ping", stubCommand("ping", "info"));
+  it("becomes public when public:true is passed", async () => {
+    const client = buildClient({ ping: stubCommand("ping", "info") });
 
     const interaction = createMockInteraction();
-    await help.run(createMockClient({ slashCommands }), interaction, [
-      arg("command", "ping"),
-    ]);
+    await help.run(client, interaction, [arg("public", true)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.embeds).toHaveLength(1);
+    expect(payload.ephemeral).toBe(false);
   });
 
-  it("replies ephemerally when given an unknown command name", async () => {
-    const slashCommands = new Collection<string, any>();
-    slashCommands.set("ping", stubCommand("ping", "info"));
+  it("filters by category when the option is passed", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      flip: stubCommand("flip", "fun"),
+    });
 
     const interaction = createMockInteraction();
-    await help.run(createMockClient({ slashCommands }), interaction, [
-      arg("command", "nope"),
-    ]);
+    await help.run(client, interaction, [arg("category", "fun")]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.embeds[0].data.title).toContain("Fun");
+  });
+
+  it("hides ownerOnly commands from non-owners", async () => {
+    const client = buildClient(
+      {
+        ping: stubCommand("ping", "info"),
+        secret: stubCommand("secret", "info", { ownerOnly: true }),
+      },
+      "owner-1"
+    );
+
+    const interaction = createMockInteraction({ user: { id: "non-owner" } });
+    await help.run(client, interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldsValues = payload.embeds[0].data.fields.map((f: any) => f.value).join(" ");
+    expect(fieldsValues).toContain("/ping");
+    expect(fieldsValues).not.toContain("/secret");
+  });
+
+  it("shows ownerOnly commands to the owner", async () => {
+    const client = buildClient(
+      {
+        ping: stubCommand("ping", "info"),
+        secret: stubCommand("secret", "info", { ownerOnly: true }),
+      },
+      "owner-1"
+    );
+
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await help.run(client, interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldsValues = payload.embeds[0].data.fields.map((f: any) => f.value).join(" ");
+    expect(fieldsValues).toContain("/secret");
+  });
+});
+
+describe("/help — detail view", () => {
+  it("shows the command's options and examples when present", async () => {
+    const command = stubCommand("ahorcado", "fun", {
+      options: [
+        {
+          name: "player2",
+          description: "Segundo jugador",
+          required: true,
+        },
+        {
+          name: "bot_picks_word",
+          description: "Si true, el bot elige",
+          required: false,
+        },
+      ],
+      examples: ["/ahorcado player2:@bob", "/ahorcado player2:@bob bot_picks_word:true"],
+    });
+    const client = buildClient({ ahorcado: command });
+
+    const interaction = createMockInteraction();
+    await help.run(client, interaction, [arg("command", "ahorcado")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fields = payload.embeds[0].data.fields;
+    expect(fields.find((f: any) => f.name === "Opciones").value).toContain("player2");
+    expect(fields.find((f: any) => f.name === "Ejemplos").value).toContain("/ahorcado");
+  });
+
+  it("returns an ephemeral notice for unknown commands", async () => {
+    const client = buildClient({ ping: stubCommand("ping", "info") });
+
+    const interaction = createMockInteraction();
+    await help.run(client, interaction, [arg("command", "ghost")]);
+
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.ephemeral).toBe(true);
-    expect(payload.content).toContain("nope");
+    expect(payload.content).toContain("ghost");
+  });
+
+  it("hides ownerOnly commands from non-owners even in detail view", async () => {
+    const client = buildClient(
+      { secret: stubCommand("secret", "info", { ownerOnly: true }) },
+      "owner-1"
+    );
+
+    const interaction = createMockInteraction({ user: { id: "non-owner" } });
+    await help.run(client, interaction, [arg("command", "secret")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.ephemeral).toBe(true);
+    expect(payload.content).toContain("secret");
+  });
+});
+
+describe("/help — autocomplete", () => {
+  const buildAutocompleteInteraction = (
+    focusedName: string,
+    focusedValue: string,
+    userId = "user-1"
+  ) => ({
+    user: { id: userId },
+    options: {
+      getFocused: vi.fn().mockReturnValue({ name: focusedName, value: focusedValue }),
+    },
+    respond: vi.fn().mockResolvedValue(undefined),
+  }) as any;
+
+  it("suggests command names that contain the query (substring match)", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      poke: stubCommand("poke", "fun"),
+      flip: stubCommand("flip", "fun"),
+    });
+
+    const interaction = buildAutocompleteInteraction("command", "po");
+    await help.autocomplete!(client, interaction);
+
+    expect(interaction.respond).toHaveBeenCalledOnce();
+    const values = interaction.respond.mock.calls[0][0].map((c: any) => c.value);
+    expect(values).toEqual(["poke"]);
+  });
+
+  it("hides ownerOnly commands from non-owner autocomplete", async () => {
+    const client = buildClient(
+      {
+        ping: stubCommand("ping", "info"),
+        secret: stubCommand("secret", "info", { ownerOnly: true }),
+      },
+      "owner-1"
+    );
+
+    const interaction = buildAutocompleteInteraction("command", "", "non-owner");
+    await help.autocomplete!(client, interaction);
+
+    const values = interaction.respond.mock.calls[0][0].map((c: any) => c.value);
+    expect(values).toContain("ping");
+    expect(values).not.toContain("secret");
+  });
+
+  it("suggests categories for the 'category' option", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      flip: stubCommand("flip", "fun"),
+    });
+
+    const interaction = buildAutocompleteInteraction("category", "");
+    await help.autocomplete!(client, interaction);
+
+    const values = interaction.respond.mock.calls[0][0].map((c: any) => c.value);
+    expect(values).toContain("info");
+    expect(values).toContain("fun");
   });
 });

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -1,15 +1,127 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
-import { Argument, ISlashCommand } from "../../shared/types";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  capitalize,
+  colorForCategory,
+  emojiForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand, SlashCommandsOptions } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
-const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+const formatOption = (opt: SlashCommandsOptions): string => {
+  const flag = opt.required ? "**" : "";
+  const star = opt.required ? "" : " *(opcional)*";
+  return `${flag}\`${opt.name}\`${flag}${star} — ${opt.description}`;
+};
+
+const visibleCommandsFor = (
+  client: ClientDiscord,
+  isOwner: boolean
+): ISlashCommand[] => {
+  const all = [...client.slashCommands.values()];
+  return isOwner ? all : all.filter((c) => !c.ownerOnly);
+};
+
+const buildAuthor = (client: ClientDiscord) => ({
+  name: BOT_BRAND_NAME,
+  iconURL: client.user?.avatarURL() ?? undefined,
+});
+
+const buildFooter = (extra?: string) => ({
+  text: `${BOT_BRAND_NAME} ${BOT_VERSION}${extra ? ` · ${extra}` : ""}`,
+});
+
+const buildListEmbed = (
+  client: ClientDiscord,
+  userId: string,
+  filterCategory: string | null,
+  isOwner: boolean
+) => {
+  const visible = visibleCommandsFor(client, isOwner);
+  const filtered = filterCategory
+    ? visible.filter((c) => c.category === filterCategory)
+    : visible;
+
+  const categories = [
+    ...new Set(
+      filtered
+        .map((c) => c.category)
+        .filter((c): c is string => Boolean(c))
+    ),
+  ].sort();
+
+  const fields = categories.map((cat) => ({
+    name: `${emojiForCategory(cat)} ${capitalize(cat)}`,
+    value:
+      filtered
+        .filter((c) => c.category === cat)
+        .map((c) => `**\`/${c.name}\`**`)
+        .join(" · ") || "—",
+    inline: false,
+  }));
+
+  return new EmbedBuilder()
+    .setAuthor(buildAuthor(client))
+    .setTitle(filterCategory ? `Comandos de ${capitalize(filterCategory)}` : "Help")
+    .setThumbnail(client.user?.avatarURL() ?? null)
+    .setDescription(
+      `Hola **<@${userId}>** — usa \`/help command:<nombre>\` para ver el detalle de un comando.\n` +
+        `**Total:** ${filtered.length} ${filtered.length === 1 ? "comando" : "comandos"}`
+    )
+    .setColor(filterCategory ? colorForCategory(filterCategory) : colorForCategory("info"))
+    .addFields(fields)
+    .setFooter(buildFooter("usa /help solo para ver todos"));
+};
+
+const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
+  const fields: { name: string; value: string; inline?: boolean }[] = [];
+
+  fields.push({
+    name: "Categoría",
+    value: command.category
+      ? `${emojiForCategory(command.category)} ${capitalize(command.category)}`
+      : "—",
+    inline: true,
+  });
+
+  if (command.ownerOnly) {
+    fields.push({ name: "Acceso", value: "🔒 Solo owner", inline: true });
+  }
+
+  if (command.options && command.options.length > 0) {
+    fields.push({
+      name: "Opciones",
+      value: command.options.map(formatOption).join("\n"),
+    });
+  }
+
+  if (command.examples && command.examples.length > 0) {
+    fields.push({
+      name: "Ejemplos",
+      value: command.examples.map((e) => `\`${e}\``).join("\n"),
+    });
+  }
+
+  return new EmbedBuilder()
+    .setAuthor(buildAuthor(client))
+    .setTitle(`/${command.name}`)
+    .setDescription(command.description || "Sin descripción")
+    .setColor(colorForCategory(command.category))
+    .addFields(fields)
+    .setFooter(buildFooter("/help para ver todos los comandos"));
+};
 
 const pull: ISlashCommand = {
   name: "help",
   category: "info",
-  description: "Muestra todos los slash commands o detalle de uno específico",
+  description: "Lista los slash commands o muestra el detalle de uno",
   ownerOnly: false,
   options: [
     {
@@ -17,81 +129,106 @@ const pull: ISlashCommand = {
       description: "Slash command a mostrar en detalle",
       type: ApplicationCommandOptionType.String,
       required: false,
+      autocomplete: true,
+    },
+    {
+      name: "category",
+      description: "Filtrar el listado por categoría",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: true,
+    },
+    {
+      name: "public",
+      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
     },
   ],
+  examples: [
+    "/help",
+    "/help command:ping",
+    "/help category:fun",
+    "/help public:true",
+  ],
+  autocomplete: async (
+    client: ClientDiscord,
+    interaction: AutocompleteInteraction
+  ) => {
+    const focused = interaction.options.getFocused(true);
+    const query = String(focused.value ?? "").toLowerCase();
+    const isOwner = interaction.user.id === client.config.ownerId;
+    const visible = visibleCommandsFor(client, isOwner);
+
+    if (focused.name === "command") {
+      const matches = visible
+        .filter((c) => c.name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((c) => ({ name: `/${c.name}`, value: c.name }));
+      await interaction.respond(matches);
+      return;
+    }
+
+    if (focused.name === "category") {
+      const cats = [
+        ...new Set(
+          visible.map((c) => c.category).filter((c): c is string => Boolean(c))
+        ),
+      ];
+      const matches = cats
+        .filter((c) => c.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((c) => ({
+          name: `${emojiForCategory(c)} ${capitalize(c)}`,
+          value: c,
+        }));
+      await interaction.respond(matches);
+    }
+  },
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const arg = (args[0]?.value as string | undefined)?.toLowerCase();
+      const commandArg = args.find((a) => a.name === "command")?.value as
+        | string
+        | undefined;
+      const categoryArg = args.find((a) => a.name === "category")?.value as
+        | string
+        | undefined;
+      const publicArg =
+        (args.find((a) => a.name === "public")?.value as boolean | undefined) ??
+        false;
+      const isOwner = interaction.user.id === client.config.ownerId;
 
-      if (!arg) {
-        const categories = [
-          ...new Set(
-            client.slashCommands
-              .map((cmd) => cmd.category)
-              .filter((c): c is string => Boolean(c))
-          ),
-        ].sort();
-
-        const fields = categories.map((cat) => ({
-          name: `▫ ${capitalize(cat)}`,
-          value:
-            client.slashCommands
-              .filter((cmd) => cmd.category === cat)
-              .map((cmd) => `\`/${cmd.name}\``)
-              .join(", ") || "—",
-          inline: true,
-        }));
-
-        const helpEmbed = new Discord.EmbedBuilder()
-          .setTitle(`${client.user?.username} Help`)
-          .setDescription(
-            `Hola **<@${interaction.user.id}>** — usa ` +
-              "`/help command:<nombre>`" +
-              ` para ver el detalle de un slash command.\n` +
-              `**Total slash commands:** ${client.slashCommands.size}`
-          )
-          .setColor("Random")
-          .addFields(fields);
-
+      // Detail view
+      if (commandArg) {
+        const command = client.slashCommands.get(commandArg.toLowerCase());
+        if (!command || (command.ownerOnly && !isOwner)) {
+          return interaction.reply({
+            content: `No existe un slash command llamado "${commandArg}".`,
+            ephemeral: true,
+          });
+        }
         return interaction.reply({
-          embeds: [helpEmbed],
+          embeds: [buildDetailEmbed(client, command)],
+          ephemeral: !publicArg,
           allowedMentions: { repliedUser: false },
         });
       }
 
-      const command = client.slashCommands.get(arg);
-      if (!command) {
-        return interaction.reply({
-          content: `No existe un slash command llamado "${args[0].value}".`,
-          allowedMentions: { repliedUser: false },
-          ephemeral: true,
-        });
-      }
-
-      const helpCmdEmbed = new Discord.EmbedBuilder()
-        .setTitle(`${client.user?.username} Help | /${command.name}`)
-        .addFields(
-          {
-            name: "Descripción",
-            value: command.description || "Sin descripción",
-          },
-          {
-            name: "Categoría",
-            value: command.category || "—",
-          },
-          {
-            name: "Owner only",
-            value: command.ownerOnly ? "Sí" : "No",
-          }
-        )
-        .setColor("Random");
-
+      // Listing
       return interaction.reply({
-        embeds: [helpCmdEmbed],
+        embeds: [
+          buildListEmbed(
+            client,
+            interaction.user.id,
+            categoryArg ?? null,
+            isOwner
+          ),
+        ],
+        ephemeral: !publicArg,
         allowedMentions: { repliedUser: false },
       });
     } catch (error) {

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -2,11 +2,12 @@ import {
   ActionRowBuilder,
   ApplicationCommandOptionType,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
-  ComponentType,
   EmbedBuilder,
+  MessageFlags,
   StringSelectMenuBuilder,
-  StringSelectMenuInteraction,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import {
@@ -24,7 +25,8 @@ import {
 import { errorHandler } from "../../shared/utils/helpers";
 
 const SELECT_CUSTOM_ID = "help-pick-command";
-const SELECT_TIMEOUT_MS = 60_000;
+const BACK_BUTTON_ID = "help-back-to-list";
+const COLLECTOR_TIMEOUT_MS = 120_000;
 
 const formatOption = (opt: SlashCommandsOptions): string => {
   const flag = opt.required ? "**" : "";
@@ -146,42 +148,79 @@ const buildSelectRow = (commands: ISlashCommand[]) => {
   );
 };
 
-const attachSelectCollector = async (
+const buildBackRow = () =>
+  new ActionRowBuilder<ButtonBuilder>().setComponents(
+    new ButtonBuilder()
+      .setCustomId(BACK_BUTTON_ID)
+      .setLabel("← Volver al listado")
+      .setStyle(ButtonStyle.Secondary)
+  );
+
+const attachComponentCollector = async (
   client: ClientDiscord,
-  interaction: ChatInputCommandInteraction
+  interaction: ChatInputCommandInteraction,
+  state: { categoryArg: string | null; isOwner: boolean }
 ) => {
   try {
     const message = await interaction.fetchReply();
-    const select = (await message.awaitMessageComponent({
-      componentType: ComponentType.StringSelect,
-      time: SELECT_TIMEOUT_MS,
-      filter: (i) =>
-        i.user.id === interaction.user.id && i.customId === SELECT_CUSTOM_ID,
-    })) as StringSelectMenuInteraction;
+    const collector = message.createMessageComponentCollector({
+      time: COLLECTOR_TIMEOUT_MS,
+      filter: (i) => i.user.id === interaction.user.id,
+    });
 
-    const isOwner = interaction.user.id === client.config.ownerId;
-    const command = client.slashCommands.get(select.values[0]);
-    if (!command || (command.ownerOnly && !isOwner)) {
-      await select.update({
-        content: `No existe un slash command llamado "${select.values[0]}".`,
-        embeds: [],
-        components: [],
-      });
-      return;
-    }
+    collector.on("collect", async (i) => {
+      try {
+        if (i.isStringSelectMenu() && i.customId === SELECT_CUSTOM_ID) {
+          const command = client.slashCommands.get(i.values[0]);
+          if (!command || (command.ownerOnly && !state.isOwner)) {
+            await i.update({
+              content: `No existe un slash command llamado "${i.values[0]}".`,
+              embeds: [],
+              components: [],
+            });
+            collector.stop("invalid-selection");
+            return;
+          }
+          await i.update({
+            embeds: [buildDetailEmbed(client, command)],
+            components: [buildBackRow()],
+          });
+          return;
+        }
 
-    await select.update({
-      embeds: [buildDetailEmbed(client, command)],
-      components: [],
+        if (i.isButton() && i.customId === BACK_BUTTON_ID) {
+          const visible = visibleCommandsFor(client, state.isOwner);
+          const filtered = state.categoryArg
+            ? visible.filter((c) => c.category === state.categoryArg)
+            : visible;
+          const row = buildSelectRow(filtered);
+          await i.update({
+            embeds: [
+              buildListEmbed(
+                client,
+                interaction.user.id,
+                state.categoryArg,
+                state.isOwner
+              ),
+            ],
+            components: row ? [row] : [],
+          });
+        }
+      } catch {
+        // Component update failed (interaction expired, etc.) — keep the collector alive
+        // so other clicks can still try.
+      }
+    });
+
+    collector.on("end", async () => {
+      try {
+        await interaction.editReply({ components: [] });
+      } catch {
+        // best-effort; the message may already be gone
+      }
     });
   } catch {
-    // Timeout or interaction expired — strip the select so the message
-    // doesn't keep an orphan dropdown.
-    try {
-      await interaction.editReply({ components: [] });
-    } catch {
-      // best-effort; ignore if the interaction is already gone
-    }
+    // fetchReply failed — nothing to attach a collector to
   }
 };
 
@@ -275,12 +314,12 @@ const pull: ISlashCommand = {
         if (!command || (command.ownerOnly && !isOwner)) {
           return interaction.reply({
             content: `No existe un slash command llamado "${commandArg}".`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
         return interaction.reply({
           embeds: [buildDetailEmbed(client, command)],
-          ephemeral: !publicArg,
+          flags: publicArg ? undefined : MessageFlags.Ephemeral,
           allowedMentions: { repliedUser: false },
         });
       }
@@ -303,13 +342,16 @@ const pull: ISlashCommand = {
           ),
         ],
         components: row ? [row] : [],
-        ephemeral: !publicArg,
+        flags: publicArg ? undefined : MessageFlags.Ephemeral,
         allowedMentions: { repliedUser: false },
       });
 
       if (row) {
-        // Fire-and-forget: collector lives until selection or timeout.
-        attachSelectCollector(client, interaction);
+        // Fire-and-forget: collector lives until select/back click or timeout.
+        attachComponentCollector(client, interaction, {
+          categoryArg: categoryArg ?? null,
+          isOwner,
+        });
       }
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -1,8 +1,12 @@
 import {
+  ActionRowBuilder,
   ApplicationCommandOptionType,
   AutocompleteInteraction,
   ChatInputCommandInteraction,
+  ComponentType,
   EmbedBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import {
@@ -12,8 +16,15 @@ import {
   colorForCategory,
   emojiForCategory,
 } from "../../shared/constants/branding";
-import { Argument, ISlashCommand, SlashCommandsOptions } from "../../shared/types";
+import {
+  Argument,
+  ISlashCommand,
+  SlashCommandsOptions,
+} from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const SELECT_CUSTOM_ID = "help-pick-command";
+const SELECT_TIMEOUT_MS = 60_000;
 
 const formatOption = (opt: SlashCommandsOptions): string => {
   const flag = opt.required ? "**" : "";
@@ -51,9 +62,7 @@ const buildListEmbed = (
 
   const categories = [
     ...new Set(
-      filtered
-        .map((c) => c.category)
-        .filter((c): c is string => Boolean(c))
+      filtered.map((c) => c.category).filter((c): c is string => Boolean(c))
     ),
   ].sort();
 
@@ -72,12 +81,14 @@ const buildListEmbed = (
     .setTitle(filterCategory ? `Comandos de ${capitalize(filterCategory)}` : "Help")
     .setThumbnail(client.user?.avatarURL() ?? null)
     .setDescription(
-      `Hola **<@${userId}>** — usa \`/help command:<nombre>\` para ver el detalle de un comando.\n` +
+      `Hola **<@${userId}>** — elegí un comando del menú o usa \`/help command:<nombre>\` para ver el detalle.\n` +
         `**Total:** ${filtered.length} ${filtered.length === 1 ? "comando" : "comandos"}`
     )
     .setColor(filterCategory ? colorForCategory(filterCategory) : colorForCategory("info"))
     .addFields(fields)
-    .setFooter(buildFooter("usa /help solo para ver todos"));
+    .setFooter(
+      buildFooter(filterCategory ? "/help solo para ver todos" : undefined)
+    );
 };
 
 const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
@@ -116,6 +127,62 @@ const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
     .setColor(colorForCategory(command.category))
     .addFields(fields)
     .setFooter(buildFooter("/help para ver todos los comandos"));
+};
+
+const buildSelectRow = (commands: ISlashCommand[]) => {
+  const options = commands.slice(0, 25).map((c) => ({
+    label: `/${c.name}`,
+    description: c.description.slice(0, 100),
+    value: c.name,
+  }));
+
+  if (options.length === 0) return null;
+
+  return new ActionRowBuilder<StringSelectMenuBuilder>().setComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(SELECT_CUSTOM_ID)
+      .setPlaceholder("Elegí un comando para ver el detalle…")
+      .addOptions(options)
+  );
+};
+
+const attachSelectCollector = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction
+) => {
+  try {
+    const message = await interaction.fetchReply();
+    const select = (await message.awaitMessageComponent({
+      componentType: ComponentType.StringSelect,
+      time: SELECT_TIMEOUT_MS,
+      filter: (i) =>
+        i.user.id === interaction.user.id && i.customId === SELECT_CUSTOM_ID,
+    })) as StringSelectMenuInteraction;
+
+    const isOwner = interaction.user.id === client.config.ownerId;
+    const command = client.slashCommands.get(select.values[0]);
+    if (!command || (command.ownerOnly && !isOwner)) {
+      await select.update({
+        content: `No existe un slash command llamado "${select.values[0]}".`,
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    await select.update({
+      embeds: [buildDetailEmbed(client, command)],
+      components: [],
+    });
+  } catch {
+    // Timeout or interaction expired — strip the select so the message
+    // doesn't keep an orphan dropdown.
+    try {
+      await interaction.editReply({ components: [] });
+    } catch {
+      // best-effort; ignore if the interaction is already gone
+    }
+  }
 };
 
 const pull: ISlashCommand = {
@@ -202,7 +269,7 @@ const pull: ISlashCommand = {
         false;
       const isOwner = interaction.user.id === client.config.ownerId;
 
-      // Detail view
+      // Detail view — no select, just the embed.
       if (commandArg) {
         const command = client.slashCommands.get(commandArg.toLowerCase());
         if (!command || (command.ownerOnly && !isOwner)) {
@@ -218,8 +285,15 @@ const pull: ISlashCommand = {
         });
       }
 
-      // Listing
-      return interaction.reply({
+      // Listing — embed + select menu so the user can drill in without
+      // re-typing /help.
+      const visible = visibleCommandsFor(client, isOwner);
+      const filtered = categoryArg
+        ? visible.filter((c) => c.category === categoryArg)
+        : visible;
+      const row = buildSelectRow(filtered);
+
+      await interaction.reply({
         embeds: [
           buildListEmbed(
             client,
@@ -228,9 +302,15 @@ const pull: ISlashCommand = {
             isOwner
           ),
         ],
+        components: row ? [row] : [],
         ephemeral: !publicArg,
         allowedMentions: { repliedUser: false },
       });
+
+      if (row) {
+        // Fire-and-forget: collector lives until selection or timeout.
+        attachSelectCollector(client, interaction);
+      }
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -29,7 +30,7 @@ describe("/clear", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("permisos");
   });
 
@@ -39,6 +40,6 @@ describe("/clear", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -1,4 +1,4 @@
-import Discord, { ChatInputCommandInteraction, PermissionFlagsBits, PermissionsBitField } from "discord.js";
+import Discord, { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits, PermissionsBitField } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
 import { Argument, ISlashCommand } from "../../shared/types";
@@ -33,7 +33,7 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "No tienes permisos para eliminar mensajes...",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -44,7 +44,7 @@ const pull: ISlashCommand = {
         return interaction.reply({
           content:
             "Por favor selecciona una cantidad de mensajes a eliminar apropiada.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -56,7 +56,7 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "No cuento con permisos para eliminar mensajes.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -76,7 +76,7 @@ const pull: ISlashCommand = {
 
       await interaction.reply({
         content: "Limpiando chat...",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
 
       channel

--- a/src/slashCommands/mod/cums.test.ts
+++ b/src/slashCommands/mod/cums.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/services/birthday.service");
@@ -42,7 +43,7 @@ describe("/cums", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("returns the empty-state notice when the filter has no results", async () => {
@@ -53,7 +54,7 @@ describe("/cums", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("No hay cumpleaños");
   });
 });

--- a/src/slashCommands/mod/cums.ts
+++ b/src/slashCommands/mod/cums.ts
@@ -2,6 +2,7 @@ import {
   APIEmbedField,
   ChatInputCommandInteraction,
   EmbedBuilder,
+  MessageFlags,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
@@ -42,14 +43,14 @@ const pull: ISlashCommand = {
         if (month < 0 || month > 11) {
           return interaction.reply({
             content: "El mes debe estar entre 1 y 12",
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
         response = await getBirthdaysByMonth(month);
         if (Object.keys(response).length === 0) {
           return interaction.reply({
             content: `No hay cumpleaños en ${calendar.months[month]}`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
       } else {

--- a/src/slashCommands/mod/nextcum.test.ts
+++ b/src/slashCommands/mod/nextcum.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/services/birthday.service");
@@ -37,6 +38,6 @@ describe("/nextcum", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/nextcum.ts
+++ b/src/slashCommands/mod/nextcum.ts
@@ -1,4 +1,8 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import calendar from "../../shared/constants/calendar";
 import {
@@ -25,7 +29,7 @@ const pull: ISlashCommand = {
       if (!response?.discordId) {
         return interaction.reply({
           content: "No hay cumpleaños próximos registrados.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/mod/register.test.ts
+++ b/src/slashCommands/mod/register.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../api/dao/user.dao");
@@ -52,7 +53,7 @@ describe("/register", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(userDao.addUser).not.toHaveBeenCalled();
   });
 });

--- a/src/slashCommands/mod/register.ts
+++ b/src/slashCommands/mod/register.ts
@@ -1,6 +1,7 @@
 import {
   ChatInputCommandInteraction,
   EmbedBuilder,
+  MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
@@ -55,7 +56,7 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "Necesitás permiso de Administrator para usar este comando.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/mod/say.test.ts
+++ b/src/slashCommands/mod/say.test.ts
@@ -1,4 +1,4 @@
-import { PermissionFlagsBits } from "discord.js";
+import { MessageFlags, PermissionFlagsBits } from "discord.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -11,7 +11,7 @@ describe("/say", () => {
 
     expect(interaction.reply).toHaveBeenCalledWith({
       content: "Listo.",
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     expect(interaction.channel.send).toHaveBeenCalledWith("hola mundo");
   });
@@ -37,7 +37,7 @@ describe("/say", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(interaction.channel.send).not.toHaveBeenCalled();
   });
 

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -12,7 +12,7 @@ import { errorHandler } from "../../shared/utils/helpers";
 const pull: ISlashCommand = {
   name: "say",
   category: "mod",
-  description: "Botito repite lo que dices",
+  description: "Xiza Bot repite lo que dices",
   ownerOnly: false,
   defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -1,6 +1,7 @@
 import {
   ChatInputCommandInteraction,
   EmbedBuilder,
+  MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
@@ -42,14 +43,14 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "No tienes los permisos requeridos para usar este comando.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
       if (!interaction.channel?.isSendable()) {
         return interaction.reply({
           content: "Este canal no soporta envío de mensajes.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -57,7 +58,7 @@ const pull: ISlashCommand = {
       const asEmbed =
         (args.find((a) => a.name === "as_embed")?.value as boolean) ?? false;
 
-      await interaction.reply({ content: "Listo.", ephemeral: true });
+      await interaction.reply({ content: "Listo.", flags: MessageFlags.Ephemeral });
 
       if (asEmbed) {
         const embed = new EmbedBuilder()


### PR DESCRIPTION
## Summary

First iteration of the per-command facelift. Builds the shared
branding constants + autocomplete plumbing and rewrites \`/help\`
to demonstrate the new visual + functional baseline.

Suite: 131 → 142 tests, all green. \`tsc --noEmit\` 0 errors.

## Commits

| # | Commit | Highlights |
|---|---|---|
| 1 | \`feat(branding): add brand constants + autocomplete + examples plumbing\` | Shared infrastructure: \`BOT_BRAND_NAME\`, \`BOT_VERSION\`, category color/emoji helpers; ISlashCommand gets \`examples?\` and \`autocomplete?\` fields; \`SlashCommandsOptions\` gets \`autocomplete?\`; \`interactionCreate\` routes autocomplete interactions; "Botito" → "Xiza Bot" in say.ts. |
| 2 | \`feat(help): full facelift — ephemeral default, autocomplete, options, branding\` | New /help with all 8 functional + 7 aesthetic improvements. |

## Branding decisions baked in

- **Brand name**: "Xiza Bot" (constant, not pulled from \`client.user.username\`)
- **Version**: read from \`package.json\` at runtime
- **Category palette** (Discord-native):
  - \`info\` → \`#5865F2\` (blurple) ℹ️
  - \`fun\` → \`#FEE75C\` (yellow) 🎉
  - \`mod\` → \`#ED4245\` (red) 🛡️

## /help functional changes

| Before | After |
|---|---|
| Public listing — spamea el canal | Ephemeral por default; \`public:true\` opt-in |
| No \`category:\` filter | New option, with autocomplete |
| Detail omits \`options[]\` | Detail muestra options con required/optional + descripción |
| No autocomplete on \`command:\` | Autocomplete substring sobre los slash commands visibles |
| ownerOnly visible to all | ownerOnly oculto a non-owners (listing + detail + autocomplete) |
| No examples | examples[] declarados en \`/help\` mismo y se muestran |

## /help aesthetic changes

- Author bar with "Xiza Bot" + bot icon
- Color por categoría (listing usa info; detail/filtered usan la categoría)
- Thumbnail del bot en el listing
- Footer con versión + hint contextual
- Command names resaltados como \`**\`/name\`**\`
- Categorías con emoji + capitalize

## What's NOT in this PR (deferred)

- Other commands keeping \`Random\` color and lacking branding — to be applied in subsequent per-command facelifts.
- Complementary commands (\`/about\`, \`/changelog\`, \`/uptime\`, \`/feedback\`) — agreed to revisit at the end of the facelift series.
- \`examples[]\` populated for the other 17 commands — fill in as we facelift each.

## Test plan

- [ ] CI green
- [ ] \`/help\` shows ephemeral embed with the 3 categories colored + emoji
- [ ] \`/help command:ping\` shows the option list with required/optional flags
- [ ] \`/help category:fun\` filters to fun commands, embed colored yellow
- [ ] Typing \`/help command:p\` shows autocomplete suggestions
- [ ] \`/help public:true\` posts visible to the whole channel
- [ ] Footer reads "Xiza Bot v0.3.2"
- [ ] Non-owner trying \`/help command:<owner-only-cmd>\` gets the same ephemeral "no existe" as for an unknown name