### PR TITLE
feat(ping): facelift — branding, deferReply pattern, 4 metrics

### DIFF
--- a/src/shared/utils/helpers.test.ts
+++ b/src/shared/utils/helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   capitalize,
   dateToUTC5,
+  formatUptime,
   mentionUser,
   random,
   rangeHandler,
@@ -95,6 +96,43 @@ describe("helpers — pure functions", () => {
   describe("mentionUser(id)", () => {
     it("wraps the id in the bold-mention markdown format", () => {
       expect(mentionUser("123456789")).toBe("**<@123456789>**");
+    });
+  });
+
+  describe("formatUptime(seconds)", () => {
+    it("returns just seconds when below a minute", () => {
+      expect(formatUptime(0)).toBe("0s");
+      expect(formatUptime(45)).toBe("45s");
+      expect(formatUptime(59)).toBe("59s");
+    });
+
+    it("returns minutes + seconds when below an hour", () => {
+      expect(formatUptime(60)).toBe("1m 0s");
+      expect(formatUptime(125)).toBe("2m 5s");
+      expect(formatUptime(3599)).toBe("59m 59s");
+    });
+
+    it("returns hours + minutes when below a day", () => {
+      expect(formatUptime(3600)).toBe("1h 0m");
+      expect(formatUptime(3660)).toBe("1h 1m");
+      expect(formatUptime(86399)).toBe("23h 59m");
+    });
+
+    it("returns days + hours + minutes for >= 1 day", () => {
+      expect(formatUptime(86400)).toBe("1d 0h 0m");
+      expect(formatUptime(86400 + 3600 + 60)).toBe("1d 1h 1m");
+      expect(formatUptime(2 * 86400 + 5 * 3600 + 30 * 60)).toBe("2d 5h 30m");
+    });
+
+    it("guards against invalid input", () => {
+      expect(formatUptime(-5)).toBe("0s");
+      expect(formatUptime(NaN)).toBe("0s");
+      expect(formatUptime(Infinity)).toBe("0s");
+    });
+
+    it("floors fractional seconds", () => {
+      expect(formatUptime(45.7)).toBe("45s");
+      expect(formatUptime(125.99)).toBe("2m 5s");
     });
   });
 

--- a/src/shared/utils/helpers.ts
+++ b/src/shared/utils/helpers.ts
@@ -149,3 +149,21 @@ export const rangeHandler = (
   if (value < min) return min;
   return value;
 };
+
+/**
+ * Formats a duration in seconds into a compact human-readable string.
+ * Examples: 45s, 5m 30s, 2h 15m, 3d 4h 0m
+ */
+export const formatUptime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0s";
+  const totalSec = Math.floor(seconds);
+  const days = Math.floor(totalSec / 86400);
+  const hours = Math.floor((totalSec % 86400) / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  const secs = totalSec % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${secs}s`;
+  return `${secs}s`;
+};

--- a/src/slashCommands/info/ping.test.ts
+++ b/src/slashCommands/info/ping.test.ts
@@ -1,25 +1,73 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
-import { createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import ping from "./ping";
 
 describe("/ping", () => {
-  it("sends 'Pinging...' to the channel and replies with the ping embed", async () => {
+  it("defers publicly by default and replies via editReply with the embed", async () => {
     const interaction = createMockInteraction();
     await ping.run(createMockClient(), interaction, []);
 
-    expect(interaction.channel.send).toHaveBeenCalledWith("🏓 Pinging...");
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    const payload = interaction.reply.mock.calls[0][0];
+    expect(interaction.deferReply).toHaveBeenCalledOnce();
+    const deferPayload = interaction.deferReply.mock.calls[0][0];
+    // Public default → no Ephemeral flag set
+    expect(deferPayload?.flags).toBeUndefined();
+
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.channel.send).not.toHaveBeenCalled();
   });
 
-  it("returns early when the channel is not sendable", async () => {
-    const interaction = createMockInteraction({
-      channel: { isSendable: () => false },
-    });
+  it("defers ephemerally when private:true is passed", async () => {
+    const interaction = createMockInteraction();
+    await ping.run(createMockClient(), interaction, [arg("private", true)]);
+
+    expect(interaction.deferReply).toHaveBeenCalledOnce();
+    const deferPayload = interaction.deferReply.mock.calls[0][0];
+    expect(deferPayload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("includes the four expected metric fields in the embed", async () => {
+    const interaction = createMockInteraction();
     await ping.run(createMockClient(), interaction, []);
 
-    expect(interaction.reply).not.toHaveBeenCalled();
+    const payload = interaction.editReply.mock.calls[0][0];
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+
+    expect(fieldNames).toContain("🏓 Round-trip");
+    expect(fieldNames).toContain("📡 API");
+    expect(fieldNames).toContain("⏰ Uptime");
+    expect(fieldNames).toContain("📦 Versión");
+  });
+
+  it("reports the API ping from client.ws.ping", async () => {
+    const client = createMockClient({ ws: { ping: 123 } });
+    const interaction = createMockInteraction();
+    await ping.run(client, interaction, []);
+
+    const payload = interaction.editReply.mock.calls[0][0];
+    const apiField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "📡 API"
+    );
+    expect(apiField.value).toContain("123ms");
+  });
+
+  it("clamps a negative ws.ping to 0 (happens when the bot just connected)", async () => {
+    const client = createMockClient({ ws: { ping: -1 } });
+    const interaction = createMockInteraction();
+    await ping.run(client, interaction, []);
+
+    const payload = interaction.editReply.mock.calls[0][0];
+    const apiField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "📡 API"
+    );
+    expect(apiField.value).toContain("0ms");
   });
 });

--- a/src/slashCommands/info/ping.ts
+++ b/src/slashCommands/info/ping.ts
@@ -1,42 +1,92 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
+import { errorHandler, formatUptime } from "../../shared/utils/helpers";
+
+const buildEmbed = (
+  client: ClientDiscord,
+  roundTripMs: number,
+  apiPingMs: number,
+  uptimeSec: number
+) =>
+  new EmbedBuilder()
+    .setAuthor({
+      name: BOT_BRAND_NAME,
+      iconURL: client.user?.avatarURL() ?? undefined,
+    })
+    .setTitle("🏓 Pong!")
+    .setThumbnail(client.user?.avatarURL() ?? null)
+    .setColor(colorForCategory("info"))
+    .addFields(
+      {
+        name: "🏓 Round-trip",
+        value: `\`${roundTripMs}ms\``,
+        inline: true,
+      },
+      {
+        name: "📡 API",
+        value: `\`${apiPingMs}ms\``,
+        inline: true,
+      },
+      {
+        name: "⏰ Uptime",
+        value: `\`${formatUptime(uptimeSec)}\``,
+        inline: true,
+      },
+      {
+        name: "📦 Versión",
+        value: `\`${BOT_VERSION}\``,
+        inline: true,
+      }
+    )
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
 const pull: ISlashCommand = {
   name: "ping",
   category: "info",
-  description: "Check the bot's ping!",
+  description: "Mide la latencia del bot",
   ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description:
+        "Mostrar la respuesta solo a vos (default: false, lo ve todo el canal)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/ping", "/ping private:true"],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
-    _: Argument[]
+    args: Argument[]
   ) => {
     try {
-      if (!interaction.channel?.isSendable()) return;
-      const msg = await interaction.channel.send(`🏓 Pinging...`);
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as boolean | undefined) ??
+        false;
 
-      const pingEmbed = new Discord.EmbedBuilder()
-        .setTitle(":signal_strength: Bot Ping")
-        .addFields([
-          {
-            name: "Time",
-            value: `${Math.floor(
-              msg!.createdAt.getTime() - interaction.createdAt.getTime()
-            )}ms`,
-            inline: true,
-          },
-          {
-            name: "API Ping",
-            value: `${client.ws.ping}ms`,
-            inline: true,
-          },
-        ])
-        .setColor("Random");
-      await interaction.reply({ embeds: [pingEmbed] });
+      await interaction.deferReply({
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
 
-      await msg?.delete();
+      const roundTrip = Date.now() - interaction.createdTimestamp;
+      const apiPing = Math.max(0, Math.round(client.ws.ping));
+      const uptime = process.uptime();
+
+      await interaction.editReply({
+        embeds: [buildEmbed(client, roundTrip, apiPing, uptime)],
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -46,6 +46,7 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
       bulkDelete: vi.fn().mockResolvedValue({ size: 5 }),
     },
     createdAt: new Date(),
+    createdTimestamp: Date.now(),
     commandName: "test",
     isChatInputCommand: () => true,
     ...overrides,


### PR DESCRIPTION
## Summary
- Reemplazo el patrón `channel.send + delete` (frágil, requiere permisos extra) por `deferReply + editReply`. Sigue funcionando en DMs/threads, no toca el canal.
- 4 métricas con emoji: 🏓 Round-trip, 📡 API (WebSocket), ⏰ Uptime, 📦 Versión.
- Branding consistente con `/help`: author = Xiza Bot, color info (#5865F2 blurple), footer con versión, thumbnail del bot.
- Nuevo opt-in `private:` (default: público — al revés de `/help`, porque `/ping` se usa más como chequeo grupal).
- Description en español.
- Nuevo helper `formatUptime(seconds)` en `shared/utils/helpers.ts` con tests dedicados.

## Test plan
- [x] `pnpm test` → 151/151 passing (was 142, +9 new tests para formatUptime y ping)
- [x] `tsc --noEmit` → limpio
- [ ] Probar `/ping` en Discord — embed público con las 4 métricas
- [ ] Probar `/ping private:true` — sale solo para vos
- [ ] Verificar que `/ping` ya no manda `🏓 Pinging...` al canal (esperado)
- [ ] Verificar que el footer dice `Xiza Bot v0.3.2` y el color del embed es blurple