### PR TITLE
feat(flip): facelift — Spanish labels, fun branding, totals, validation

### DIFF
--- a/src/slashCommands/fun/flip.test.ts
+++ b/src/slashCommands/fun/flip.test.ts
@@ -1,32 +1,107 @@
-import { describe, expect, it, vi } from "vitest";
+import { MessageFlags } from "discord.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import flip from "./flip";
 
-describe("/flip", () => {
-  it("replies with a single Heads-or-Tails by default", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.1); // < 0.5 → Heads
+const stubRandom = (value: number) =>
+  vi.spyOn(Math, "random").mockReturnValue(value);
 
+describe("/flip", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("flips a single coin by default and replies publicly", async () => {
+    stubRandom(0.1); // < 0.5 → Cara
     const interaction = createMockInteraction();
     await flip.run(createMockClient(), interaction, []);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(payload.flags).toBeUndefined(); // public default
+    expect(payload.embeds[0].data.description).toContain("Cara");
   });
 
-  it("flips N coins when the option is provided", async () => {
+  it("renders Cruz when Math.random returns >= 0.5", async () => {
+    stubRandom(0.9);
     const interaction = createMockInteraction();
-    await flip.run(createMockClient(), interaction, [arg("coins", 5)]);
+    await flip.run(createMockClient(), interaction, []);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.embeds[0].data.description).toContain("Cruz");
+    expect(payload.embeds[0].data.description).not.toContain("Cara");
   });
 
-  it("clamps coin counts above 10 down to 10", async () => {
+  it("flips N coins and adds a totals line when N > 1", async () => {
+    stubRandom(0.1); // all heads
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("coins", 3)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    // 3 cara lines
+    expect(desc.split("Cara").length - 1).toBe(3);
+    expect(desc).toContain("**Total:**");
+    expect(desc).toContain("3 caras");
+    expect(desc).toContain("0 cruces");
+  });
+
+  it("clamps coins above 10 down to 10", async () => {
+    stubRandom(0.1);
     const interaction = createMockInteraction();
     await flip.run(createMockClient(), interaction, [arg("coins", 999)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    // The function uses ?.value && clamp internally; we just verify it doesn't blow up
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    expect(desc.split("Cara").length - 1).toBe(10);
+  });
+
+  it("rejects ephemerally when coins < 1", async () => {
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("coins", 0)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 1");
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    stubRandom(0.1);
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("private", true)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
+    stubRandom(0.1);
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.color).toBe(0xfee75c); // fun yellow
+    expect(embed.data.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.data.author).toBeUndefined();
+  });
+
+  it("singular Spanish: '1 cara · 0 cruces' (and inverse) for N === 2 with mixed result", async () => {
+    // Two flips: first random ≥ 0.5 → Cruz, second < 0.5 → Cara
+    const seq = [0.9, 0.1];
+    let i = 0;
+    vi.spyOn(Math, "random").mockImplementation(() => seq[i++]);
+
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("coins", 2)]);
+
+    const desc = interaction.reply.mock.calls[0][0].embeds[0].data.description;
+    expect(desc).toContain("1 cara");
+    expect(desc).toContain("1 cruz"); // singular for tails as well
   });
 });

--- a/src/slashCommands/fun/flip.ts
+++ b/src/slashCommands/fun/flip.ts
@@ -1,44 +1,101 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const MIN_COINS = 1;
+const MAX_COINS = 10;
+
+const HEADS_LABEL = "👑 Cara";
+const TAILS_LABEL = "🛡 Cruz";
+
+type FlipResult = "heads" | "tails";
+
+const flipOnce = (): FlipResult => (Math.random() < 0.5 ? "heads" : "tails");
+
+const labelFor = (r: FlipResult) => (r === "heads" ? HEADS_LABEL : TAILS_LABEL);
+
+const buildEmbed = (results: FlipResult[]) => {
+  const heads = results.filter((r) => r === "heads").length;
+  const tails = results.length - heads;
+
+  const lines = results.map(labelFor);
+
+  const description =
+    results.length === 1
+      ? lines[0]
+      : `${lines.join("\n")}\n\n**Total:** ${heads} ${
+          heads === 1 ? "cara" : "caras"
+        } · ${tails} ${tails === 1 ? "cruz" : "cruces"}`;
+
+  return new EmbedBuilder()
+    .setTitle("🪙 Moneda al aire")
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
 
 const pull: ISlashCommand = {
   name: "flip",
   category: "fun",
-  description: "Flip a coin!",
+  description: "Tira una moneda al aire (cara o cruz)",
   ownerOnly: false,
   options: [
     {
       name: "coins",
-      description: "The number of coins to flip",
-      type: ApplicationCommandOptionType.Number,
+      description: `Cantidad de monedas a tirar (${MIN_COINS}–${MAX_COINS}, default: 1)`,
+      type: ApplicationCommandOptionType.Integer,
+      required: false,
+    },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a vos (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
   ],
+  examples: ["/flip", "/flip coins:5", "/flip coins:3 private:true"],
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const value: number = parseInt(args[0]?.value?.toString() || "1");
-      const number =
-        (args[0]?.value && (value > 10 ? 10 : value < 1 ? 1 : value)) || 1;
-      const result = [];
-      for (let i = 0; i < number; i++) {
-        result.push(Math.random() < 0.5 ? "🧑 Heads" : "🛡️ Tails");
-      }
-      const embed = new Discord.EmbedBuilder()
-        .setColor("Random")
-        .setTitle("Coin Flip")
-        .setDescription(result.join("\n"))
-        .setFooter({
-          text: `Requested by ${interaction.user.tag}`,
-          iconURL: interaction.user.displayAvatarURL(),
+      const rawCoins = args.find((a) => a.name === "coins")?.value as
+        | number
+        | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as boolean | undefined) ??
+        false;
+
+      // Reject 0/negative explicitly instead of silently clamping — the user
+      // probably mistyped. Big positive values still clamp to MAX_COINS.
+      if (rawCoins !== undefined && rawCoins < MIN_COINS) {
+        return interaction.reply({
+          content: `La cantidad de monedas debe ser al menos ${MIN_COINS}.`,
+          flags: MessageFlags.Ephemeral,
         });
-      interaction.reply({ embeds: [embed] });
+      }
+
+      const coins = Math.min(rawCoins ?? 1, MAX_COINS);
+
+      const results: FlipResult[] = [];
+      for (let i = 0; i < coins; i++) results.push(flipOnce());
+
+      return interaction.reply({
+        embeds: [buildEmbed(results)],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }


### PR DESCRIPTION
## Summary
Primer comando del facelift de la categoría **fun**, aplicando la convención que dejamos en PR #49 (sin setAuthor, footer-only, emojis distintos title vs cuerpo).

## Cambios
- Description y labels en español: `Tira una moneda al aire`, `👑 Cara` / `🛡 Cruz`
- Title `🪙 Moneda al aire` (distinto a los emojis del cuerpo)
- Color `fun` (#FEE75C amarillo Discord) en lugar de `Random`
- Footer con la firma estándar (`Xiza Bot vX.Y.Z`), eliminado `Requested by …`
- Nuevo opt-in `private:` — default **público** (es para compartir, mismo patrón que `/ping`)
- Línea de totales cuando hay > 1 moneda: `**Total:** 3 caras · 2 cruces` (con singulares correctos)
- Validación: `coins < 1` ahora responde ephemeral en lugar de silenciar al usuario clampeando a 1
- Tipo de opción: `Number` → `Integer` (no podés tirar media moneda)

## Test plan
- [x] `pnpm test` → 163/163 (was 158, +5 tests para `/flip`)
- [x] `tsc --noEmit` → limpio
- [ ] `/flip` → 1 cara o cruz, embed amarillo, footer
- [ ] `/flip coins:5` → 5 líneas + total
- [ ] `/flip coins:0` → notice ephemeral
- [ ] `/flip coins:999` → clamp a 10
- [ ] `/flip private:true` → solo lo ves vos