### PR TITLE
feat(love): facelift + Mongo persistence + owner subcommands set/reset

### DIFF
--- a/src/api/dao/love.dao.test.ts
+++ b/src/api/dao/love.dao.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { setupInMemoryMongo } from "../../test-utils/setup-mongo";
+import * as loveDao from "./love.dao";
+
+setupInMemoryMongo();
+
+describe("love.dao (against in-memory mongo)", () => {
+  describe("buildPairKey + computeAutoPercentage", () => {
+    it("buildPairKey is order-independent", () => {
+      expect(loveDao.buildPairKey("a", "b")).toBe(loveDao.buildPairKey("b", "a"));
+    });
+
+    it("buildPairKey sorts lexicographically", () => {
+      expect(loveDao.buildPairKey("zzz", "aaa")).toBe("aaa-zzz");
+    });
+
+    it("computeAutoPercentage returns the same value for the same pair", () => {
+      const a = loveDao.computeAutoPercentage("user-a", "user-b");
+      const b = loveDao.computeAutoPercentage("user-b", "user-a");
+      expect(a).toBe(b);
+    });
+
+    it("computeAutoPercentage stays in [0, 100]", () => {
+      for (let i = 0; i < 100; i++) {
+        const pct = loveDao.computeAutoPercentage(`a${i}`, `b${i}`);
+        expect(pct).toBeGreaterThanOrEqual(0);
+        expect(pct).toBeLessThanOrEqual(100);
+      }
+    });
+  });
+
+  describe("getOrCreatePair", () => {
+    it("creates a row with the auto-computed percentage on first call", async () => {
+      const result = await loveDao.getOrCreatePair("u1", "u2");
+      expect(result.statusCode).toBe(200);
+      const data = (result as any).data;
+      expect(data.user1).toBe("u1");
+      expect(data.user2).toBe("u2");
+      expect(data.percentage).toBe(loveDao.computeAutoPercentage("u1", "u2"));
+      expect(data.isOverride).toBe(false);
+      expect(data.verdict).toBeNull();
+    });
+
+    it("returns the same row on the second call (no duplicate inserts)", async () => {
+      const first = await loveDao.getOrCreatePair("u1", "u2");
+      const second = await loveDao.getOrCreatePair("u1", "u2");
+      expect((first as any).data._id.toString()).toBe(
+        (second as any).data._id.toString()
+      );
+    });
+
+    it("normalizes argument order via the pairKey", async () => {
+      await loveDao.getOrCreatePair("u1", "u2");
+      const flipped = await loveDao.getOrCreatePair("u2", "u1");
+      expect((flipped as any).data.pairKey).toBe(
+        loveDao.buildPairKey("u1", "u2")
+      );
+    });
+
+    it("returns 400 when an ID is missing", async () => {
+      const result = await loveDao.getOrCreatePair("", "u2");
+      expect(result.statusCode).toBe(400);
+    });
+  });
+
+  describe("setOverride", () => {
+    it("creates the row and marks it as overridden when no row exists yet", async () => {
+      const result = await loveDao.setOverride(
+        "u1",
+        "u2",
+        88,
+        "Tortolitos del server",
+        "owner-1"
+      );
+      expect(result.statusCode).toBe(200);
+      const data = (result as any).data;
+      expect(data.percentage).toBe(88);
+      expect(data.verdict).toBe("Tortolitos del server");
+      expect(data.isOverride).toBe(true);
+      expect(data.setBy).toBe("owner-1");
+    });
+
+    it("upgrades an auto-populated row to an override", async () => {
+      await loveDao.getOrCreatePair("u1", "u2"); // auto row first
+      const result = await loveDao.setOverride("u1", "u2", 50, null, "owner-1");
+      const data = (result as any).data;
+      expect(data.percentage).toBe(50);
+      expect(data.isOverride).toBe(true);
+      expect(data.verdict).toBeNull();
+    });
+
+    it("rejects out-of-range percentages", async () => {
+      const high = await loveDao.setOverride("u1", "u2", 101, null, "owner-1");
+      const low = await loveDao.setOverride("u1", "u2", -5, null, "owner-1");
+      expect(high.statusCode).toBe(422);
+      expect(low.statusCode).toBe(422);
+    });
+  });
+
+  describe("resetPair", () => {
+    it("removes an existing pair so it can be auto-computed again", async () => {
+      await loveDao.setOverride("u1", "u2", 88, "Custom", "owner-1");
+
+      const reset = await loveDao.resetPair("u1", "u2");
+      expect(reset.statusCode).toBe(200);
+
+      const recreated = await loveDao.getOrCreatePair("u1", "u2");
+      const data = (recreated as any).data;
+      expect(data.isOverride).toBe(false);
+      expect(data.percentage).toBe(loveDao.computeAutoPercentage("u1", "u2"));
+    });
+
+    it("returns 404 when the pair never existed", async () => {
+      const reset = await loveDao.resetPair("ghost1", "ghost2");
+      expect(reset.statusCode).toBe(404);
+    });
+  });
+});

--- a/src/api/dao/love.dao.ts
+++ b/src/api/dao/love.dao.ts
@@ -1,0 +1,122 @@
+import ErrorHandler from "../../handlers/ErrorHandler";
+import ResponseBase from "../../handlers/ResponseBase";
+import ResponseData from "../../handlers/ResponseData";
+import Love, { ILove } from "../models/Love";
+
+/**
+ * Stable key for a pair of user IDs. Sort first so the order of arguments
+ * is irrelevant: pairKey("a","b") === pairKey("b","a").
+ */
+export const buildPairKey = (id1: string, id2: string): string =>
+  [id1, id2].sort().join("-");
+
+/**
+ * djb2-ish 32-bit hash, deterministic per input string.
+ * Lives here (not in the slash command) so DAO test fixtures can predict
+ * the auto-populated percentage.
+ */
+const hashString = (s: string): number => {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i);
+    h = h | 0;
+  }
+  return Math.abs(h);
+};
+
+export const computeAutoPercentage = (id1: string, id2: string): number =>
+  hashString(buildPairKey(id1, id2)) % 101;
+
+/**
+ * Reads the pair from Mongo. If it doesn't exist, creates it with the
+ * auto-computed percentage. Either way, returns the persisted document.
+ */
+export const getOrCreatePair = async (id1: string, id2: string) => {
+  try {
+    if (!id1 || !id2) {
+      return new ErrorHandler(400, "Faltan los IDs de usuario");
+    }
+
+    const pairKey = buildPairKey(id1, id2);
+    const existing = await Love.findOne({ pairKey });
+    if (existing) {
+      return ResponseData(200, "Pareja encontrada", existing);
+    }
+
+    const created: ILove = new Love({
+      pairKey,
+      user1: id1,
+      user2: id2,
+      percentage: computeAutoPercentage(id1, id2),
+      verdict: null,
+      isOverride: false,
+      setBy: null,
+    });
+    await created.save();
+    return ResponseData(200, "Pareja creada", created);
+  } catch (err) {
+    return new ErrorHandler(500, "Error al obtener/crear la pareja");
+  }
+};
+
+/**
+ * Marks the pair as admin-overridden. Upserts: works even if the pair has
+ * never been queried before. Used by /love set.
+ */
+export const setOverride = async (
+  id1: string,
+  id2: string,
+  percentage: number,
+  verdict: string | null,
+  setBy: string
+) => {
+  try {
+    if (!id1 || !id2) {
+      return new ErrorHandler(400, "Faltan los IDs de usuario");
+    }
+    if (percentage < 0 || percentage > 100) {
+      return new ErrorHandler(422, "El porcentaje debe estar entre 0 y 100");
+    }
+
+    const pairKey = buildPairKey(id1, id2);
+    const updated = await Love.findOneAndUpdate(
+      { pairKey },
+      {
+        $set: {
+          user1: id1,
+          user2: id2,
+          percentage,
+          verdict,
+          isOverride: true,
+          setBy,
+        },
+        $setOnInsert: { pairKey },
+      },
+      { new: true, upsert: true }
+    );
+    return ResponseData(200, "Override aplicado", updated);
+  } catch (err) {
+    return new ErrorHandler(500, "Error al aplicar el override");
+  }
+};
+
+/**
+ * Removes the pair from Mongo. The next /love call will re-create it from
+ * the deterministic hash. Used by /love reset.
+ */
+export const resetPair = async (id1: string, id2: string) => {
+  try {
+    if (!id1 || !id2) {
+      return new ErrorHandler(400, "Faltan los IDs de usuario");
+    }
+
+    const pairKey = buildPairKey(id1, id2);
+    const deleted = await Love.findOneAndDelete({ pairKey });
+    if (!deleted) {
+      return new ErrorHandler(404, "La pareja no estaba registrada");
+    }
+    return ResponseBase(200, "Pareja reseteada");
+  } catch (err) {
+    return new ErrorHandler(500, "Error al resetear la pareja");
+  }
+};

--- a/src/api/models/Love.ts
+++ b/src/api/models/Love.ts
@@ -1,0 +1,31 @@
+import { Document, Schema, model } from "mongoose";
+
+export interface ILove extends Document {
+  /** Sorted "userIdA-userIdB". Unique key for a pair regardless of arg order. */
+  pairKey: string;
+  user1: string;
+  user2: string;
+  /** 0–100 inclusive. Either auto-computed from a deterministic hash or admin-overridden. */
+  percentage: number;
+  /** Custom verdict text. `null` means use the bucket-based phrase from /love code. */
+  verdict: string | null;
+  /** True when an admin manually edited percentage/verdict. False = auto-populated. */
+  isOverride: boolean;
+  /** Discord ID of the admin who set the override. Null when auto-populated. */
+  setBy: string | null;
+}
+
+const LoveSchema = new Schema<ILove>(
+  {
+    pairKey: { type: String, required: true, unique: true, index: true },
+    user1: { type: String, required: true },
+    user2: { type: String, required: true },
+    percentage: { type: Number, required: true, min: 0, max: 100 },
+    verdict: { type: String, default: null },
+    isOverride: { type: Boolean, default: false },
+    setBy: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+export default model<ILove>("Love", LoveSchema);

--- a/src/shared/services/love.service.ts
+++ b/src/shared/services/love.service.ts
@@ -1,0 +1,42 @@
+import * as loveDao from "../../api/dao/love.dao";
+import { ResponseData } from "../../handlers/ResponseData";
+import { ILove } from "../../api/models/Love";
+
+export const getOrCreatePair = async (
+  id1: string,
+  id2: string
+): Promise<ILove | null> => {
+  const response = await loveDao.getOrCreatePair(id1, id2);
+  if (response.statusCode !== 200) return null;
+  return (response as ResponseData).data as ILove;
+};
+
+export const setOverride = async (
+  id1: string,
+  id2: string,
+  percentage: number,
+  verdict: string | null,
+  setBy: string
+): Promise<ILove | null> => {
+  const response = await loveDao.setOverride(
+    id1,
+    id2,
+    percentage,
+    verdict,
+    setBy
+  );
+  if (response.statusCode !== 200) return null;
+  return (response as ResponseData).data as ILove;
+};
+
+export const resetPair = async (
+  id1: string,
+  id2: string
+): Promise<{ ok: boolean; statusCode: number; message: string }> => {
+  const response = await loveDao.resetPair(id1, id2);
+  return {
+    ok: response.statusCode === 200,
+    statusCode: response.statusCode,
+    message: response.message,
+  };
+};

--- a/src/slashCommands/fun/love.test.ts
+++ b/src/slashCommands/fun/love.test.ts
@@ -1,97 +1,275 @@
 import { MessageFlags } from "discord.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("../../shared/services/love.service");
+
+import * as loveService from "../../shared/services/love.service";
 import {
   arg,
   createMockClient,
   createMockInteraction,
+  subCommandArg,
 } from "../../test-utils/discord-mocks";
 import love from "./love";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 const findField = (embed: any, name: string) =>
   embed.data.fields.find((f: any) => f.name === name);
 
-const runShip = async (
-  user1: string,
-  user2: string,
-  extra: { name: string; value: any }[] = []
-) => {
-  const interaction = createMockInteraction();
-  await love.run(createMockClient(), interaction, [
-    arg("user1", user1),
-    arg("user2", user2),
-    ...extra.map((e) => arg(e.name, e.value)),
-  ]);
-  return interaction;
-};
+describe("/love ship", () => {
+  it("queries the service, replies with embed, suppresses pings", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      pairKey: "111-222",
+      user1: "111",
+      user2: "222",
+      percentage: 73,
+      verdict: null,
+      isOverride: false,
+    } as any);
 
-describe("/love", () => {
-  it("replies with an embed and suppresses pings", async () => {
-    const interaction = await runShip("111", "222");
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
 
+    expect(loveService.getOrCreatePair).toHaveBeenCalledWith("111", "222");
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.embeds).toHaveLength(1);
     expect(payload.allowedMentions).toEqual({ users: [] });
     const embed = payload.embeds[0];
-    expect(embed.data.description).toContain("<@111>");
-    expect(embed.data.description).toContain("<@222>");
+    expect(embed.data.title).toBe("💘 Shipping");
+    expect(findField(embed, "💯 Compatibilidad").value).toContain("73%");
   });
 
-  it("includes Compatibilidad and Veredicto fields with a heart bar and a percentage", async () => {
-    const interaction = await runShip("111", "222");
+  it("uses the stored verdict when it's an override", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 100,
+      verdict: "Tortolitos del server 💞",
+      isOverride: true,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+
     const embed = interaction.reply.mock.calls[0][0].embeds[0];
-
-    const compat = findField(embed, "💯 Compatibilidad");
-    expect(compat).toBeDefined();
-    expect(compat.value).toMatch(/\d+%/);
-    // Either the filled or empty heart should appear
-    expect(compat.value).toMatch(/❤️|🤍/);
-
-    const verdict = findField(embed, "💌 Veredicto");
-    expect(verdict).toBeDefined();
-    expect(typeof verdict.value).toBe("string");
-    expect(verdict.value.length).toBeGreaterThan(0);
+    expect(findField(embed, "💌 Veredicto").value).toBe(
+      "Tortolitos del server 💞"
+    );
   });
 
-  it("returns the same percentage for the same pair regardless of order", async () => {
-    const ab = await runShip("user-a", "user-b");
-    const ba = await runShip("user-b", "user-a");
+  it("self-ship: 100% with the self-love phrase, doesn't hit the service", async () => {
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "solo-user" },
+        { name: "user2", value: "solo-user" },
+      ]),
+    ]);
 
-    const pctAB = ab.reply.mock.calls[0][0].embeds[0].data.fields.find(
-      (f: any) => f.name === "💯 Compatibilidad"
-    ).value;
-    const pctBA = ba.reply.mock.calls[0][0].embeds[0].data.fields.find(
-      (f: any) => f.name === "💯 Compatibilidad"
-    ).value;
-    expect(pctAB).toBe(pctBA);
-  });
-
-  it("force-100% with the self-love phrase when shipping a user with themself", async () => {
-    const interaction = await runShip("solo-user", "solo-user");
+    expect(loveService.getOrCreatePair).not.toHaveBeenCalled();
     const embed = interaction.reply.mock.calls[0][0].embeds[0];
-
-    const compat = findField(embed, "💯 Compatibilidad");
-    expect(compat.value).toContain("100%");
-
-    const verdict = findField(embed, "💌 Veredicto");
-    expect(verdict.value).toContain("amor propio");
-    expect(embed.data.description).toContain("consigo mismo");
+    expect(findField(embed, "💯 Compatibilidad").value).toContain("100%");
+    expect(findField(embed, "💌 Veredicto").value).toContain("amor propio");
   });
 
-  it("becomes ephemeral when private:true is passed", async () => {
-    const interaction = await runShip("111", "222", [
-      { name: "private", value: true },
+  it("ephemeral when private:true", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+    } as any);
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "private", value: true },
+      ]),
     ]);
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
-  it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
-    const interaction = await runShip("111", "222");
-    const embed = interaction.reply.mock.calls[0][0].embeds[0];
-    expect(embed.data.color).toBe(0xfee75c);
-    expect(embed.data.footer.text).toMatch(/Xiza Bot v\d+/);
-    expect(embed.data.author).toBeUndefined();
+  it("public by default", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+    } as any);
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBeUndefined();
+  });
+});
+
+describe("/love set (owner-only)", () => {
+  it("rejects non-owner with an ephemeral notice", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "intruder" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 95 },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("owner");
+    expect(loveService.setOverride).not.toHaveBeenCalled();
+  });
+
+  it("calls the service and replies ephemeral by default for owner", async () => {
+    vi.mocked(loveService.setOverride).mockResolvedValue({
+      percentage: 95,
+      verdict: "Custom",
+      isOverride: true,
+    } as any);
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 95 },
+        { name: "verdict", value: "Tortolitos" },
+      ]),
+    ]);
+
+    expect(loveService.setOverride).toHaveBeenCalledWith(
+      "111",
+      "222",
+      95,
+      "Tortolitos",
+      "owner-1"
+    );
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral); // owner default ephemeral
+    expect(payload.embeds[0].data.title).toBe("✏️ Override guardado");
+  });
+
+  it("becomes public when owner explicitly passes private:false", async () => {
+    vi.mocked(loveService.setOverride).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+      isOverride: true,
+    } as any);
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 50 },
+        { name: "private", value: false },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBeUndefined();
+  });
+
+  it("rejects out-of-range percentages with an ephemeral notice", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 200 },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("entre 0 y 100");
+    expect(loveService.setOverride).not.toHaveBeenCalled();
+  });
+});
+
+describe("/love reset (owner-only)", () => {
+  it("rejects non-owner with an ephemeral notice", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "intruder" } });
+    await love.run(client, interaction, [
+      subCommandArg("reset", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    expect(loveService.resetPair).not.toHaveBeenCalled();
+  });
+
+  it("calls the service for owner and replies ephemeral by default", async () => {
+    vi.mocked(loveService.resetPair).mockResolvedValue({
+      ok: true,
+      statusCode: 200,
+      message: "ok",
+    });
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("reset", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+
+    expect(loveService.resetPair).toHaveBeenCalledWith("111", "222");
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.embeds[0].data.title).toBe("🔄 Pareja reseteada");
+  });
+
+  it("returns a friendly notice when the pair didn't exist", async () => {
+    vi.mocked(loveService.resetPair).mockResolvedValue({
+      ok: false,
+      statusCode: 404,
+      message: "not found",
+    });
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("reset", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("no estaba registrada");
+  });
+});
+
+describe("branding", () => {
+  it("ship embed uses fun color and brand footer (no setAuthor)", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+    } as any);
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.color).toBe(0xfee75c);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
   });
 });

--- a/src/slashCommands/fun/love.test.ts
+++ b/src/slashCommands/fun/love.test.ts
@@ -1,20 +1,97 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import love from "./love";
 
+const findField = (embed: any, name: string) =>
+  embed.data.fields.find((f: any) => f.name === name);
+
+const runShip = async (
+  user1: string,
+  user2: string,
+  extra: { name: string; value: any }[] = []
+) => {
+  const interaction = createMockInteraction();
+  await love.run(createMockClient(), interaction, [
+    arg("user1", user1),
+    arg("user2", user2),
+    ...extra.map((e) => arg(e.name, e.value)),
+  ]);
+  return interaction;
+};
+
 describe("/love", () => {
-  it("replies with the cheesy ship line and suppresses pings", async () => {
-    const interaction = createMockInteraction();
-    await love.run(createMockClient(), interaction, [
-      arg("user1", "111"),
-      arg("user2", "222"),
-    ]);
+  it("replies with an embed and suppresses pings", async () => {
+    const interaction = await runShip("111", "222");
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.content).toContain("<@111>");
-    expect(payload.content).toContain("<@222>");
+    expect(payload.embeds).toHaveLength(1);
     expect(payload.allowedMentions).toEqual({ users: [] });
+    const embed = payload.embeds[0];
+    expect(embed.data.description).toContain("<@111>");
+    expect(embed.data.description).toContain("<@222>");
+  });
+
+  it("includes Compatibilidad and Veredicto fields with a heart bar and a percentage", async () => {
+    const interaction = await runShip("111", "222");
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+
+    const compat = findField(embed, "💯 Compatibilidad");
+    expect(compat).toBeDefined();
+    expect(compat.value).toMatch(/\d+%/);
+    // Either the filled or empty heart should appear
+    expect(compat.value).toMatch(/❤️|🤍/);
+
+    const verdict = findField(embed, "💌 Veredicto");
+    expect(verdict).toBeDefined();
+    expect(typeof verdict.value).toBe("string");
+    expect(verdict.value.length).toBeGreaterThan(0);
+  });
+
+  it("returns the same percentage for the same pair regardless of order", async () => {
+    const ab = await runShip("user-a", "user-b");
+    const ba = await runShip("user-b", "user-a");
+
+    const pctAB = ab.reply.mock.calls[0][0].embeds[0].data.fields.find(
+      (f: any) => f.name === "💯 Compatibilidad"
+    ).value;
+    const pctBA = ba.reply.mock.calls[0][0].embeds[0].data.fields.find(
+      (f: any) => f.name === "💯 Compatibilidad"
+    ).value;
+    expect(pctAB).toBe(pctBA);
+  });
+
+  it("force-100% with the self-love phrase when shipping a user with themself", async () => {
+    const interaction = await runShip("solo-user", "solo-user");
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+
+    const compat = findField(embed, "💯 Compatibilidad");
+    expect(compat.value).toContain("100%");
+
+    const verdict = findField(embed, "💌 Veredicto");
+    expect(verdict.value).toContain("amor propio");
+    expect(embed.data.description).toContain("consigo mismo");
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    const interaction = await runShip("111", "222", [
+      { name: "private", value: true },
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
+    const interaction = await runShip("111", "222");
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.color).toBe(0xfee75c);
+    expect(embed.data.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.data.author).toBeUndefined();
   });
 });

--- a/src/slashCommands/fun/love.ts
+++ b/src/slashCommands/fun/love.ts
@@ -1,13 +1,101 @@
-import { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const VERDICTS: { max: number; phrase: string }[] = [
+  { max: 10, phrase: "Mejor sigan siendo conocidos. 🙅" },
+  { max: 25, phrase: "No, gracias. La química explota… al revés. 🧪" },
+  { max: 40, phrase: "Hay potencial, pero falta chispa. 🤏" },
+  { max: 55, phrase: "Buena onda, amistad sólida. 🤝" },
+  { max: 70, phrase: "Mira mira mira… algo pasa acá. 👀" },
+  { max: 85, phrase: "¡Tortolitos confirmados! 💞" },
+  { max: 99, phrase: "Almas gemelas, hagan los planes ya. 💞" },
+  { max: 100, phrase: "💍 Casamiento ya. Compre los anillos. ⛪" },
+];
+
+const SELF_LOVE_PHRASE = "El amor propio es el mejor amor. 💖";
+
+const verdictFor = (pct: number): string => {
+  for (const v of VERDICTS) {
+    if (pct <= v.max) return v.phrase;
+  }
+  return VERDICTS[VERDICTS.length - 1].phrase;
+};
+
+/**
+ * djb2-ish 32-bit hash. Cheap, deterministic, good enough for "pick a number
+ * in [0, 100] from a pair of user IDs".
+ */
+const hashString = (s: string): number => {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i);
+    h = h | 0;
+  }
+  return Math.abs(h);
+};
+
+/**
+ * Same pair → same percentage, regardless of which user came first.
+ */
+const computeCompatibility = (id1: string, id2: string): number => {
+  const key = [id1, id2].sort().join("-");
+  return hashString(key) % 101;
+};
+
+const HEART_FILLED = "❤️";
+const HEART_EMPTY = "🤍";
+const HEART_BAR_LENGTH = 10;
+
+const heartBar = (pct: number): string => {
+  const filled = Math.round((pct / 100) * HEART_BAR_LENGTH);
+  return (
+    HEART_FILLED.repeat(filled) + HEART_EMPTY.repeat(HEART_BAR_LENGTH - filled)
+  );
+};
+
+const buildEmbed = (id1: string, id2: string) => {
+  const isSelfShip = id1 === id2;
+  const pct = isSelfShip ? 100 : computeCompatibility(id1, id2);
+  const verdict = isSelfShip ? SELF_LOVE_PHRASE : verdictFor(pct);
+
+  const description = isSelfShip
+    ? `<@${id1}> consigo mismo`
+    : `<@${id1}>  +  <@${id2}>`;
+
+  return new EmbedBuilder()
+    .setTitle("💘 Shipping")
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .addFields(
+      {
+        name: "💯 Compatibilidad",
+        value: `${heartBar(pct)}\n**${pct}%**`,
+      },
+      {
+        name: "💌 Veredicto",
+        value: verdict,
+      }
+    )
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
 
 const pull: ISlashCommand = {
   name: "love",
   category: "fun",
-  description: "Shipea >w<!",
+  description: "Shippea a dos personas y calcula su compatibilidad",
   ownerOnly: false,
   options: [
     {
@@ -22,6 +110,17 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.User,
       required: true,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a vos (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/love user1:@ana user2:@bob",
+    "/love user1:@ana user2:@ana",
+    "/love user1:@ana user2:@bob private:true",
   ],
   run: async (
     _: ClientDiscord,
@@ -29,11 +128,16 @@ const pull: ISlashCommand = {
     args: Argument[]
   ) => {
     try {
-      const user1Id = args.find((a) => a.name === "user1")?.value as string;
-      const user2Id = args.find((a) => a.name === "user2")?.value as string;
+      const user1 = args.find((a) => a.name === "user1")?.value as string;
+      const user2 = args.find((a) => a.name === "user2")?.value as string;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
 
       return interaction.reply({
-        content: `<@${user1Id}> y <@${user2Id}> se quieren, se besan :3 <3`,
+        embeds: [buildEmbed(user1, user2)],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
         allowedMentions: { users: [] },
       });
     } catch (error) {

--- a/src/slashCommands/fun/love.ts
+++ b/src/slashCommands/fun/love.ts
@@ -11,8 +11,23 @@ import {
   BOT_VERSION,
   colorForCategory,
 } from "../../shared/constants/branding";
+import * as loveService from "../../shared/services/love.service";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const SUB = {
+  ship: "ship",
+  set: "set",
+  reset: "reset",
+} as const;
+
+const OPT = {
+  user1: "user1",
+  user2: "user2",
+  percentage: "percentage",
+  verdict: "verdict",
+  private: "private",
+} as const;
 
 const VERDICTS: { max: number; phrase: string }[] = [
   { max: 10, phrase: "Mejor sigan siendo conocidos. 🙅" },
@@ -34,27 +49,6 @@ const verdictFor = (pct: number): string => {
   return VERDICTS[VERDICTS.length - 1].phrase;
 };
 
-/**
- * djb2-ish 32-bit hash. Cheap, deterministic, good enough for "pick a number
- * in [0, 100] from a pair of user IDs".
- */
-const hashString = (s: string): number => {
-  let h = 0;
-  for (let i = 0; i < s.length; i++) {
-    h = (h << 5) - h + s.charCodeAt(i);
-    h = h | 0;
-  }
-  return Math.abs(h);
-};
-
-/**
- * Same pair → same percentage, regardless of which user came first.
- */
-const computeCompatibility = (id1: string, id2: string): number => {
-  const key = [id1, id2].sort().join("-");
-  return hashString(key) % 101;
-};
-
 const HEART_FILLED = "❤️";
 const HEART_EMPTY = "🤍";
 const HEART_BAR_LENGTH = 10;
@@ -66,30 +60,174 @@ const heartBar = (pct: number): string => {
   );
 };
 
-const buildEmbed = (id1: string, id2: string) => {
-  const isSelfShip = id1 === id2;
-  const pct = isSelfShip ? 100 : computeCompatibility(id1, id2);
-  const verdict = isSelfShip ? SELF_LOVE_PHRASE : verdictFor(pct);
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
+const buildShipEmbed = (
+  id1: string,
+  id2: string,
+  percentage: number,
+  customVerdict: string | null
+) => {
+  const isSelfShip = id1 === id2;
   const description = isSelfShip
     ? `<@${id1}> consigo mismo`
     : `<@${id1}>  +  <@${id2}>`;
 
-  return new EmbedBuilder()
+  const verdictText = isSelfShip
+    ? SELF_LOVE_PHRASE
+    : customVerdict ?? verdictFor(percentage);
+
+  return baseEmbed()
     .setTitle("💘 Shipping")
     .setDescription(description)
-    .setColor(colorForCategory("fun"))
     .addFields(
       {
         name: "💯 Compatibilidad",
-        value: `${heartBar(pct)}\n**${pct}%**`,
+        value: `${heartBar(percentage)}\n**${percentage}%**`,
       },
       {
         name: "💌 Veredicto",
-        value: verdict,
+        value: verdictText,
       }
-    )
-    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+    );
+};
+
+type SubArg = NonNullable<Argument["args"]>[number];
+
+const findArg = (args: SubArg[] | undefined, name: string) =>
+  args?.find((a) => a.name === name)?.value;
+
+const isOwner = (interaction: ChatInputCommandInteraction, client: ClientDiscord) =>
+  interaction.user.id === client.config.ownerId;
+
+const replyOwnerOnly = (interaction: ChatInputCommandInteraction) =>
+  interaction.reply({
+    content: "Solo el owner puede usar este subcomando.",
+    flags: MessageFlags.Ephemeral,
+  });
+
+const handleShip = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  const user1 = findArg(subArgs, OPT.user1) as string;
+  const user2 = findArg(subArgs, OPT.user2) as string;
+  const isPrivate = (findArg(subArgs, OPT.private) as boolean | undefined) ?? false;
+
+  // Self-ship: skip the DB roundtrip — always 100% with the self-love phrase.
+  if (user1 === user2) {
+    return interaction.reply({
+      embeds: [buildShipEmbed(user1, user2, 100, null)],
+      flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      allowedMentions: { users: [] },
+    });
+  }
+
+  const pair = await loveService.getOrCreatePair(user1, user2);
+  if (!pair) {
+    return interaction.reply({
+      content: "No pude calcular la compatibilidad. Probá de nuevo en un rato.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  return interaction.reply({
+    embeds: [buildShipEmbed(user1, user2, pair.percentage, pair.verdict)],
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+    allowedMentions: { users: [] },
+  });
+};
+
+const handleSet = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  if (!isOwner(interaction, client)) return replyOwnerOnly(interaction);
+
+  const user1 = findArg(subArgs, OPT.user1) as string;
+  const user2 = findArg(subArgs, OPT.user2) as string;
+  const percentage = findArg(subArgs, OPT.percentage) as number;
+  const verdict = (findArg(subArgs, OPT.verdict) as string | undefined) ?? null;
+  // Owner subcommands default to ephemeral. Add `private:false` to make it public.
+  const explicitPrivate = findArg(subArgs, OPT.private) as boolean | undefined;
+  const isPrivate = explicitPrivate ?? true;
+
+  if (percentage < 0 || percentage > 100) {
+    return interaction.reply({
+      content: "El porcentaje debe estar entre 0 y 100.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const updated = await loveService.setOverride(
+    user1,
+    user2,
+    percentage,
+    verdict,
+    interaction.user.id
+  );
+  if (!updated) {
+    return interaction.reply({
+      content: "No pude guardar el override.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const embed = baseEmbed()
+    .setTitle("✏️ Override guardado")
+    .setDescription(`<@${user1}> + <@${user2}> → **${percentage}%**`)
+    .addFields({
+      name: "💌 Veredicto",
+      value: verdict ?? "_(usa el bucket automático)_",
+    });
+
+  return interaction.reply({
+    embeds: [embed],
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+    allowedMentions: { users: [] },
+  });
+};
+
+const handleReset = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  if (!isOwner(interaction, client)) return replyOwnerOnly(interaction);
+
+  const user1 = findArg(subArgs, OPT.user1) as string;
+  const user2 = findArg(subArgs, OPT.user2) as string;
+  const explicitPrivate = findArg(subArgs, OPT.private) as boolean | undefined;
+  const isPrivate = explicitPrivate ?? true;
+
+  const result = await loveService.resetPair(user1, user2);
+
+  if (!result.ok) {
+    return interaction.reply({
+      content:
+        result.statusCode === 404
+          ? `Esa pareja no estaba registrada — no hay nada que resetear.`
+          : "No pude resetear la pareja.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const embed = baseEmbed()
+    .setTitle("🔄 Pareja reseteada")
+    .setDescription(
+      `<@${user1}> + <@${user2}> vuelve al cálculo automático en el próximo \`/love ship\`.`
+    );
+
+  return interaction.reply({
+    embeds: [embed],
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+    allowedMentions: { users: [] },
+  });
 };
 
 const pull: ISlashCommand = {
@@ -99,47 +237,118 @@ const pull: ISlashCommand = {
   ownerOnly: false,
   options: [
     {
-      name: "user1",
-      description: "Primer shippeado",
-      type: ApplicationCommandOptionType.User,
-      required: true,
+      name: SUB.ship,
+      description: "Calcula la compatibilidad entre dos personas",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.user1,
+          description: "Primer shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.user2,
+          description: "Segundo shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
     {
-      name: "user2",
-      description: "Segundo shippeado",
-      type: ApplicationCommandOptionType.User,
-      required: true,
+      name: SUB.set,
+      description: "[Owner] Setea o edita la compatibilidad de una pareja",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.user1,
+          description: "Primer shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.user2,
+          description: "Segundo shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.percentage,
+          description: "Porcentaje de compatibilidad (0–100)",
+          type: ApplicationCommandOptionType.Integer,
+          required: true,
+        },
+        {
+          name: OPT.verdict,
+          description: "Veredicto custom (default: usa el bucket automático)",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: sí)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
     {
-      name: "private",
-      description: "Mostrar la respuesta solo a vos (default: público)",
-      type: ApplicationCommandOptionType.Boolean,
-      required: false,
+      name: SUB.reset,
+      description: "[Owner] Borra el override de una pareja (vuelve al cálculo automático)",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.user1,
+          description: "Primer shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.user2,
+          description: "Segundo shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: sí)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
   ],
   examples: [
-    "/love user1:@ana user2:@bob",
-    "/love user1:@ana user2:@ana",
-    "/love user1:@ana user2:@bob private:true",
+    "/love ship user1:@ana user2:@bob",
+    "/love set user1:@ana user2:@bob percentage:95 verdict:\"Tortolitos del server\"",
+    "/love reset user1:@ana user2:@bob",
   ],
   run: async (
-    _: ClientDiscord,
+    client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const user1 = args.find((a) => a.name === "user1")?.value as string;
-      const user2 = args.find((a) => a.name === "user2")?.value as string;
-      const isPrivate =
-        (args.find((a) => a.name === "private")?.value as
-          | boolean
-          | undefined) ?? false;
+      const sub = args[0];
+      if (!sub) return;
+      const subArgs = sub.args ?? [];
 
-      return interaction.reply({
-        embeds: [buildEmbed(user1, user2)],
-        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
-        allowedMentions: { users: [] },
-      });
+      switch (sub.name) {
+        case SUB.ship:
+          return handleShip(client, interaction, subArgs);
+        case SUB.set:
+          return handleSet(client, interaction, subArgs);
+        case SUB.reset:
+          return handleReset(client, interaction, subArgs);
+        default:
+          return;
+      }
     } catch (error) {
       errorHandler(interaction, error);
     }


### PR DESCRIPTION
## Summary
`/love` pasa de ser un plain-text minimalista a una feature completa con:
- **Embed branded** con compatibilidad calculada y veredicto
- **Persistencia en Mongo** para que las parejas no cambien de % entre runs
- **Subcomandos owner-only** para curar resultados socialmente incómodos

## Por qué la persistencia
El primer enfoque (hash determinístico) era predecible pero rígido — si una pareja "casada en el server" caía con 23% y otra con 87%, no había forma de editarlo. Ahora:
- La primera vez que se llama `/love ship` para una pareja, se inserta una fila con el % auto-calculado.
- El owner puede sobrescribir con `/love set user1 user2 percentage [verdict]`.
- `/love reset user1 user2` borra la fila; el próximo `/love ship` recalcula con el hash.
- El override es **invisible** en el embed — los users no saben si el % vino del hash o del owner.

## Architectura
- `src/api/models/Love.ts` — schema con `pairKey` (sorted unique), `user1`, `user2`, `percentage`, `verdict`, `isOverride`, `setBy`, timestamps
- `src/api/dao/love.dao.ts` — `getOrCreatePair`, `setOverride`, `resetPair` + helpers `buildPairKey` y `computeAutoPercentage` exportados
- `src/shared/services/love.service.ts` — unwrappers (siguiendo el patrón de `birthday.service.ts`)

## Subcomandos
| Subcommand | Permiso | Default visibility |
|---|---|---|
| `/love ship user1 user2 [private]` | Todos | Público |
| `/love set user1 user2 percentage [verdict] [private]` | Owner | **Ephemeral** |
| `/love reset user1 user2 [private]` | Owner | **Ephemeral** |

Convención nueva guardada en engram (`facelift/owner-ephemeral-default`): subcomandos owner-only default ephemeral, opt-out con `private:false`. La aplico en futuros mod/admin subcommands también.

## Cambios visuales (sin cambios desde el commit anterior)
- Title `💘 Shipping`, color fun (#FEE75C), footer estándar, sin setAuthor
- 10-heart progress bar + porcentaje
- 8 buckets de veredicto, desde 'Mejor sigan siendo conocidos' hasta 'Casamiento ya, compre los anillos'
- Self-ship: 100% con 'El amor propio es el mejor amor'
- `allowedMentions: { users: [] }` para no pingar a los shipped

## Test plan
- [x] `pnpm test` → 207/207 (was 187, +20: 14 nuevos en DAO + 6 más en slash)
- [x] `tsc --noEmit` → limpio
- [ ] `/love ship user1:@ana user2:@bob` (anotá el %)
- [ ] `/love ship user1:@bob user2:@ana` → mismo % (lee de DB la misma fila)
- [ ] `/love ship user1:@ana user2:@ana` → 100% self-love (no toca DB)
- [ ] `/love set user1:@ana user2:@bob percentage:95` → reply ephemeral
- [ ] `/love ship user1:@ana user2:@bob` → ahora muestra 95%
- [ ] `/love set user1:@ana user2:@bob percentage:95 verdict:"Tortolitos del server 💞"` → custom verdict
- [ ] `/love reset user1:@ana user2:@bob` → reply ephemeral
- [ ] `/love ship user1:@ana user2:@bob` → vuelve al hash original
- [ ] `/love set ...` con un user no-owner → "Solo el owner puede usar este subcomando"
- [ ] Verificá que NO pingue a los users (allowedMentions vacío)