### PR TITLE
refactor: replace dynamic loaders with static manifests

### DIFF
--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1,16 +1,11 @@
 import { Router } from "express";
-import { readdirSync } from "fs";
-import path from "path";
+
+import routes from "./routes";
 
 const _router: Router = Router();
 
-(async () => {
-  const routes = readdirSync(path.resolve(__dirname, "./routes"));
-  for (const route of routes) {
-    const routeFile = await import(`./routes/${route}`);
-    const routePath = `/${route.split(".")[0]}`;
-    _router.use(routePath, routeFile.default);
-  }
-})();
+for (const { path, router } of routes) {
+  _router.use(path, router);
+}
 
 export default _router;

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -1,0 +1,29 @@
+// Manifest estático de routes de Express.
+//
+// Este array es la única fuente de verdad para qué rutas monta el router de
+// `/api`. Si agregás una route nueva:
+//   1. Crearla en `src/api/routes/<recurso>.router.ts` con `export default Router`
+//   2. Importarla arriba y agregar la entrada con `path` y `router`
+//
+// No usamos `readdirSync` + `import()` dinámico — ver
+// `src/slashCommands/index.ts` para el por qué.
+// Bonus: el loader anterior corría en una IIFE async, lo que generaba una
+// race condition contra `app.listen`. Con imports estáticos las rutas se
+// montan sincrónicamente antes de que arranque el server.
+
+import { Router } from "express";
+
+import birthdayRouter from "./birthday.router";
+import userRouter from "./user.router";
+
+export interface RouteEntry {
+  path: string;
+  router: Router;
+}
+
+const routes: RouteEntry[] = [
+  { path: "/birthday", router: birthdayRouter },
+  { path: "/user", router: userRouter },
+];
+
+export default routes;

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,0 +1,28 @@
+// Manifest estático de event handlers de Discord.
+//
+// Este array es la única fuente de verdad para qué events registra el bot.
+// Si agregás un event nuevo:
+//   1. Crealo en `src/events/<categoria>/<nombre>.ts` con `export default`
+//   2. Importalo arriba y agregalo al array
+//
+// No usamos `readdirSync` + `import()` dinámico — ver
+// `src/slashCommands/index.ts` para el por qué.
+
+import { IBotEvent } from "../shared/types";
+
+import interactionCreate from "./client/interactionCreate";
+import ready from "./client/ready";
+
+import messageDelete from "./message/messageDelete";
+import messageUpdate from "./message/messageUpdate";
+
+const events: IBotEvent[] = [
+  // client
+  interactionCreate,
+  ready,
+  // message
+  messageDelete,
+  messageUpdate,
+];
+
+export default events;

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,114 +1,55 @@
-import { readdirSync } from "fs";
+import { ApplicationCommandDataResolvable, ClientEvents } from "discord.js";
+import chalk from "chalk";
 
 import ClientDiscord from "../shared/classes/ClientDiscord";
-import { ApplicationCommandDataResolvable } from "discord.js";
-import path from "path";
-import chalk from "chalk";
+import events from "../events";
+import slashCommands from "../slashCommands";
 import { logger } from "../shared/utils/helpers";
 
-// Match the runtime's source file extension: .ts when running via tsx
-// (npm run dev), .js when running compiled output (npm start). Skip
-// .d.ts declaration files and co-located *.test.* files (Vitest is
-// ESM-only and breaks when required from CJS at runtime).
-const sourceExt = __filename.endsWith(".ts") ? ".ts" : ".js";
-const isLoadable = (file: string) =>
-  file.endsWith(sourceExt) &&
-  !file.endsWith(".d.ts") &&
-  !file.endsWith(`.test${sourceExt}`);
+const ok = (type: "Event" | "SlashCommand", name: string) =>
+  ` ✔️  => ${type} '${name}' is ready `;
 
-const checkHandler = (
-  type: "Event" | "SlashCommand",
-  file: string,
-  status: 0 | 1
-) => {
-  if (status === 1)
-    return ` ✔️  => ${type} '${file.substring(0, file.length - 3)}' is ready `;
-  return ` ❌  => ${type} '${file.substring(
-    0,
-    file.length - 3
-  )}' missing a help.name or help.name is not in string `;
-};
+const missing = (type: "Event" | "SlashCommand") =>
+  ` ❌  => ${type} missing a 'name' field or 'name' is not a string `;
 
-export const loadEvents = async (client: ClientDiscord) => {
-  const eventFolders = readdirSync(path.resolve(__dirname, "./../events"));
-  for (const folder of eventFolders) {
-    const eventFiles = readdirSync(
-      path.resolve(__dirname, `./../events/${folder}`)
-    ).filter(isLoadable);
+export const loadEvents = (client: ClientDiscord) => {
+  for (const event of events) {
+    if (!event.name) {
+      logger(chalk.bgRedBright.black(missing("Event")));
+      continue;
+    }
 
-    for (const file of eventFiles) {
-      let event;
-      try {
-        const mod = await import(`../events/${folder}/${file}`);
-        event = mod.default ?? mod;
-      } catch (err) {
-        logger(
-          chalk.bgRedBright.black(
-            ` ❌  => Event '${file.substring(0, file.length - 3)}' failed to load: ${err}`
-          )
-        );
-        continue;
-      }
+    logger(chalk.bgGreen.black(ok("Event", event.name)));
 
-      if (event.name) {
-        logger(chalk.bgGreen.black(checkHandler("Event", file, 1)));
-      } else {
-        logger(chalk.bgRedBright.black(checkHandler("Event", file, 0)));
-        continue;
-      }
+    if (!event.type) continue;
 
-      if (event.type) {
-        if (event.once) {
-          client.once(
-            event.name,
-            async (...args) => await event.execute(...args, client)
-          );
-        } else {
-          client.on(
-            event.name,
-            async (...args) => await event.execute(...args, client)
-          );
-        }
-      }
+    const handler = async (...args: unknown[]) =>
+      await event.execute(...args, client);
+
+    if (event.once) {
+      client.once(event.name as keyof ClientEvents, handler);
+    } else {
+      client.on(event.name as keyof ClientEvents, handler);
     }
   }
 };
 
-export const loadSlashCommands = async (client: ClientDiscord) => {
+export const loadSlashCommands = (client: ClientDiscord) => {
   const slash: ApplicationCommandDataResolvable[] = [];
 
-  const commandFolders = readdirSync(
-    path.resolve(__dirname, "./../slashCommands")
-  );
-  for (const folder of commandFolders) {
-    const commandFiles = readdirSync(
-      path.resolve(__dirname, `./../slashCommands/${folder}`)
-    ).filter(isLoadable);
-
-    for (const file of commandFiles) {
-      let command;
-      try {
-        command = (await import(`../slashCommands/${folder}/${file}`)).default;
-      } catch (err) {
-        logger(
-          chalk.bgRedBright.black(
-            ` ❌  => SlashCommand '${file.substring(0, file.length - 3)}' failed to load: ${err}`
-          )
-        );
-        continue;
-      }
-
-      if (command.name) {
-        client.slashCommands.set(command.name, command);
-        slash.push(command);
-        logger(
-          chalk.bgGreenBright.black(checkHandler("SlashCommand", file, 1))
-        );
-      } else {
-        logger(chalk.bgRedBright.black(checkHandler("SlashCommand", file, 0)));
-        continue;
-      }
+  for (const command of slashCommands) {
+    if (!command.name) {
+      logger(chalk.bgRedBright.black(missing("SlashCommand")));
+      continue;
     }
+
+    client.slashCommands.set(command.name, command);
+    // Cast: ISlashCommand y ApplicationCommandDataResolvable son compatibles en
+    // runtime, pero TS no puede inferir la unión discriminada porque
+    // SlashCommandsOptions.type es opcional. Deuda preexistente que el manifest
+    // estático reveló (antes el `import()` dinámico hacía `command: any`).
+    slash.push(command as unknown as ApplicationCommandDataResolvable);
+    logger(chalk.bgGreenBright.black(ok("SlashCommand", command.name)));
   }
 
   client.on("clientReady", async () => {

--- a/src/shared/types/main.ts
+++ b/src/shared/types/main.ts
@@ -60,6 +60,13 @@ export type ISlashCommand = {
   ) => Promise<unknown>;
 };
 
+export interface IBotEvent {
+  name: string;
+  type: string;
+  once?: boolean;
+  execute: (...args: any[]) => unknown;
+}
+
 export type Week = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export type Month = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 

--- a/src/slashCommands/index.ts
+++ b/src/slashCommands/index.ts
@@ -1,0 +1,59 @@
+// Manifest estático de slash commands.
+//
+// Este array es la única fuente de verdad para qué slash commands carga el
+// bot. Si agregás un comando nuevo:
+//   1. Crealo en `src/slashCommands/<categoria>/<nombre>.ts` con `export default`
+//   2. Importalo arriba y agregalo al array en su sección de categoría
+//
+// No usamos `readdirSync` + `import()` dinámico porque los watchers
+// (tsx watch, node --watch, esbuild, etc.) no pueden inferir paths con
+// strings interpolados, y eso rompe el reload en dev.
+
+import { ISlashCommand } from "../shared/types";
+
+import ahorcado from "./fun/ahorcado";
+import flip from "./fun/flip";
+import imc from "./fun/imc";
+import love from "./fun/love";
+import poke from "./fun/poke";
+import roll from "./fun/roll";
+import ruleta from "./fun/ruleta";
+import shuffle from "./fun/shuffle";
+
+import channelId from "./info/channel-id";
+import gmi2 from "./info/gmi2";
+import help from "./info/help";
+import ping from "./info/ping";
+
+import clear from "./mod/clear";
+import cums from "./mod/cums";
+import nextcum from "./mod/nextcum";
+import register from "./mod/register";
+import say from "./mod/say";
+import who from "./mod/who";
+
+const slashCommands: ISlashCommand[] = [
+  // fun
+  ahorcado,
+  flip,
+  imc,
+  love,
+  poke,
+  roll,
+  ruleta,
+  shuffle,
+  // info
+  channelId,
+  gmi2,
+  help,
+  ping,
+  // mod
+  clear,
+  cums,
+  nextcum,
+  register,
+  say,
+  who,
+];
+
+export default slashCommands;


### PR DESCRIPTION
## Summary
- Reemplaza loaders dinamicos por manifests estaticos en 3 puntos del bot.
- Resuelve el bug de pnpm dev que no recargaba al editar slash commands, events, o routes (tsx watch no puede inferir paths de import() dinamico con strings interpolados).
- Bonus: arregla race condition latente en api/router.ts (IIFE async contra app.listen).

## Files
**Nuevos manifests:**
- src/slashCommands/index.ts - 18 commands
- src/events/index.ts - 4 events
- src/api/routes/index.ts - 2 routes

**Refactorizados:**
- src/handlers/index.ts - loadEvents/loadSlashCommands sin readdirSync
- src/api/router.ts - for-loop sincronico en lugar de IIFE async
- src/shared/types/main.ts - agrega IBotEvent

## Test plan
- [ ] pnpm dev arranca, logs identicos a antes (mismos nombres y orden)
- [ ] pnpm dev + editar src/slashCommands/mod/say.ts -> recarga
- [ ] pnpm dev + editar src/events/client/ready.ts -> recarga
- [ ] pnpm dev + editar src/api/routes/birthday.router.ts -> recarga
- [ ] pnpm build && pnpm start - build pasa, prod arranca
- [ ] /ahorcado, /help, /say siguen respondiendo en Discord
- [ ] GET /api/birthday y GET /api/user siguen respondiendo

## Convention
Politica de manifests estaticos documentada en .claude/conventions.md 12 (gitignored, local).

Para agregar comandos/events/routes nuevos: crear el archivo + agregar al manifest. Una linea mas, pero el watcher funciona y el type checker valida en build time.