### PR TITLE
feat(poke): facelift — type-driven color, autocomplete, error handling

### DIFF
--- a/src/slashCommands/fun/poke.test.ts
+++ b/src/slashCommands/fun/poke.test.ts
@@ -1,16 +1,20 @@
 import { MessageFlags } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createMockClient, createMockInteraction, subCommandArg } from "../../test-utils/discord-mocks";
+import {
+  createMockClient,
+  createMockInteraction,
+  subCommandArg,
+} from "../../test-utils/discord-mocks";
 import poke from "./poke";
 
 const fakePokemon = {
   name: "charmander",
   order: 4,
   sprites: {
-    front_default: "url-default",
+    front_default: "https://example.com/charmander.png",
     front_female: null,
-    front_shiny: "url-shiny",
+    front_shiny: "https://example.com/charmander-shiny.png",
     front_shiny_female: null,
   },
   types: [{ type: { name: "fire" } }],
@@ -28,15 +32,17 @@ const fakeTypeListing = {
   pokemon: [{ pokemon: { name: "charmander" } }],
 };
 
+const okFetch = (async (url: any) => {
+  const stringUrl = url.toString();
+  if (stringUrl.includes("/type/")) {
+    return new Response(JSON.stringify(fakeTypeListing), { status: 200 });
+  }
+  return new Response(JSON.stringify(fakePokemon), { status: 200 });
+}) as any;
+
 describe("/poke", () => {
   beforeEach(() => {
-    vi.spyOn(global, "fetch").mockImplementation((async (url: any) => {
-      const stringUrl = url.toString();
-      if (stringUrl.includes("/type/")) {
-        return new Response(JSON.stringify(fakeTypeListing), { status: 200 });
-      }
-      return new Response(JSON.stringify(fakePokemon), { status: 200 });
-    }) as any);
+    vi.spyOn(global, "fetch").mockImplementation(okFetch);
   });
 
   afterEach(() => {
@@ -46,23 +52,60 @@ describe("/poke", () => {
   describe("types subcommand", () => {
     it("replies with the static list of types — no fetch needed", async () => {
       const interaction = createMockInteraction();
-      await poke.run(createMockClient(), interaction, [subCommandArg("types")]);
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("types"),
+      ]);
 
       expect(interaction.reply).toHaveBeenCalledOnce();
       const payload = interaction.reply.mock.calls[0][0];
       expect(payload.embeds).toHaveLength(1);
       expect(global.fetch).not.toHaveBeenCalled();
     });
+
+    it("becomes ephemeral when private:true", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("types", [{ name: "private", value: true }]),
+      ]);
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    });
   });
 
   describe("random subcommand", () => {
     it("defers, fetches a pokemon, and replies via editReply", async () => {
       const interaction = createMockInteraction();
-      await poke.run(createMockClient(), interaction, [subCommandArg("random")]);
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
 
       expect(interaction.deferReply).toHaveBeenCalledOnce();
       expect(global.fetch).toHaveBeenCalledOnce();
       expect(interaction.editReply).toHaveBeenCalledOnce();
+    });
+
+    it("defers ephemerally when private:true", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random", [{ name: "private", value: true }]),
+      ]);
+      const deferPayload = interaction.deferReply.mock.calls[0][0];
+      expect(deferPayload.flags).toBe(MessageFlags.Ephemeral);
+    });
+
+    it("falls back to a friendly error message when fetch fails", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue(
+        new Response("oops", { status: 500 })
+      );
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
+
+      const payload = interaction.editReply.mock.calls[0][0];
+      expect(payload.content).toContain("PokéAPI");
+      // No flags here on purpose — editReply can't change ephemerality after defer
+      expect(payload.flags).toBeUndefined();
     });
   });
 
@@ -88,6 +131,78 @@ describe("/poke", () => {
       const payload = interaction.reply.mock.calls[0][0];
       expect(payload.flags).toBe(MessageFlags.Ephemeral);
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a friendly error when the type listing endpoint fails", async () => {
+      vi.spyOn(global, "fetch").mockImplementation((async (url: any) => {
+        if (url.toString().includes("/type/")) {
+          return new Response("oops", { status: 500 });
+        }
+        return new Response(JSON.stringify(fakePokemon), { status: 200 });
+      }) as any);
+
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("type", [{ name: "name", value: "fire" }]),
+      ]);
+
+      const payload = interaction.editReply.mock.calls[0][0];
+      expect(payload.content).toContain("PokéAPI");
+    });
+  });
+
+  describe("branding", () => {
+    it("fire-type Pokémon embed uses fire color and brand footer (no setAuthor)", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
+
+      const payload = interaction.editReply.mock.calls[0][0];
+      const embed = payload.embeds[0].data;
+      expect(embed.color).toBe(0xee8130); // fire color
+      expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+      expect(embed.author).toBeUndefined();
+    });
+
+    it("title is prefixed with 🔴", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0].data;
+      expect(embed.title).toMatch(/^🔴 /);
+    });
+  });
+
+  describe("autocomplete", () => {
+    const buildAutocompleteInteraction = (focusedValue: string) =>
+      ({
+        options: {
+          getFocused: vi
+            .fn()
+            .mockReturnValue({ name: "name", value: focusedValue }),
+        },
+        respond: vi.fn().mockResolvedValue(undefined),
+      }) as any;
+
+    it("returns matching types as choices (substring)", async () => {
+      const interaction = buildAutocompleteInteraction("fi");
+      await poke.autocomplete!(createMockClient(), interaction);
+
+      expect(interaction.respond).toHaveBeenCalledOnce();
+      const choices = interaction.respond.mock.calls[0][0];
+      const values = choices.map((c: any) => c.value);
+      expect(values).toContain("fire");
+      expect(values).toContain("fighting");
+      expect(values).not.toContain("water");
+    });
+
+    it("returns the full list when query is empty", async () => {
+      const interaction = buildAutocompleteInteraction("");
+      await poke.autocomplete!(createMockClient(), interaction);
+      const choices = interaction.respond.mock.calls[0][0];
+      expect(choices.length).toBe(18);
     });
   });
 });

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -1,6 +1,16 @@
-import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random } from "../../shared/utils/helpers";
 
@@ -25,11 +35,136 @@ const POKE_TYPES = [
   "water",
 ] as const;
 
+type PokeType = (typeof POKE_TYPES)[number];
+
+/**
+ * Canonical Pokémon type colors. Signal-carrying — convention bends as in /imc.
+ * Multi-type pokémon use the FIRST type's color (Bulbasaur is grass, not poison).
+ */
+const TYPE_COLOR: Record<PokeType, number> = {
+  bug: 0xa6b91a,
+  dark: 0x705746,
+  dragon: 0x6f35fc,
+  electric: 0xf7d02c,
+  fairy: 0xd685ad,
+  fighting: 0xc22e28,
+  fire: 0xee8130,
+  flying: 0xa98ff3,
+  ghost: 0x735797,
+  grass: 0x7ac74c,
+  ground: 0xe2bf65,
+  ice: 0x96d9d6,
+  normal: 0xa8a77a,
+  poison: 0xa33ea1,
+  psychic: 0xf95587,
+  rock: 0xb6a136,
+  steel: 0xb7b7ce,
+  water: 0x6390f0,
+};
+
+const DEFAULT_POKE_COLOR = 0xa8a77a; // normal-type fallback
+
 const SUB = {
   random: "random",
   types: "types",
   type: "type",
 } as const;
+
+const OPT = {
+  name: "name",
+  private: "private",
+} as const;
+
+const POKEAPI_BASE = "https://pokeapi.co/api/v2";
+const MAX_POKE_ID = 898; // Gen 1–8. Don't bump without verifying API coverage.
+
+const capitalizeFirst = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1);
+
+const isPokeType = (s: string): s is PokeType =>
+  (POKE_TYPES as readonly string[]).includes(s);
+
+const colorForFirstType = (data: any): number => {
+  const firstType = (data.types?.[0]?.type?.name as string | undefined) ?? "";
+  return isPokeType(firstType) ? TYPE_COLOR[firstType] : DEFAULT_POKE_COLOR;
+};
+
+const pickSprite = (data: any): { url: string; isShiny: boolean } => {
+  const sprites = [
+    data.sprites.front_default,
+    data.sprites.front_female,
+    data.sprites.front_shiny,
+    data.sprites.front_shiny_female,
+  ];
+  // 1-in-50 chance to pick from any of the four sprites (incl. shinies);
+  // otherwise default to one of the first two.
+  let img =
+    random(0, 49) === 1
+      ? sprites[random(0, sprites.length - 1)]
+      : sprites[random(0, 1)];
+  img ??= data.sprites.front_default;
+  return {
+    url: img,
+    isShiny: img === sprites[2] || img === sprites[3],
+  };
+};
+
+const buildPokemonEmbed = (data: any, idOrName: number | string) => {
+  const { url: img, isShiny } = pickSprite(data);
+  const types = (data.types as any[])
+    .map((t) => `\`${capitalizeFirst(t.type.name)}\``)
+    .join(" ");
+  const stats = data.stats as any[];
+  const order =
+    typeof idOrName === "number" || !data.order || data.order < 1
+      ? idOrName.toString()
+      : data.order;
+
+  return new EmbedBuilder()
+    .setTitle(
+      `🔴 ${capitalizeFirst(data.name)}${isShiny ? " ⭐️" : ""} #${order}`
+    )
+    .setDescription(types)
+    .setColor(colorForFirstType(data))
+    .addFields(
+      { name: "HP", value: `\`${stats[0].base_stat}\``, inline: true },
+      { name: "Attack", value: `\`${stats[1].base_stat}\``, inline: true },
+      { name: "Defense", value: `\`${stats[2].base_stat}\``, inline: true },
+      { name: "Speed", value: `\`${stats[5].base_stat}\``, inline: true },
+      { name: "Sp. Atk", value: `\`${stats[3].base_stat}\``, inline: true },
+      { name: "Sp. Def", value: `\`${stats[4].base_stat}\``, inline: true }
+    )
+    .setImage(img)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildTypesListEmbed = () =>
+  new EmbedBuilder()
+    .setTitle("🔴 Tipos disponibles")
+    .setDescription(POKE_TYPES.map((t) => `\`${t}\``).join(" "))
+    .setColor(DEFAULT_POKE_COLOR)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const fetchJson = async (url: string): Promise<any | null> => {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+};
+
+// Note: no `flags` field — editReply can't change ephemerality after defer.
+// The error inherits the visibility chosen at deferReply time.
+const apiErrorPayload = () => ({
+  content: "La PokéAPI no respondió bien. Intentá de nuevo en un rato.",
+});
+
+type SubArg = NonNullable<Argument["args"]>[number];
+
+const findArg = (args: SubArg[] | undefined, name: string) =>
+  args?.find((a) => a.name === name)?.value;
 
 const pull: ISlashCommand = {
   name: "poke",
@@ -41,11 +176,27 @@ const pull: ISlashCommand = {
       name: SUB.random,
       description: "Pokémon completamente random (1-898)",
       type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
     {
       name: SUB.types,
       description: "Lista los tipos disponibles",
       type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
     {
       name: SUB.type,
@@ -53,14 +204,42 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
-          name: "name",
+          name: OPT.name,
           description: "Tipo (fire, water, grass, etc.)",
           type: ApplicationCommandOptionType.String,
           required: true,
+          autocomplete: true,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
         },
       ],
     },
   ],
+  examples: [
+    "/poke random",
+    "/poke types",
+    "/poke type name:fire",
+    "/poke type name:water private:true",
+  ],
+  autocomplete: async (
+    _: ClientDiscord,
+    interaction: AutocompleteInteraction
+  ) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== OPT.name) {
+      await interaction.respond([]);
+      return;
+    }
+    const query = String(focused.value ?? "").toLowerCase();
+    const matches = POKE_TYPES.filter((t) => t.includes(query))
+      .slice(0, 25)
+      .map((t) => ({ name: capitalizeFirst(t), value: t }));
+    await interaction.respond(matches);
+  },
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
@@ -69,96 +248,53 @@ const pull: ISlashCommand = {
     try {
       const sub = args[0];
       if (!sub) return;
+      const subArgs = sub.args ?? [];
+      const isPrivate =
+        (findArg(subArgs, OPT.private) as boolean | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
 
       if (sub.name === SUB.types) {
-        const list = POKE_TYPES.map((t) => `\`${t}\``).join(" ");
         return interaction.reply({
-          embeds: [
-            { color: 0x0099ff, title: "Tipos disponibles", description: list },
-          ],
+          embeds: [buildTypesListEmbed()],
+          flags,
         });
       }
 
       if (sub.name === SUB.type) {
-        const typeName = sub.args?.[0].value as string;
-        if (!POKE_TYPES.includes(typeName as (typeof POKE_TYPES)[number])) {
+        const typeName = (findArg(subArgs, OPT.name) as string) ?? "";
+        if (!isPokeType(typeName)) {
           return interaction.reply({
             content: `Tipo no encontrado. Prueba con: ${POKE_TYPES.join(", ")}`,
             flags: MessageFlags.Ephemeral,
           });
         }
-        await interaction.deferReply();
-        const typeRes = await fetch(
-          `https://pokeapi.co/api/v2/type/${typeName}`
-        );
-        const typeData: any = await typeRes.json();
+
+        await interaction.deferReply({ flags });
+        const typeData = await fetchJson(`${POKEAPI_BASE}/type/${typeName}`);
+        if (!typeData?.pokemon?.length) {
+          return interaction.editReply(apiErrorPayload());
+        }
         const picked =
           typeData.pokemon[random(0, typeData.pokemon.length - 1)].pokemon.name;
-        const pokeRes = await fetch(
-          `https://pokeapi.co/api/v2/pokemon/${picked}`
-        );
-        const pokeData: any = await pokeRes.json();
-        return interaction.editReply(buildEmbed(pokeData, picked));
+        const pokeData = await fetchJson(`${POKEAPI_BASE}/pokemon/${picked}`);
+        if (!pokeData) return interaction.editReply(apiErrorPayload());
+        return interaction.editReply({
+          embeds: [buildPokemonEmbed(pokeData, picked)],
+        });
       }
 
-      // SUB.random (default)
-      await interaction.deferReply();
-      const id = random(1, 898);
-      const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`);
-      const data: any = await res.json();
-      return interaction.editReply(buildEmbed(data, id));
+      // SUB.random (default fallthrough)
+      await interaction.deferReply({ flags });
+      const id = random(1, MAX_POKE_ID);
+      const data = await fetchJson(`${POKEAPI_BASE}/pokemon/${id}`);
+      if (!data) return interaction.editReply(apiErrorPayload());
+      return interaction.editReply({
+        embeds: [buildPokemonEmbed(data, id)],
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }
   },
-};
-
-const capitalizeFirst = (s: string) =>
-  s.charAt(0).toUpperCase() + s.slice(1);
-
-const buildEmbed = (data: any, idOrName: number | string) => {
-  const sprites = [
-    data.sprites.front_default,
-    data.sprites.front_female,
-    data.sprites.front_shiny,
-    data.sprites.front_shiny_female,
-  ];
-
-  let img =
-    random(0, 49) === 1
-      ? sprites[random(0, sprites.length - 1)]
-      : sprites[random(0, 1)];
-  img ??= data.sprites.front_default;
-  const isShiny = img === sprites[2] || img === sprites[3];
-
-  const types = (data.types as any[])
-    .map((t) => `\`${capitalizeFirst(t.type.name)}\``)
-    .join(" ");
-
-  const stats = data.stats as any[];
-  const order =
-    typeof idOrName === "number" || !data.order || data.order < 1
-      ? idOrName.toString()
-      : data.order;
-
-  return {
-    embeds: [
-      {
-        color: 0x0099ff,
-        title: `${capitalizeFirst(data.name)}${isShiny ? " ⭐️" : ""} #${order}`,
-        description: types,
-        fields: [
-          { name: "HP", value: `\`${stats[0].base_stat}\``, inline: true },
-          { name: "Attack", value: `\`${stats[1].base_stat}\``, inline: true },
-          { name: "Defense", value: `\`${stats[2].base_stat}\``, inline: true },
-          { name: "Speed", value: `\`${stats[5].base_stat}\``, inline: true },
-          { name: "Sp. Atk", value: `\`${stats[3].base_stat}\``, inline: true },
-          { name: "Sp. Def", value: `\`${stats[4].base_stat}\``, inline: true },
-        ],
-        image: { url: img },
-      },
-    ],
-  };
 };
 
 export default pull;


### PR DESCRIPTION
## Summary
Sexto comando del facelift de **fun**. `/poke` ya estaba en español y la lógica de PokéAPI andaba bien; este PR aplica branding consistente, mejora la UX del subcomando `type`, y robustece el manejo de errores.

## Cambios

### Branding
- **Color por tipo del Pokémon**: el embed se pinta del color canónico del tipo principal (fire → naranja-rojo, water → azul, grass → verde, electric → amarillo, etc.). Map de los 18 tipos. Excepción a la convención de color, igual que `/imc` — el color carga signal del Pokémon, no solo brand.
- Title con prefijo 🔴 (Pokéball)
- Footer estándar `Xiza Bot vX.Y.Z` (también en `/poke types`)

### UX
- **Autocomplete** en `/poke type name:`: escribís `fi` y te sugiere `fire` y `fighting`. Antes tenías que recordarte los 18 nombres exactos.
- **`private:` opt-in** en los 3 subcomandos (default: público)

### Robustez
- Helper `fetchJson()` que envuelve `fetch` en try/catch y chequea `res.ok`
- Si la PokéAPI falla → reply friendly `"La PokéAPI no respondió bien. Intentá de nuevo en un rato."` en lugar de throw al errorHandler con stacktrace genérico
- Caveat: la visibilidad del error la hereda del `deferReply` original (Discord no permite cambiar ephemerality post-defer)

### Refactor interno
- Inline embed objects → `EmbedBuilder` para consistencia con el resto del codebase
- Helpers extraídos: `pickSprite`, `colorForFirstType`, `buildPokemonEmbed`, `buildTypesListEmbed`

## Test plan
- [x] `pnpm test` → 220/220 (was 212, +8 nuevos)
- [x] `tsc --noEmit` → limpio
- [ ] `/poke random` → embed con color del tipo del pokemon
- [ ] `/poke types` → lista de los 18 tipos
- [ ] `/poke type name:fi` → autocomplete debería ofrecer fire y fighting
- [ ] `/poke type name:fire` → un pokemon de fuego, embed naranja-rojo
- [ ] `/poke type name:lava` → notice "Tipo no encontrado"
- [ ] `/poke random private:true` → solo lo ves vos
- [ ] (opcional) probar con la API caída — debería responder friendly