### PR TITLE
chore(branding): drop setAuthor block, dedup ping pong icon

### DIFF
--- a/src/slashCommands/info/channel-id.ts
+++ b/src/slashCommands/info/channel-id.ts
@@ -33,7 +33,7 @@ const TYPE_LABELS: Partial<Record<ChannelType, string>> = {
 const formatChannelType = (type: ChannelType): string =>
   TYPE_LABELS[type] ?? `Tipo ${type}`;
 
-const buildEmbed = (client: ClientDiscord, channel: Channel) => {
+const buildEmbed = (channel: Channel) => {
   const fields: { name: string; value: string; inline?: boolean }[] = [];
 
   // For guild channels we can mention them; for DMs we just show "—"
@@ -66,10 +66,6 @@ const buildEmbed = (client: ClientDiscord, channel: Channel) => {
   }
 
   return new EmbedBuilder()
-    .setAuthor({
-      name: BOT_BRAND_NAME,
-      iconURL: client.user?.avatarURL() ?? undefined,
-    })
     .setTitle("Información del canal")
     .setColor(colorForCategory("info"))
     .addFields(fields)
@@ -131,7 +127,7 @@ const pull: ISlashCommand = {
       }
 
       return interaction.reply({
-        embeds: [buildEmbed(client, channel)],
+        embeds: [buildEmbed(channel)],
         flags: publicArg ? undefined : MessageFlags.Ephemeral,
         allowedMentions: { repliedUser: false },
       });

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -42,11 +42,6 @@ const visibleCommandsFor = (
   return isOwner ? all : all.filter((c) => !c.ownerOnly);
 };
 
-const buildAuthor = (client: ClientDiscord) => ({
-  name: BOT_BRAND_NAME,
-  iconURL: client.user?.avatarURL() ?? undefined,
-});
-
 const buildFooter = (extra?: string) => ({
   text: `${BOT_BRAND_NAME} ${BOT_VERSION}${extra ? ` · ${extra}` : ""}`,
 });
@@ -79,7 +74,6 @@ const buildListEmbed = (
   }));
 
   return new EmbedBuilder()
-    .setAuthor(buildAuthor(client))
     .setTitle(filterCategory ? `Comandos de ${capitalize(filterCategory)}` : "Help")
     .setThumbnail(client.user?.avatarURL() ?? null)
     .setDescription(
@@ -93,7 +87,7 @@ const buildListEmbed = (
     );
 };
 
-const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
+const buildDetailEmbed = (command: ISlashCommand) => {
   const fields: { name: string; value: string; inline?: boolean }[] = [];
 
   fields.push({
@@ -123,7 +117,6 @@ const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
   }
 
   return new EmbedBuilder()
-    .setAuthor(buildAuthor(client))
     .setTitle(`/${command.name}`)
     .setDescription(command.description || "Sin descripción")
     .setColor(colorForCategory(command.category))
@@ -182,7 +175,7 @@ const attachComponentCollector = async (
             return;
           }
           await i.update({
-            embeds: [buildDetailEmbed(client, command)],
+            embeds: [buildDetailEmbed(command)],
             components: [buildBackRow()],
           });
           return;
@@ -318,7 +311,7 @@ const pull: ISlashCommand = {
           });
         }
         return interaction.reply({
-          embeds: [buildDetailEmbed(client, command)],
+          embeds: [buildDetailEmbed(command)],
           flags: publicArg ? undefined : MessageFlags.Ephemeral,
           allowedMentions: { repliedUser: false },
         });

--- a/src/slashCommands/info/ping.test.ts
+++ b/src/slashCommands/info/ping.test.ts
@@ -41,7 +41,7 @@ describe("/ping", () => {
     const payload = interaction.editReply.mock.calls[0][0];
     const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
 
-    expect(fieldNames).toContain("🏓 Round-trip");
+    expect(fieldNames).toContain("📶 Round-trip");
     expect(fieldNames).toContain("📡 API");
     expect(fieldNames).toContain("⏰ Uptime");
     expect(fieldNames).toContain("📦 Versión");

--- a/src/slashCommands/info/ping.ts
+++ b/src/slashCommands/info/ping.ts
@@ -20,16 +20,12 @@ const buildEmbed = (
   uptimeSec: number
 ) =>
   new EmbedBuilder()
-    .setAuthor({
-      name: BOT_BRAND_NAME,
-      iconURL: client.user?.avatarURL() ?? undefined,
-    })
     .setTitle("🏓 Pong!")
     .setThumbnail(client.user?.avatarURL() ?? null)
     .setColor(colorForCategory("info"))
     .addFields(
       {
-        name: "🏓 Round-trip",
+        name: "📶 Round-trip",
         value: `\`${roundTripMs}ms\``,
         inline: true,
       },


### PR DESCRIPTION
## Summary
Owner observó dos detalles en los embeds ya faceliftados de `/help`, `/ping` y `/channel-id`:

1. **\"Xiza Bot\" aparecía 2 veces** dentro del embed (author block arriba + footer abajo) — más el nombre del bot que Discord ya muestra arriba del mensaje son **3 menciones** del mismo brand. Lectura: egocéntrico.
2. **`/ping` repetía el ícono 🏓** entre el title (\"🏓 Pong!\") y el primer field (\"🏓 Round-trip\").

## Cambios

- Removido `setAuthor` de los 3 embeds afectados (`/help` list + detail, `/ping`, `/channel-id`). Footer queda como única firma del bot.
- `/ping`: `📶 Round-trip` (era 🏓). El title \"🏓 Pong!\" se queda con su 🏓 icónico.
- Limpieza menor: `buildDetailEmbed` y `buildEmbed` ya no reciben `client` como parámetro (solo lo usaban para el author).

## Convención para los 15 comandos pendientes
- **NO** `setAuthor`. Solo footer con `Xiza Bot vX.Y.Z`.
- Title y field names usan emojis **distintos** entre sí.
- Thumbnail (avatar bot) sigue OK como decoración opcional.

Guardado en engram con topic_key \`facelift/branding-convention\`.

## Test plan
- [x] \`pnpm test\` → 158/158
- [x] \`tsc --noEmit\` → limpio
- [ ] \`/help\` — sin nombre/avatar arriba, solo footer
- [ ] \`/ping\` — sin author, Round-trip con 📶, API con 📡
- [ ] \`/channel-id\` — sin author, footer con versión