### PR TITLE
feat(roll): facelift — Spanish labels, fun branding, totals, validation

### DIFF
--- a/src/slashCommands/fun/roll.test.ts
+++ b/src/slashCommands/fun/roll.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("jimp", () => ({
@@ -9,7 +10,11 @@ vi.mock("jimp", () => ({
 }));
 
 import { Jimp } from "jimp";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import roll from "./roll";
 
 beforeEach(() => {
@@ -55,5 +60,69 @@ describe("/roll", () => {
 
     expect(Jimp.read).toHaveBeenCalledTimes(20);
     expect(interaction.reply).toHaveBeenCalledOnce();
+  });
+
+  it("includes a Total line when quantity > 1", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [
+      arg("quantity", 4),
+      arg("sides", 20),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    expect(desc).toContain("**4d20**");
+    expect(desc).toContain("**Total:**");
+  });
+
+  it("uses singular phrasing for a single roll", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("sides", 20)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    expect(desc).toContain("Sacaste un");
+    expect(desc).toContain("d20");
+    expect(desc).not.toContain("Total");
+  });
+
+  it("rejects ephemerally when quantity < 1", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("quantity", 0)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 1");
+    expect(Jimp.read).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when sides < 2", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("sides", 1)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 2");
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [
+      arg("sides", 20),
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("sides", 20)]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.color).toBe(0xfee75c);
+    expect(embed.data.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.data.author).toBeUndefined();
   });
 });

--- a/src/slashCommands/fun/roll.ts
+++ b/src/slashCommands/fun/roll.ts
@@ -1,118 +1,154 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+import { Jimp } from "jimp";
+
 import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random } from "../../shared/utils/helpers";
-import { Jimp } from "jimp";
 
 const OPTIONS = {
   quantity: "quantity",
   sides: "sides",
+  private: "private",
 } as const;
 
-type OPTIONS_TYPES = (typeof OPTIONS)[keyof typeof OPTIONS];
+const MIN_QUANTITY = 1;
+const MAX_QUANTITY = 20;
+const MIN_SIDES = 2;
+const MAX_SIDES = 100;
+
+const IMAGE_AVAILABLE_SIDES = [4, 6, 12] as const;
+const TILES_PER_ROW = 6;
+
+const composeDiceImage = async (rolls: number[], sides: number) => {
+  const repo = config.oldRoot;
+  const images = await Promise.all(
+    rolls.map((r) => Jimp.read(`${repo}/d${sides}/d${r}.png`))
+  );
+
+  const tileWidth = images[0].width;
+  const tileHeight = images[0].height;
+  const cols = Math.min(images.length, TILES_PER_ROW);
+  const rows = Math.ceil(images.length / TILES_PER_ROW);
+  const finalImage = new Jimp({
+    width: cols * tileWidth,
+    height: rows * tileHeight,
+  });
+
+  for (let i = 0; i < images.length; i++) {
+    const col = i % TILES_PER_ROW;
+    const row = Math.floor(i / TILES_PER_ROW);
+    finalImage.composite(images[i], col * tileWidth, row * tileHeight);
+  }
+
+  return finalImage.getBuffer("image/png");
+};
+
+const buildEmbed = (rolls: number[], sides: number) => {
+  const total = rolls.reduce((a, b) => a + b, 0);
+  const dieLabel = `${rolls.length}d${sides}`;
+
+  const description =
+    rolls.length === 1
+      ? `Sacaste un **${rolls[0]}** (\`d${sides}\`)`
+      : `**${dieLabel}**: ${rolls.join(", ")}\n\n**Total:** ${total}`;
+
+  return new EmbedBuilder()
+    .setTitle("🎲 Dados")
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
 
 const pull: ISlashCommand = {
   name: "roll",
   category: "fun",
-  description: "roll dices",
+  description: "Tira dados (con imagen para d4, d6 y d12)",
   ownerOnly: false,
   options: [
     {
       name: OPTIONS.quantity,
-      description: "The number of dices to roll",
-      type: ApplicationCommandOptionType.Number,
+      description: `Cantidad de dados (${MIN_QUANTITY}–${MAX_QUANTITY}, default: 1)`,
+      type: ApplicationCommandOptionType.Integer,
       required: false,
     },
     {
       name: OPTIONS.sides,
-      description: "The number of sides of the dice",
-      type: ApplicationCommandOptionType.Number,
+      description: `Cantidad de lados (${MIN_SIDES}–${MAX_SIDES}, default: 6)`,
+      type: ApplicationCommandOptionType.Integer,
+      required: false,
+    },
+    {
+      name: OPTIONS.private,
+      description: "Mostrar la respuesta solo a vos (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
   ],
+  examples: ["/roll", "/roll quantity:3 sides:6", "/roll sides:20"],
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const { quantity, sides } = getArgs(args);
-      const result = [];
-      const existImages = [4, 6, 12];
-      const repo = config.oldRoot;
-      for (let i = 0; i < quantity; i++) {
-        result.push(random(1, sides));
-      }
-      const embed = new Discord.EmbedBuilder()
-        .setColor("Gold")
-        .setTitle("Dice Roll")
-        .setFooter({
-          text: `Requested by ${interaction.user.tag}`,
-          iconURL: interaction.user.displayAvatarURL(),
+      const rawQuantity = args.find((a) => a.name === OPTIONS.quantity)
+        ?.value as number | undefined;
+      const rawSides = args.find((a) => a.name === OPTIONS.sides)?.value as
+        | number
+        | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === OPTIONS.private)?.value as
+          | boolean
+          | undefined) ?? false;
+
+      if (rawQuantity !== undefined && rawQuantity < MIN_QUANTITY) {
+        return interaction.reply({
+          content: `La cantidad de dados debe ser al menos ${MIN_QUANTITY}.`,
+          flags: MessageFlags.Ephemeral,
         });
+      }
+      if (rawSides !== undefined && rawSides < MIN_SIDES) {
+        return interaction.reply({
+          content: `Un dado debe tener al menos ${MIN_SIDES} lados.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
-      if (existImages.includes(sides)) {
-        const images = await Promise.all(
-          result.map((r) => Jimp.read(`${repo}/d${sides}/d${r}.png`))
-        );
+      const quantity = Math.min(rawQuantity ?? 1, MAX_QUANTITY);
+      const sides = Math.min(rawSides ?? 6, MAX_SIDES);
 
-        const tileWidth = images[0].width;
-        const tileHeight = images[0].height;
-        const width = (images.length > 6 ? 6 : images.length) * tileWidth;
-        const height = Math.ceil(images.length / 6) * tileHeight;
-        const finalImage = new Jimp({ width, height });
-        let x = 0;
-        let col = 0;
-        let row = 0;
-        for (const image of images) {
-          finalImage.composite(image, x, row * tileHeight);
-          x += tileWidth;
-          col++;
-          if (col === 6) {
-            col = 0;
-            row++;
-            x = 0;
-          }
-        }
-        const buffer = await finalImage.getBuffer("image/png");
-        embed.setImage(`attachment://dice.png`);
-        interaction.reply({
+      const rolls: number[] = [];
+      for (let i = 0; i < quantity; i++) rolls.push(random(1, sides));
+
+      const embed = buildEmbed(rolls, sides);
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
+
+      if ((IMAGE_AVAILABLE_SIDES as readonly number[]).includes(sides)) {
+        const buffer = await composeDiceImage(rolls, sides);
+        embed.setImage("attachment://dice.png");
+        return interaction.reply({
           embeds: [embed],
           files: [{ attachment: buffer, name: "dice.png" }],
+          flags,
         });
-        return;
-      } else {
-        embed.setDescription(result.join("\n"));
       }
 
-      interaction.reply({ embeds: [embed] });
+      return interaction.reply({ embeds: [embed], flags });
     } catch (error) {
       errorHandler(interaction, error);
     }
   },
-};
-
-const maxQuantity = 20;
-
-const getArgs = (args: Argument[]) => {
-  let { quantity, sides } = args!.reduce<
-    Partial<Record<OPTIONS_TYPES, string | number | boolean>>
-  >(
-    (acc, cur) => {
-      acc[cur.name as OPTIONS_TYPES] = cur.value;
-      return acc;
-    },
-    { quantity: 1, sides: 6 }
-  );
-  quantity = Number(quantity);
-  sides = Number(sides);
-  if (!quantity) quantity = 1;
-  if (!sides) sides = 6;
-  quantity = quantity > maxQuantity ? maxQuantity : quantity < 1 ? 1 : quantity;
-  sides = sides > 100 ? 100 : sides < 1 ? 1 : sides;
-  return { quantity, sides };
 };
 
 export default pull;


### PR DESCRIPTION
## Summary
Segundo comando del facelift de **fun**, mismo patrón que `/flip`. La generación de imagen para d4/d6/d12 se preserva intacta.

## Cambios
- Description y title en español: `Tira dados (con imagen para d4, d6 y d12)` · `🎲 Dados`
- Color `fun` (#FEE75C amarillo) en lugar de `Gold`
- Footer estándar (`Xiza Bot vX.Y.Z`), eliminado `Requested by …`
- Description siempre presente (antes era vacía cuando había imagen):
  - 1 tirada: `Sacaste un **5** (d6)`
  - >1 tirada: `**4d20**: 12, 7, 18, 3 — **Total:** 40`
- Nuevo opt-in `private:` (default público)
- Validación: `quantity < 1` o `sides < 2` → notice ephemeral (antes clampeaba en silencio)
- Tipos: `Number` → `Integer`
- Refactor menor: helper `composeDiceImage`, math con módulo en lugar de contador col/row imperativo

## Test plan
- [x] `pnpm test` → 169/169 (was 163, +6 tests nuevos)
- [x] `tsc --noEmit` → limpio
- [ ] `/roll` → 1d6 con imagen
- [ ] `/roll quantity:3 sides:6` → 3 dados visuales + total
- [ ] `/roll sides:20` → texto sin imagen, 1d20
- [ ] `/roll quantity:4 sides:20` → texto con total
- [ ] `/roll quantity:0` → notice ephemeral
- [ ] `/roll sides:1` → notice ephemeral
- [ ] `/roll private:true` → solo lo ves vos