### PR TITLE
feat(shuffle): facelift + fix shuffle helper mutation

### DIFF
--- a/src/shared/utils/helpers.test.ts
+++ b/src/shared/utils/helpers.test.ts
@@ -91,6 +91,18 @@ describe("helpers — pure functions", () => {
     it("handles empty input", () => {
       expect(shuffle([])).toEqual([]);
     });
+
+    it("does NOT mutate the input array", () => {
+      const input = [1, 2, 3, 4, 5];
+      const snapshot = [...input];
+      shuffle(input);
+      expect(input).toEqual(snapshot);
+    });
+
+    it("returns a new array reference", () => {
+      const input = [1, 2, 3];
+      expect(shuffle(input)).not.toBe(input);
+    });
   });
 
   describe("mentionUser(id)", () => {

--- a/src/shared/utils/helpers.ts
+++ b/src/shared/utils/helpers.ts
@@ -75,24 +75,17 @@ export const channelSender = (
   channel.send(msg);
 };
 
+/**
+ * Returns a shuffled COPY of the input array — the original is untouched.
+ * Uses Fisher-Yates so the distribution is uniform.
+ */
 export const shuffle = <T>(array: T[]): T[] => {
-  let currentIndex = array.length;
-  let randomIndex;
-
-  // While there remain elements to shuffle.
-  while (currentIndex !== 0) {
-    // Pick a remaining element.
-    randomIndex = Math.floor(Math.random() * currentIndex);
-    currentIndex--;
-
-    // And swap it with the current element.
-    [array[currentIndex], array[randomIndex]] = [
-      array[randomIndex],
-      array[currentIndex],
-    ];
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
   }
-
-  return array;
+  return result;
 };
 
 export const ownerSender = async (

--- a/src/slashCommands/fun/shuffle.test.ts
+++ b/src/slashCommands/fun/shuffle.test.ts
@@ -1,5 +1,5 @@
 import { MessageFlags } from "discord.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createMockClient,
@@ -9,7 +9,7 @@ import {
 import shuffle from "./shuffle";
 
 describe("/shuffle", () => {
-  describe("words subcommand", () => {
+  describe("words subcommand — no winners (instant)", () => {
     it("replies with the shuffled list and an original-list field", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
@@ -21,7 +21,9 @@ describe("/shuffle", () => {
       expect(payload.embeds).toHaveLength(1);
       const embed = payload.embeds[0].data;
       expect(embed.title).toBe("🔀 Lista aleatoria");
-      const original = embed.fields.find((f: any) => f.name === "Lista original");
+      const original = embed.fields.find(
+        (f: any) => f.name === "Lista original"
+      );
       expect(original.value).toBe("ana, bob, carla, david");
     });
 
@@ -33,35 +35,10 @@ describe("/shuffle", () => {
 
       const payload = interaction.reply.mock.calls[0][0];
       const embed = payload.embeds[0].data;
-      const original = embed.fields.find((f: any) => f.name === "Lista original");
+      const original = embed.fields.find(
+        (f: any) => f.name === "Lista original"
+      );
       expect(original.value).toBe("ana, bob, carla");
-    });
-
-    it("uses the singular 'Ganador' title when winners=1", async () => {
-      const interaction = createMockInteraction();
-      await shuffle.run(createMockClient(), interaction, [
-        subCommandArg("words", [
-          { name: "list", value: "ana bob carla" },
-          { name: "winners", value: 1 },
-        ]),
-      ]);
-
-      const payload = interaction.reply.mock.calls[0][0];
-      expect(payload.embeds[0].data.title).toBe("🏆 Ganador");
-    });
-
-    it("caps winners to the list length when winners > items", async () => {
-      const interaction = createMockInteraction();
-      await shuffle.run(createMockClient(), interaction, [
-        subCommandArg("words", [
-          { name: "list", value: "ana bob" },
-          { name: "winners", value: 99 },
-        ]),
-      ]);
-
-      const payload = interaction.reply.mock.calls[0][0];
-      // capped to 2 → plural
-      expect(payload.embeds[0].data.title).toBe("🏆 Ganadores (2)");
     });
 
     it("rejects ephemerally when the list has fewer than 2 items", async () => {
@@ -74,8 +51,73 @@ describe("/shuffle", () => {
       expect(payload.flags).toBe(MessageFlags.Ephemeral);
       expect(payload.content).toContain("al menos 2");
     });
+  });
 
-    it("rejects ephemerally when winners < 1", async () => {
+  describe("words subcommand — winners (animated raffle)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("defers, edits N teaser frames, then edits with the final winners embed", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "winners", value: 1 },
+        ]),
+      ]);
+
+      // Drive the timers so all setTimeout-based sleeps resolve
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(interaction.deferReply).toHaveBeenCalledOnce();
+      // 3 teaser frames + 1 final reveal = 4 editReply calls
+      expect(interaction.editReply).toHaveBeenCalledTimes(4);
+      expect(interaction.reply).not.toHaveBeenCalled();
+
+      // The final edit should carry the winners embed
+      const finalCall = interaction.editReply.mock.calls.at(-1)![0];
+      expect(finalCall.embeds[0].data.title).toBe("🏆 Ganador");
+    });
+
+    it("uses 'Ganadores (N)' title for plural winners", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla david" },
+          { name: "winners", value: 3 },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const finalCall = interaction.editReply.mock.calls.at(-1)![0];
+      expect(finalCall.embeds[0].data.title).toBe("🏆 Ganadores (3)");
+    });
+
+    it("caps winners to the list length when winners > items", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob" },
+          { name: "winners", value: 99 },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const finalCall = interaction.editReply.mock.calls.at(-1)![0];
+      expect(finalCall.embeds[0].data.title).toBe("🏆 Ganadores (2)");
+    });
+
+    it("rejects ephemerally when winners < 1 (no defer, no animation)", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
         subCommandArg("words", [
@@ -87,6 +129,44 @@ describe("/shuffle", () => {
       const payload = interaction.reply.mock.calls[0][0];
       expect(payload.flags).toBe(MessageFlags.Ephemeral);
       expect(payload.content).toContain("al menos 1");
+      expect(interaction.deferReply).not.toHaveBeenCalled();
+      expect(interaction.editReply).not.toHaveBeenCalled();
+    });
+
+    it("teaser frames use the '🎰 Sorteando...' title before the reveal", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "winners", value: 1 },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const calls = interaction.editReply.mock.calls;
+      // First three calls are teasers, last is the reveal
+      for (let i = 0; i < 3; i++) {
+        expect(calls[i][0].embeds[0].data.title).toBe("🎰 Sorteando...");
+      }
+    });
+
+    it("respects private:true on deferReply (animation runs ephemerally)", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "winners", value: 1 },
+          { name: "private", value: true },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const deferPayload = interaction.deferReply.mock.calls[0][0];
+      expect(deferPayload.flags).toBe(MessageFlags.Ephemeral);
     });
   });
 
@@ -136,7 +216,7 @@ describe("/shuffle", () => {
       expect(embed.author).toBeUndefined();
     });
 
-    it("becomes ephemeral when private:true is passed (words)", async () => {
+    it("becomes ephemeral when private:true is passed (words, no winners)", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
         subCommandArg("words", [

--- a/src/slashCommands/fun/shuffle.test.ts
+++ b/src/slashCommands/fun/shuffle.test.ts
@@ -1,11 +1,16 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
-import { arg, createMockClient, createMockInteraction, subCommandArg } from "../../test-utils/discord-mocks";
+import {
+  createMockClient,
+  createMockInteraction,
+  subCommandArg,
+} from "../../test-utils/discord-mocks";
 import shuffle from "./shuffle";
 
 describe("/shuffle", () => {
   describe("words subcommand", () => {
-    it("replies with the shuffled list", async () => {
+    it("replies with the shuffled list and an original-list field", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
         subCommandArg("words", [{ name: "list", value: "ana bob carla david" }]),
@@ -14,9 +19,25 @@ describe("/shuffle", () => {
       expect(interaction.reply).toHaveBeenCalledOnce();
       const payload = interaction.reply.mock.calls[0][0];
       expect(payload.embeds).toHaveLength(1);
+      const embed = payload.embeds[0].data;
+      expect(embed.title).toBe("🔀 Lista aleatoria");
+      const original = embed.fields.find((f: any) => f.name === "Lista original");
+      expect(original.value).toBe("ana, bob, carla, david");
     });
 
-    it("respects the winners cap", async () => {
+    it("accepts comma-separated input", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [{ name: "list", value: "ana, bob, carla" }]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      const embed = payload.embeds[0].data;
+      const original = embed.fields.find((f: any) => f.name === "Lista original");
+      expect(original.value).toBe("ana, bob, carla");
+    });
+
+    it("uses the singular 'Ganador' title when winners=1", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
         subCommandArg("words", [
@@ -25,7 +46,47 @@ describe("/shuffle", () => {
         ]),
       ]);
 
-      expect(interaction.reply).toHaveBeenCalledOnce();
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.embeds[0].data.title).toBe("🏆 Ganador");
+    });
+
+    it("caps winners to the list length when winners > items", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob" },
+          { name: "winners", value: 99 },
+        ]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      // capped to 2 → plural
+      expect(payload.embeds[0].data.title).toBe("🏆 Ganadores (2)");
+    });
+
+    it("rejects ephemerally when the list has fewer than 2 items", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [{ name: "list", value: "ana" }]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+      expect(payload.content).toContain("al menos 2");
+    });
+
+    it("rejects ephemerally when winners < 1", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "winners", value: 0 },
+        ]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+      expect(payload.content).toContain("al menos 1");
     });
   });
 
@@ -37,15 +98,68 @@ describe("/shuffle", () => {
       ]);
 
       expect(interaction.reply).toHaveBeenCalledOnce();
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.embeds[0].data.title).toBe("🔀 Números (1–5)");
     });
 
-    it("clamps quantity above 20 down to 20", async () => {
+    it("clamps quantity above 50 down to 50", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
-        subCommandArg("numbers", [{ name: "quantity", value: 99 }]),
+        subCommandArg("numbers", [{ name: "quantity", value: 999 }]),
       ]);
 
-      expect(interaction.reply).toHaveBeenCalledOnce();
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.embeds[0].data.title).toBe("🔀 Números (1–50)");
+    });
+
+    it("rejects ephemerally when quantity < 1", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("numbers", [{ name: "quantity", value: 0 }]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    });
+  });
+
+  describe("branding", () => {
+    it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [{ name: "list", value: "ana bob carla" }]),
+      ]);
+
+      const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+      expect(embed.color).toBe(0xfee75c);
+      expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+      expect(embed.author).toBeUndefined();
+    });
+
+    it("becomes ephemeral when private:true is passed (words)", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "private", value: true },
+        ]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    });
+
+    it("becomes ephemeral when private:true is passed (numbers)", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("numbers", [
+          { name: "quantity", value: 5 },
+          { name: "private", value: true },
+        ]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
     });
   });
 });

--- a/src/slashCommands/fun/shuffle.ts
+++ b/src/slashCommands/fun/shuffle.ts
@@ -1,57 +1,165 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
-import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
-import { Argument, ISlashCommand } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 
-const OPTIONS = {
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler, shuffle } from "../../shared/utils/helpers";
+
+const SUB = {
   words: "words",
   numbers: "numbers",
+} as const;
+
+const OPT = {
   list: "list",
   winners: "winners",
   quantity: "quantity",
+  private: "private",
 } as const;
 
-type OPTIONS_TYPES = (typeof OPTIONS)[keyof typeof OPTIONS];
+const MIN_ITEMS = 2;
+const MIN_QUANTITY = 1;
+const MAX_QUANTITY = 50;
+
+/**
+ * Splits the raw list on commas, semicolons, or any whitespace, trims each
+ * item and drops empties. Supports `"ana bob carla"`, `"ana,bob,carla"`,
+ * `"ana, bob, carla"`, etc. — whichever feels natural to the user.
+ */
+const parseWordList = (raw: string): string[] =>
+  raw
+    .split(/[,;\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+const enumerateLines = (items: (string | number)[]) =>
+  items.map((item, i) => `**${i + 1}.** ${item}`).join("\n");
+
+const buildBaseEmbed = (title: string, description: string) =>
+  new EmbedBuilder()
+    .setTitle(title)
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+type Result = { embed?: EmbedBuilder; error?: string };
+
+const handleWords = (rawList: string, winners: number | undefined): Result => {
+  const list = parseWordList(rawList);
+  if (list.length < MIN_ITEMS) {
+    return {
+      error: `Necesito al menos ${MIN_ITEMS} elementos. Separá la lista con espacios, comas o punto y coma.`,
+    };
+  }
+  if (winners !== undefined && winners < 1) {
+    return { error: "El número de ganadores debe ser al menos 1." };
+  }
+
+  const shuffled = shuffle(list);
+  const cap =
+    winners !== undefined ? Math.min(winners, list.length) : list.length;
+  const picked = shuffled.slice(0, cap);
+
+  let title: string;
+  if (winners !== undefined) {
+    title = cap === 1 ? "🏆 Ganador" : `🏆 Ganadores (${cap})`;
+  } else {
+    title = "🔀 Lista aleatoria";
+  }
+
+  const embed = buildBaseEmbed(title, enumerateLines(picked)).addFields({
+    name: "Lista original",
+    value: list.join(", "),
+  });
+
+  return { embed };
+};
+
+const handleNumbers = (rawQuantity: number | undefined): Result => {
+  if (rawQuantity === undefined) {
+    return { error: "Tenés que pasar la cantidad." };
+  }
+  if (rawQuantity < MIN_QUANTITY) {
+    return { error: `La cantidad debe ser al menos ${MIN_QUANTITY}.` };
+  }
+
+  const quantity = Math.min(rawQuantity, MAX_QUANTITY);
+  const list = Array.from({ length: quantity }, (_, i) => i + 1);
+  const shuffled = shuffle(list);
+
+  const embed = buildBaseEmbed(
+    `🔀 Números (1–${quantity})`,
+    shuffled.join(", ")
+  );
+
+  return { embed };
+};
 
 const pull: ISlashCommand = {
   name: "shuffle",
   category: "fun",
-  description: "Shuffle a list of words or numbers",
+  description: "Mezcla aleatoriamente una lista de palabras o números",
   ownerOnly: false,
   options: [
     {
-      name: OPTIONS.words,
-      description: "Shuffle a list of words",
+      name: SUB.words,
+      description: "Mezcla una lista de palabras",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
-          name: OPTIONS.list,
-          description: "example: name1 name2 name3",
+          name: OPT.list,
+          description: "Lista separada por espacios, comas o punto y coma",
           type: ApplicationCommandOptionType.String,
           required: true,
         },
         {
-          name: OPTIONS.winners,
-          description: "the number of winners",
+          name: OPT.winners,
+          description:
+            "Cantidad de ganadores a elegir (default: toda la lista)",
           type: ApplicationCommandOptionType.Integer,
+          required: false,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
       ],
     },
     {
-      name: OPTIONS.numbers,
-      description: "Shuffle a list of numbers",
+      name: SUB.numbers,
+      description: "Genera y mezcla los números del 1 al N",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
-          name: OPTIONS.quantity,
-          description: "the number of numbers to sort",
+          name: OPT.quantity,
+          description: `Cantidad de números (${MIN_QUANTITY}–${MAX_QUANTITY})`,
           type: ApplicationCommandOptionType.Integer,
           required: true,
         },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
       ],
     },
+  ],
+  examples: [
+    "/shuffle words list:ana,bob,carla",
+    "/shuffle words list:ana bob carla winners:1",
+    "/shuffle numbers quantity:10",
   ],
   run: async (
     _: ClientDiscord,
@@ -59,91 +167,41 @@ const pull: ISlashCommand = {
     args: Argument[]
   ) => {
     try {
-      const subCommand = args[0];
+      const sub = args[0];
+      if (!sub) return;
 
-      if (subCommand.name === OPTIONS.words) {
-        let { list: value, winners } = subCommand.args!.reduce<
-          Partial<Record<OPTIONS_TYPES, string | number | boolean>>
-        >(
-          (acc, cur) => {
-            acc[cur.name as OPTIONS_TYPES] = cur.value;
-            return acc;
-          },
-          { list: "" }
-        );
+      const subArgs = sub.args ?? [];
+      const findArg = (name: string) =>
+        subArgs.find((a) => a.name === name)?.value;
+      const isPrivate = (findArg(OPT.private) as boolean | undefined) ?? false;
 
-        const list = (value as string)?.split(" ").map((item) => item.trim());
-        const withWinners = Boolean(winners);
-        winners = parseInt(winners?.toString() || list.length.toString());
-        const title = withWinners
-          ? winners === 1
-            ? "Ganador"
-            : "Ganadores"
-          : "Lista aleatoria";
-        const shuffledList = shuffle(list);
-
-        const embed = new Discord.EmbedBuilder()
-          .setColor("Random")
-          .setTitle(title)
-          .setDescription(enumerateArray(shuffledList, winners))
-          .setFields([
-            {
-              name: "Lista original",
-              value: list.join(", "),
-              inline: true,
-            },
-          ])
-          .setFooter({
-            text: `Requested by ${interaction.user.tag}`,
-            iconURL: interaction.user.displayAvatarURL(),
-          });
-
-        interaction.reply({ embeds: [embed] });
-      } else if (subCommand.name === OPTIONS.numbers) {
-        let quantity = subCommand.args?.[0].value as number;
-        if (quantity > 20) quantity = 20;
-        if (quantity < 1) quantity = 1;
-        const list = [];
-        for (let i = 1; i <= quantity; i++) {
-          list.push(i);
-        }
-        // const shuffledList = list.sort(() => Math.random() - 0.5);
-        const shuffledList = shuffle(list);
-
-        const embed = new Discord.EmbedBuilder()
-          .setColor("Random")
-          .setTitle("Shuffled List")
-          .setDescription(shuffledList.join(", "))
-          .setFooter({
-            text: `Requested by ${interaction.user.tag}`,
-            iconURL: interaction.user.displayAvatarURL(),
-          });
-
-        interaction.reply({ embeds: [embed] });
+      let result: Result;
+      if (sub.name === SUB.words) {
+        const rawList = (findArg(OPT.list) as string) ?? "";
+        const winners = findArg(OPT.winners) as number | undefined;
+        result = handleWords(rawList, winners);
+      } else if (sub.name === SUB.numbers) {
+        const quantity = findArg(OPT.quantity) as number | undefined;
+        result = handleNumbers(quantity);
+      } else {
+        return;
       }
+
+      if (result.error) {
+        return interaction.reply({
+          content: result.error,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      return interaction.reply({
+        embeds: [result.embed!],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }
   },
 };
-
-const enumerateArray = (array: (string | number)[], winners: number) => {
-  const slicedArray = array.slice(0, winners);
-  let list = "";
-  for (let i = 0; i < slicedArray.length; i++) {
-    list += `${i + 1}. ${slicedArray[i]}\n`;
-  }
-  list = list.slice(0, -1);
-  return list;
-};
-
-function shuffle<T>(array: T[]): T[] {
-  const result = [...array]; // copiar para no mutar el original
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1)); // índice aleatorio 0..i
-    [result[i], result[j]] = [result[j], result[i]]; // swap
-  }
-  return result;
-}
 
 export default pull;

--- a/src/slashCommands/fun/shuffle.ts
+++ b/src/slashCommands/fun/shuffle.ts
@@ -30,11 +30,13 @@ const MIN_ITEMS = 2;
 const MIN_QUANTITY = 1;
 const MAX_QUANTITY = 50;
 
-/**
- * Splits the raw list on commas, semicolons, or any whitespace, trims each
- * item and drops empties. Supports `"ana bob carla"`, `"ana,bob,carla"`,
- * `"ana, bob, carla"`, etc. — whichever feels natural to the user.
- */
+// Animation only fires for /shuffle words winners:N — the dramatic reveal case.
+// Total wait: ANIMATION_FRAMES * FRAME_DELAY_MS = 1.8s with the defaults.
+const ANIMATION_FRAMES = 3;
+const FRAME_DELAY_MS = 600;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
 const parseWordList = (raw: string): string[] =>
   raw
     .split(/[,;\s]+/)
@@ -44,64 +46,67 @@ const parseWordList = (raw: string): string[] =>
 const enumerateLines = (items: (string | number)[]) =>
   items.map((item, i) => `**${i + 1}.** ${item}`).join("\n");
 
-const buildBaseEmbed = (title: string, description: string) =>
+const teaserDescription = (list: string[]) =>
+  list.map((w, i) => `**${i + 1}.** ${w}`).join("\n");
+
+const baseEmbed = (title: string, description: string) =>
   new EmbedBuilder()
     .setTitle(title)
     .setDescription(description)
     .setColor(colorForCategory("fun"))
     .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
-type Result = { embed?: EmbedBuilder; error?: string };
+const buildTeaserEmbed = (list: string[]) =>
+  baseEmbed("🎰 Sorteando...", teaserDescription(shuffle(list)));
 
-const handleWords = (rawList: string, winners: number | undefined): Result => {
-  const list = parseWordList(rawList);
-  if (list.length < MIN_ITEMS) {
-    return {
-      error: `Necesito al menos ${MIN_ITEMS} elementos. Separá la lista con espacios, comas o punto y coma.`,
-    };
-  }
-  if (winners !== undefined && winners < 1) {
-    return { error: "El número de ganadores debe ser al menos 1." };
-  }
-
-  const shuffled = shuffle(list);
-  const cap =
-    winners !== undefined ? Math.min(winners, list.length) : list.length;
+const buildWinnersEmbed = (
+  shuffled: string[],
+  cap: number,
+  originalList: string[]
+) => {
   const picked = shuffled.slice(0, cap);
+  const title = cap === 1 ? "🏆 Ganador" : `🏆 Ganadores (${cap})`;
+  return baseEmbed(title, enumerateLines(picked)).addFields({
+    name: "Lista original",
+    value: originalList.join(", "),
+  });
+};
 
-  let title: string;
-  if (winners !== undefined) {
-    title = cap === 1 ? "🏆 Ganador" : `🏆 Ganadores (${cap})`;
-  } else {
-    title = "🔀 Lista aleatoria";
-  }
-
-  const embed = buildBaseEmbed(title, enumerateLines(picked)).addFields({
+const buildShuffleEmbed = (list: string[]) =>
+  baseEmbed("🔀 Lista aleatoria", enumerateLines(shuffle(list))).addFields({
     name: "Lista original",
     value: list.join(", "),
   });
 
-  return { embed };
-};
-
-const handleNumbers = (rawQuantity: number | undefined): Result => {
-  if (rawQuantity === undefined) {
-    return { error: "Tenés que pasar la cantidad." };
-  }
-  if (rawQuantity < MIN_QUANTITY) {
-    return { error: `La cantidad debe ser al menos ${MIN_QUANTITY}.` };
-  }
-
-  const quantity = Math.min(rawQuantity, MAX_QUANTITY);
-  const list = Array.from({ length: quantity }, (_, i) => i + 1);
-  const shuffled = shuffle(list);
-
-  const embed = buildBaseEmbed(
+const buildNumbersEmbed = (quantity: number) =>
+  baseEmbed(
     `🔀 Números (1–${quantity})`,
-    shuffled.join(", ")
+    shuffle(Array.from({ length: quantity }, (_, i) => i + 1)).join(", ")
   );
 
-  return { embed };
+/**
+ * Animated raffle reveal: defer → N teaser frames with re-shuffles → final winners.
+ * Runs purely on editReply so it works in both public and ephemeral mode.
+ */
+const animateWinnersReveal = async (
+  interaction: ChatInputCommandInteraction,
+  list: string[],
+  cap: number,
+  isPrivate: boolean
+) => {
+  await interaction.deferReply({
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+  });
+
+  for (let i = 0; i < ANIMATION_FRAMES; i++) {
+    await interaction.editReply({ embeds: [buildTeaserEmbed(list)] });
+    await sleep(FRAME_DELAY_MS);
+  }
+
+  const finalShuffle = shuffle(list);
+  await interaction.editReply({
+    embeds: [buildWinnersEmbed(finalShuffle, cap, list)],
+  });
 };
 
 const pull: ISlashCommand = {
@@ -124,7 +129,7 @@ const pull: ISlashCommand = {
         {
           name: OPT.winners,
           description:
-            "Cantidad de ganadores a elegir (default: toda la lista)",
+            "Cantidad de ganadores a elegir (default: toda la lista, activa animación)",
           type: ApplicationCommandOptionType.Integer,
           required: false,
         },
@@ -174,30 +179,60 @@ const pull: ISlashCommand = {
       const findArg = (name: string) =>
         subArgs.find((a) => a.name === name)?.value;
       const isPrivate = (findArg(OPT.private) as boolean | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
 
-      let result: Result;
       if (sub.name === SUB.words) {
         const rawList = (findArg(OPT.list) as string) ?? "";
         const winners = findArg(OPT.winners) as number | undefined;
-        result = handleWords(rawList, winners);
-      } else if (sub.name === SUB.numbers) {
-        const quantity = findArg(OPT.quantity) as number | undefined;
-        result = handleNumbers(quantity);
-      } else {
-        return;
-      }
+        const list = parseWordList(rawList);
 
-      if (result.error) {
+        if (list.length < MIN_ITEMS) {
+          return interaction.reply({
+            content: `Necesito al menos ${MIN_ITEMS} elementos. Separá la lista con espacios, comas o punto y coma.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        if (winners !== undefined && winners < 1) {
+          return interaction.reply({
+            content: "El número de ganadores debe ser al menos 1.",
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+
+        // Winners path → dramatic reveal with animation
+        if (winners !== undefined) {
+          const cap = Math.min(winners, list.length);
+          return animateWinnersReveal(interaction, list, cap, isPrivate);
+        }
+
+        // No winners → instant shuffle
         return interaction.reply({
-          content: result.error,
-          flags: MessageFlags.Ephemeral,
+          embeds: [buildShuffleEmbed(list)],
+          flags,
         });
       }
 
-      return interaction.reply({
-        embeds: [result.embed!],
-        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
-      });
+      if (sub.name === SUB.numbers) {
+        const rawQuantity = findArg(OPT.quantity) as number | undefined;
+        if (rawQuantity === undefined) {
+          return interaction.reply({
+            content: "Tenés que pasar la cantidad.",
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        if (rawQuantity < MIN_QUANTITY) {
+          return interaction.reply({
+            content: `La cantidad debe ser al menos ${MIN_QUANTITY}.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+
+        const quantity = Math.min(rawQuantity, MAX_QUANTITY);
+        return interaction.reply({
+          embeds: [buildNumbersEmbed(quantity)],
+          flags,
+        });
+      }
     } catch (error) {
       errorHandler(interaction, error);
     }


### PR DESCRIPTION
## Summary
Tercer comando del facelift de **fun**, más un bug fix en el helper compartido `shuffle()`, **más animación de sorteo** para el caso `winners`.

## /shuffle
- Description en español: `Mezcla aleatoriamente una lista de palabras o números`
- Títulos según caso: `🔀 Lista aleatoria` · `🏆 Ganador` · `🏆 Ganadores (N)` · `🔀 Números (1–N)` · `🎰 Sorteando...` (frames de animación)
- Color `fun` (#FEE75C), footer estándar, sin `setAuthor`
- Parser de lista acepta **coma, punto y coma o espacios**
- Items numerados en bold: `**1.** ana`
- `private:` opt-in en ambos subcomandos
- Validaciones con notice ephemeral

## ✨ Animación para `/shuffle words winners:N`
Cuando se pide ganadores, el comando hace `deferReply` y edita 3 frames "teaser" con shuffles sucesivos (cada ~600ms), antes del reveal final con `🏆 Ganador(es)`. Total ≈ 1.8s de drama. Respeta `private:true` (el defer ya carga el flag ephemeral).

Otros paths sin cambio: `/shuffle words` sin winners y `/shuffle numbers` siguen siendo instantáneos.

## helpers.shuffle — BUG FIX
- **Antes**: mutaba el array de entrada.
- **Ahora**: copia y mezcla la copia. Devuelve un array nuevo.
- Tests nuevos: aserción explícita de no-mutación + nueva referencia.

## Test plan
- [x] `pnpm test` → 182/182 (was 169, +13 nuevos)
- [x] `tsc --noEmit` → limpio
- [ ] `/shuffle words list:ana,bob,carla winners:1` → animación + ganador
- [ ] `/shuffle words list:ana bob carla david winners:3` → animación + 3 ganadores
- [ ] `/shuffle words list:ana,bob,carla` (sin winners) → instant, sin animación
- [ ] `/shuffle words list:"ana bob" winners:99` → cap a 2, animación
- [ ] `/shuffle words list:ana` → notice ephemeral
- [ ] `/shuffle numbers quantity:10` (sin animación)
- [ ] `/shuffle words ... winners:1 private:true` → animación se ve solo para vos