### PR TITLE
feat(imc): facelift — brand footer, peso ideal field, private opt-in

### DIFF
--- a/src/slashCommands/fun/imc.test.ts
+++ b/src/slashCommands/fun/imc.test.ts
@@ -1,8 +1,15 @@
 import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import imc from "./imc";
+
+const findField = (embed: any, name: string) =>
+  embed.data.fields.find((f: any) => f.name === name);
 
 describe("/imc", () => {
   it("calculates IMC for a normal-weight input", async () => {
@@ -15,17 +22,27 @@ describe("/imc", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    const imcField = findField(payload.embeds[0], "IMC");
+    expect(imcField.value).toContain("22.86");
+    const stateField = findField(payload.embeds[0], "Estado");
+    expect(stateField.value).toContain("Peso normal");
   });
 
-  it("treats height > 3 as centimeters and divides by 100", async () => {
-    const interaction = createMockInteraction();
-    await imc.run(createMockClient(), interaction, [
+  it("treats height > 3 as centimeters and divides by 100 (same IMC as meters)", async () => {
+    const cmInteraction = createMockInteraction();
+    const mInteraction = createMockInteraction();
+    await imc.run(createMockClient(), cmInteraction, [
       arg("peso", 70),
-      arg("altura", 175), // cm
+      arg("altura", 175),
+    ]);
+    await imc.run(createMockClient(), mInteraction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
     ]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    // The embed should reflect the same IMC as the meters version (~22.86)
+    const cmIMC = findField(cmInteraction.reply.mock.calls[0][0].embeds[0], "IMC").value;
+    const mIMC = findField(mInteraction.reply.mock.calls[0][0].embeds[0], "IMC").value;
+    expect(cmIMC).toBe(mIMC);
   });
 
   it("rejects ephemerally on zero or negative input", async () => {
@@ -38,5 +55,71 @@ describe("/imc", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("includes the 'Peso ideal' range field derived from the height", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+    ]);
+
+    const idealField = findField(
+      interaction.reply.mock.calls[0][0].embeds[0],
+      "Peso ideal"
+    );
+    expect(idealField).toBeDefined();
+    // 18.5 * 1.75^2 = 56.65625 → 56.7
+    // 24.9 * 1.75^2 = 76.25625 → 76.3
+    expect(idealField.value).toBe("`56.7–76.3 kg`");
+  });
+
+  it("uses the data-driven status color and the brand footer (no setAuthor)", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+    ]);
+
+    const data = interaction.reply.mock.calls[0][0].embeds[0].data;
+    // 22.86 IMC → "Peso normal" → green #00ff00 = 0x00ff00
+    expect(data.color).toBe(0x00ff00);
+    expect(data.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(data.author).toBeUndefined();
+  });
+
+  it("uses the underweight color (red) for IMC below 18.5", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 45),
+      arg("altura", 1.75),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.color).toBe(0xff0000);
+    expect(findField(embed, "Estado").value).toContain("Bajo peso");
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("public by default", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBeUndefined();
   });
 });

--- a/src/slashCommands/fun/imc.ts
+++ b/src/slashCommands/fun/imc.ts
@@ -1,11 +1,16 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   ColorResolvable,
   EmbedBuilder,
   MessageFlags,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
@@ -15,6 +20,12 @@ type ImcRange = {
   color: string;
 };
 
+/**
+ * Data-driven color: red/yellow/green according to the BMI bucket. We INTENTIONALLY
+ * deviate from the fun-category yellow here — the status color encodes real meaning
+ * (healthy / overweight / underweight), not just branding. The convention of
+ * "color matches the category" bends when the color is a signal.
+ */
 const imcData: { [threshold: string]: ImcRange } = {
   "18.5": { message: "Bajo peso", icon: "🙀", color: "#ff0000" },
   "24.9": { message: "Peso normal", icon: "😺", color: "#00ff00" },
@@ -28,10 +39,26 @@ const thresholds = Object.keys(imcData)
   .map((k) => parseFloat(k))
   .sort((a, b) => a - b);
 
+const findRange = (imc: number): ImcRange => {
+  for (const t of thresholds) {
+    if (imc < t) return imcData[t.toString()]!;
+  }
+  return imcData[thresholds[thresholds.length - 1].toString()]!;
+};
+
+/**
+ * Healthy weight range derived from BMI 18.5–24.9 for the given height in meters.
+ * Returns kg with one decimal place.
+ */
+const idealWeightRange = (heightM: number): { min: number; max: number } => ({
+  min: Math.round(18.5 * heightM * heightM * 10) / 10,
+  max: Math.round(24.9 * heightM * heightM * 10) / 10,
+});
+
 const pull: ISlashCommand = {
   name: "imc",
   category: "fun",
-  description: "Calcula tu IMC",
+  description: "Calcula tu Índice de Masa Corporal",
   ownerOnly: false,
   options: [
     {
@@ -46,6 +73,17 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Number,
       required: true,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a vos (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/imc peso:70 altura:1.75",
+    "/imc peso:70 altura:175",
+    "/imc peso:70 altura:1.75 private:true",
   ],
   run: async (
     _: ClientDiscord,
@@ -53,51 +91,50 @@ const pull: ISlashCommand = {
     args: Argument[]
   ) => {
     try {
-      const weight = Number(args.find((a) => a.name === "peso")?.value);
-      const rawHeight = Number(args.find((a) => a.name === "altura")?.value);
+      const peso = Number(args.find((a) => a.name === "peso")?.value);
+      const rawAltura = Number(args.find((a) => a.name === "altura")?.value);
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
 
-      if (!weight || !rawHeight || weight <= 0 || rawHeight <= 0) {
+      if (!peso || !rawAltura || peso <= 0 || rawAltura <= 0) {
         return interaction.reply({
           content: "No seas pendejo, peso y altura tienen que ser > 0.",
           flags: MessageFlags.Ephemeral,
         });
       }
 
-      const height = rawHeight > 3 ? rawHeight / 100 : rawHeight;
-      const imcNumber = weight / (height * height);
+      const altura = rawAltura > 3 ? rawAltura / 100 : rawAltura;
+      const imc = peso / (altura * altura);
+      const range = findRange(imc);
+      const ideal = idealWeightRange(altura);
 
-      let imc: ImcRange = {
-        message: "No se pudo calcular",
-        icon: "🤔",
-        color: "#000000",
-      };
-      for (const threshold of thresholds) {
-        if (imcNumber < threshold) {
-          imc = imcData[threshold.toString()]!;
-          break;
-        }
-      }
-
-      const embed = new EmbedBuilder({
-        title: "Índice de Masa Corporal  🩺",
-        fields: [
-          {
-            name: "IMC",
-            value: `\`${imcNumber.toFixed(2)}\``,
-            inline: true,
-          },
+      const embed = new EmbedBuilder()
+        .setTitle("🩺 Índice de Masa Corporal")
+        .addFields(
+          { name: "IMC", value: `\`${imc.toFixed(2)}\``, inline: true },
           {
             name: "Estado",
-            value: `\`${imc.message}\` ${imc.icon}`,
+            value: `\`${range.message}\` ${range.icon}`,
             inline: true,
           },
-        ],
-        thumbnail: {
-          url: "https://es.calcuworld.com/wp-content/uploads/sites/2/2013/02/imc.png",
-        },
-      }).setColor(imc.color as ColorResolvable);
+          {
+            name: "Peso ideal",
+            value: `\`${ideal.min}–${ideal.max} kg\``,
+            inline: true,
+          }
+        )
+        .setColor(range.color as ColorResolvable)
+        .setThumbnail(
+          "https://es.calcuworld.com/wp-content/uploads/sites/2/2013/02/imc.png"
+        )
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
-      return interaction.reply({ embeds: [embed] });
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }


### PR DESCRIPTION
## Summary
Quinto comando del facelift de **fun**. `/imc` ya estaba en español y tenía buena estructura; este PR aplica branding consistente y agrega un campo útil.

## Cambios
- Description: `Calcula tu IMC` → `Calcula tu Índice de Masa Corporal`
- Title con emoji adelante: `🩺 Índice de Masa Corporal`
- Footer estándar `Xiza Bot vX.Y.Z`
- Nuevo field **`Peso ideal`** con el rango calculado del BMI 18.5–24.9 para tu altura (ej: `56.7–76.3 kg` para 1.75m)
- `private:` opt-in (default público)
- Pequeño refactor: extraídos `findRange()` y `idealWeightRange()` como helpers puros

## Excepción a la convención de color
Mantiene los colores **data-driven** (rojo/amarillo/verde según el bucket de BMI) en lugar de usar el yellow de fun (#FEE75C). El color acá es un **signal** (saludable / sobrepeso / bajo peso), no decoración. La convención bend cuando el color carga significado.

## Test plan
- [x] `pnpm test` → 212/212 (was 207, +5 nuevos)
- [x] `tsc --noEmit` → limpio
- [ ] `/imc peso:70 altura:1.75` → IMC 22.86, peso normal verde, peso ideal 56.7–76.3 kg
- [ ] `/imc peso:70 altura:175` (cm) → mismo resultado que la versión metros
- [ ] `/imc peso:45 altura:1.75` → bajo peso, embed rojo
- [ ] `/imc peso:90 altura:1.65` → sobrepeso/obesidad, embed según corresponda
- [ ] `/imc peso:0 altura:1.75` → notice ephemeral con el insulto cariñoso
- [ ] `/imc peso:70 altura:1.75 private:true` → solo lo ves vos