### PR TITLE
feat(channel-id): facelift — embed with metadata, ephemeral default

### DIFF
--- a/src/slashCommands/info/channel-id.test.ts
+++ b/src/slashCommands/info/channel-id.test.ts
@@ -1,27 +1,143 @@
-import { describe, expect, it } from "vitest";
+import { ChannelType, MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import channelId from "./channel-id";
 
 describe("/channel-id", () => {
-  it("returns the current channel id when no option is provided", async () => {
+  it("uses the current channel id when no option is provided", async () => {
+    const client = createMockClient();
     const interaction = createMockInteraction({ channelId: "current-ch" });
-    await channelId.run(createMockClient(), interaction, []);
 
+    await channelId.run(client, interaction, []);
+
+    expect(client.channels.fetch).toHaveBeenCalledWith("current-ch");
     expect(interaction.reply).toHaveBeenCalledOnce();
-    const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.content).toContain("<#current-ch>");
-    expect(payload.content).toContain("current-ch");
   });
 
-  it("returns the provided channel id when the option is set", async () => {
+  it("fetches the provided channel id when the option is set", async () => {
+    const client = createMockClient();
     const interaction = createMockInteraction();
-    await channelId.run(createMockClient(), interaction, [
-      arg("channel", "specific-ch"),
-    ]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    await channelId.run(client, interaction, [arg("channel", "specific-ch")]);
+
+    expect(client.channels.fetch).toHaveBeenCalledWith("specific-ch");
+  });
+
+  it("is ephemeral by default and public when public:true is passed", async () => {
+    const interaction1 = createMockInteraction();
+    await channelId.run(createMockClient(), interaction1, []);
+    const ephemeralPayload = interaction1.reply.mock.calls[0][0];
+    expect(ephemeralPayload.flags).toBe(MessageFlags.Ephemeral);
+
+    const interaction2 = createMockInteraction();
+    await channelId.run(createMockClient(), interaction2, [arg("public", true)]);
+    const publicPayload = interaction2.reply.mock.calls[0][0];
+    expect(publicPayload.flags).toBeUndefined();
+  });
+
+  it("includes the core metadata fields in the embed", async () => {
+    const interaction = createMockInteraction({ channelId: "ch-42" });
+    await channelId.run(createMockClient(), interaction, []);
+
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.content).toContain("<#specific-ch>");
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+
+    expect(fieldNames).toContain("📁 Canal");
+    expect(fieldNames).toContain("🆔 ID");
+    expect(fieldNames).toContain("🏷 Tipo");
+  });
+
+  it("wraps the id in backticks for tap-to-copy", async () => {
+    const interaction = createMockInteraction({ channelId: "ch-99" });
+    await channelId.run(createMockClient(), interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const idField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "🆔 ID"
+    );
+    expect(idField.value).toBe("`ch-99`");
+  });
+
+  it("includes the parent category field when the channel has one", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockResolvedValueOnce({
+      id: "ch-with-parent",
+      name: "general",
+      type: ChannelType.GuildText,
+      guild: { id: "g", name: "G" },
+      parent: { name: "Charla" },
+      nsfw: false,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await channelId.run(client, interaction, [arg("channel", "ch-with-parent")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+    expect(fieldNames).toContain("📂 Categoría");
+    const parentField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "📂 Categoría"
+    );
+    expect(parentField.value).toBe("Charla");
+  });
+
+  it("only adds the NSFW field when the channel is flagged NSFW", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockResolvedValueOnce({
+      id: "spicy",
+      name: "spicy",
+      type: ChannelType.GuildText,
+      guild: { id: "g", name: "G" },
+      parent: null,
+      nsfw: true,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await channelId.run(client, interaction, [arg("channel", "spicy")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+    expect(fieldNames).toContain("🔞 NSFW");
+  });
+
+  it("formats common channel types with friendly labels", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockResolvedValueOnce({
+      id: "v",
+      type: ChannelType.GuildVoice,
+      guild: { id: "g" },
+      parent: null,
+      nsfw: false,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await channelId.run(client, interaction, [arg("channel", "v")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const typeField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "🏷 Tipo"
+    );
+    expect(typeField.value).toContain("Voz");
+  });
+
+  it("returns an ephemeral notice when the channel can't be fetched and there's no fallback", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockRejectedValueOnce(new Error("404"));
+
+    const interaction = createMockInteraction({
+      channelId: "ghost",
+      channel: null,
+    });
+
+    await channelId.run(client, interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.content).toContain("ghost");
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/info/channel-id.ts
+++ b/src/slashCommands/info/channel-id.ts
@@ -1,13 +1,85 @@
-import { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  Channel,
+  ChannelType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const TYPE_LABELS: Partial<Record<ChannelType, string>> = {
+  [ChannelType.GuildText]: "💬 Texto",
+  [ChannelType.GuildVoice]: "🔊 Voz",
+  [ChannelType.GuildCategory]: "📂 Categoría",
+  [ChannelType.GuildAnnouncement]: "📢 Anuncios",
+  [ChannelType.AnnouncementThread]: "🧵 Hilo (anuncios)",
+  [ChannelType.PublicThread]: "🧵 Hilo público",
+  [ChannelType.PrivateThread]: "🔒 Hilo privado",
+  [ChannelType.GuildStageVoice]: "🎤 Stage",
+  [ChannelType.GuildForum]: "💭 Foro",
+  [ChannelType.GuildMedia]: "🖼️ Media",
+  [ChannelType.DM]: "💌 DM",
+  [ChannelType.GroupDM]: "👥 Group DM",
+};
+
+const formatChannelType = (type: ChannelType): string =>
+  TYPE_LABELS[type] ?? `Tipo ${type}`;
+
+const buildEmbed = (client: ClientDiscord, channel: Channel) => {
+  const fields: { name: string; value: string; inline?: boolean }[] = [];
+
+  // For guild channels we can mention them; for DMs we just show "—"
+  const isGuildChannel = "guild" in channel;
+  const channelLabel = isGuildChannel
+    ? `<#${channel.id}>`
+    : (channel as any).name ?? "DM";
+
+  fields.push({ name: "📁 Canal", value: channelLabel, inline: true });
+  fields.push({ name: "🆔 ID", value: `\`${channel.id}\``, inline: true });
+  fields.push({
+    name: "🏷 Tipo",
+    value: formatChannelType(channel.type),
+    inline: true,
+  });
+
+  if (isGuildChannel) {
+    const parent = (channel as any).parent;
+    if (parent?.name) {
+      fields.push({
+        name: "📂 Categoría",
+        value: parent.name,
+        inline: true,
+      });
+    }
+
+    if ((channel as any).nsfw === true) {
+      fields.push({ name: "🔞 NSFW", value: "Sí", inline: true });
+    }
+  }
+
+  return new EmbedBuilder()
+    .setAuthor({
+      name: BOT_BRAND_NAME,
+      iconURL: client.user?.avatarURL() ?? undefined,
+    })
+    .setTitle("Información del canal")
+    .setColor(colorForCategory("info"))
+    .addFields(fields)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
 
 const pull: ISlashCommand = {
   name: "channel-id",
   category: "info",
-  description: "Muestra el id del canal",
+  description: "Muestra la información y el ID de un canal",
   ownerOnly: false,
   options: [
     {
@@ -16,17 +88,52 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Channel,
       required: false,
     },
+    {
+      name: "public",
+      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/channel-id",
+    "/channel-id channel:#general",
+    "/channel-id public:true",
   ],
   run: async (
-    _: ClientDiscord,
+    client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const channelId = (args[0]?.value as string) ?? interaction.channelId;
+      const channelArg = args.find((a) => a.name === "channel")?.value as
+        | string
+        | undefined;
+      const publicArg =
+        (args.find((a) => a.name === "public")?.value as boolean | undefined) ??
+        false;
+
+      const channelId = channelArg ?? interaction.channelId;
+
+      let channel: Channel | null = null;
+      try {
+        channel = await client.channels.fetch(channelId);
+      } catch {
+        // Fallback: if fetch fails (eg. uncached DM), use interaction.channel
+        channel = interaction.channel ?? null;
+      }
+
+      if (!channel) {
+        return interaction.reply({
+          content: `No encontré el canal con id \`${channelId}\`.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
       return interaction.reply({
-        content: `El canal es: <#${channelId}> con id ${channelId}`,
+        embeds: [buildEmbed(client, channel)],
+        flags: publicArg ? undefined : MessageFlags.Ephemeral,
+        allowedMentions: { repliedUser: false },
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -77,7 +77,19 @@ export const createMockClient = (overrides: Record<string, any> = {}) =>
     slashCommands: new Collection<string, any>(),
     commands: new Collection<string, any>(),
     ws: { ping: 50 },
-    channels: { cache: new Collection<string, any>() },
+    channels: {
+      cache: new Collection<string, any>(),
+      fetch: vi.fn().mockImplementation((id: string) =>
+        Promise.resolve({
+          id,
+          name: `channel-${id}`,
+          type: 0, // ChannelType.GuildText
+          guild: { id: "guild-1", name: "TestGuild" },
+          parent: null,
+          nsfw: false,
+        })
+      ),
+    },
     guilds: { cache: new Collection<string, any>() },
     application: {
       commands: {


### PR DESCRIPTION
## Summary
- Reemplazo el plain-text `"El canal es: <#X> con id X"` por embed branded info.
- 5 campos con emoji: 📁 Canal · 🆔 ID (en code block para tap-to-copy) · 🏷 Tipo (con label amigable por `ChannelType`) · 📂 Categoría (solo si tiene parent) · 🔞 NSFW (solo si está marcado).
- Nuevo opt-in `public:` (default: ephemeral — `/channel-id` típicamente es un lookup personal, no broadcast grupal). Mismo patrón que `/help`.
- Fallback defensivo: si `client.channels.fetch` falla, usa `interaction.channel`. Si tampoco hay → notice ephemeral.

## Test plan
- [x] \`pnpm test\` → 158/158 (was 151, +7 tests nuevos)
- [x] \`tsc --noEmit\` → limpio
- [ ] \`/channel-id\` en un canal de texto → embed ephemeral con tipo "💬 Texto"
- [ ] \`/channel-id channel:#nombre\` → embed con metadata del canal pasado
- [ ] \`/channel-id public:true\` → embed visible para todo el canal
- [ ] Probar en un canal de voz, foro o thread para validar los labels de tipo
- [ ] Confirmar que el ID copia con un tap en mobile (gracias a los backticks)