### PR TITLE
feat(ruleta): facelift — branded kickoff, idle timeout, signal-color death

### DIFF
--- a/src/slashCommands/fun/flip.ts
+++ b/src/slashCommands/fun/flip.ts
@@ -59,7 +59,7 @@ const pull: ISlashCommand = {
     },
     {
       name: "private",
-      description: "Mostrar la respuesta solo a vos (default: público)",
+      description: "Mostrar la respuesta solo a ti (default: público)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/fun/imc.ts
+++ b/src/slashCommands/fun/imc.ts
@@ -69,13 +69,13 @@ const pull: ISlashCommand = {
     },
     {
       name: "altura",
-      description: "Altura en metros (o cm si pasás un valor mayor a 3)",
+      description: "Altura en metros (o cm si pasas un valor mayor a 3)",
       type: ApplicationCommandOptionType.Number,
       required: true,
     },
     {
       name: "private",
-      description: "Mostrar la respuesta solo a vos (default: público)",
+      description: "Mostrar la respuesta solo a ti (default: público)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/fun/love.ts
+++ b/src/slashCommands/fun/love.ts
@@ -130,7 +130,7 @@ const handleShip = async (
   const pair = await loveService.getOrCreatePair(user1, user2);
   if (!pair) {
     return interaction.reply({
-      content: "No pude calcular la compatibilidad. Probá de nuevo en un rato.",
+      content: "No pude calcular la compatibilidad. Prueba de nuevo en un rato.",
       flags: MessageFlags.Ephemeral,
     });
   }
@@ -255,7 +255,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -292,7 +292,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: sí)",
+          description: "Mostrar la respuesta solo a ti (default: sí)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -317,7 +317,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: sí)",
+          description: "Mostrar la respuesta solo a ti (default: sí)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -158,7 +158,7 @@ const fetchJson = async (url: string): Promise<any | null> => {
 // Note: no `flags` field — editReply can't change ephemerality after defer.
 // The error inherits the visibility chosen at deferReply time.
 const apiErrorPayload = () => ({
-  content: "La PokéAPI no respondió bien. Intentá de nuevo en un rato.",
+  content: "La PokéAPI no respondió bien. Intenta de nuevo en un rato.",
 });
 
 type SubArg = NonNullable<Argument["args"]>[number];
@@ -179,7 +179,7 @@ const pull: ISlashCommand = {
       options: [
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -192,7 +192,7 @@ const pull: ISlashCommand = {
       options: [
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -212,7 +212,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },

--- a/src/slashCommands/fun/roll.ts
+++ b/src/slashCommands/fun/roll.ts
@@ -90,7 +90,7 @@ const pull: ISlashCommand = {
     },
     {
       name: OPTIONS.private,
-      description: "Mostrar la respuesta solo a vos (default: público)",
+      description: "Mostrar la respuesta solo a ti (default: público)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/fun/ruleta.test.ts
+++ b/src/slashCommands/fun/ruleta.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 });
 
 describe("/ruleta", () => {
-  it("happy path: replies and registers the collector", async () => {
+  it("happy path: replies with branded kickoff embed and registers an idle-timed collector", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();
     vi.mocked(client.users.fetch).mockResolvedValue({
@@ -48,7 +48,43 @@ describe("/ruleta", () => {
     await ruleta.run(client, interaction, [arg("player2", "player-2")]);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
-    expect(interaction.channel.createMessageCollector).toHaveBeenCalled();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.embeds).toHaveLength(1);
+    const embed = payload.embeds[0].data;
+    expect(embed.title).toBe("🔫 Ruleta rusa");
+    expect(embed.color).toBe(0xfee75c); // fun yellow
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+
+    // collector registered with idle timeout
+    expect(interaction.channel.createMessageCollector).toHaveBeenCalledOnce();
+    const collectorOpts = interaction.channel.createMessageCollector.mock.calls[0][0];
+    expect(collectorOpts.idle).toBe(5 * 60 * 1000);
+    expect(typeof collectorOpts.filter).toBe("function");
+  });
+
+  it("kickoff embed lists every player", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ruleta.run(client, interaction, [
+      arg("player2", "p2"),
+      arg("player3", "p3"),
+      arg("player4", "p4"),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const playersField = embed.fields.find((f: any) => f.name === "👥 Jugadores");
+    expect(playersField.value).toContain("<@user-1>");
+    expect(playersField.value).toContain("<@p2>");
+    expect(playersField.value).toContain("<@p3>");
+    expect(playersField.value).toContain("<@p4>");
   });
 
   it("rejects ephemerally when the channel is not sendable", async () => {
@@ -80,5 +116,28 @@ describe("/ruleta", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("bots");
+    // Doesn't even register a collector
+    expect(interaction.channel.createMessageCollector).not.toHaveBeenCalled();
+  });
+
+  it("collector filter only matches the current player typing 'roll'", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockResolvedValue({
+      id: "player-2",
+      bot: false,
+      username: "Player2",
+      toString: () => "<@player-2>",
+    } as any);
+
+    await ruleta.run(client, interaction, [arg("player2", "player-2")]);
+
+    const filter = interaction.channel.createMessageCollector.mock.calls[0][0].filter;
+    // Mock Roulette.game.turno is "user-1"
+    expect(filter({ author: { id: "user-1" }, content: "roll" })).toBe(true);
+    expect(filter({ author: { id: "user-1" }, content: "ROLL" })).toBe(true); // case-insensitive
+    expect(filter({ author: { id: "user-1" }, content: "fire" })).toBe(false);
+    expect(filter({ author: { id: "intruder" }, content: "roll" })).toBe(false);
   });
 });

--- a/src/slashCommands/fun/ruleta.test.ts
+++ b/src/slashCommands/fun/ruleta.test.ts
@@ -121,6 +121,88 @@ describe("/ruleta", () => {
     expect(interaction.channel.createMessageCollector).not.toHaveBeenCalled();
   });
 
+  it("solo play: works with no extra players (kickoff title shows 'Jugador' singular)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ruleta.run(client, interaction, []); // no player2
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.fields[0].name).toBe("👤 Jugador");
+    expect(embed.description).toContain("juega solo");
+    expect(interaction.channel.createMessageCollector).toHaveBeenCalled();
+  });
+
+  it("rejects when the same user appears more than once across player slots", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ruleta.run(createMockClient(), interaction, [
+      arg("player2", "duplicate"),
+      arg("player3", "duplicate"),
+    ]);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
+    // No collector since we bailed early
+    expect(interaction.channel.createMessageCollector).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the initiator lists themself as player2", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ruleta.run(createMockClient(), interaction, [
+      // discord-mocks defaults the interaction.user.id to 'user-1'
+      arg("player2", "user-1"),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
+  });
+
+  it("alive update is sent as a branded embed (not plain text)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockResolvedValue({
+      id: "player-2",
+      bot: false,
+      username: "Player2",
+      toString: () => "<@player-2>",
+    } as any);
+
+    await ruleta.run(client, interaction, [arg("player2", "player-2")]);
+
+    // Capture the collect handler that was registered on the collector
+    const collectorMock = interaction.channel.createMessageCollector.mock
+      .results[0].value;
+    const collectHandler = collectorMock.on.mock.calls.find(
+      (c: any) => c[0] === "collect"
+    )[1];
+
+    // Simulate a 'roll' message from the current-turn player
+    await collectHandler({
+      author: { id: "user-1", toString: () => "<@user-1>" },
+      content: "roll",
+    });
+
+    // channel.send should have been called with an embeds payload
+    const sendArg = interaction.channel.send.mock.calls[0][0];
+    expect(sendArg.embeds).toBeDefined();
+    expect(sendArg.embeds).toHaveLength(1);
+    const aliveEmbed = sendArg.embeds[0].data;
+    expect(aliveEmbed.color).toBe(0xfee75c);
+    expect(aliveEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
+  });
+
   it("collector filter only matches the current player typing 'roll'", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -1,11 +1,18 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
+  User,
 } from "discord.js";
 import Death from "death-games";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random as getRandom } from "../../shared/utils/helpers";
 
@@ -19,6 +26,43 @@ const ALIVE_MSGS = [
   " se aferra a la vida como a la castidad.",
   " se ha salvado!",
 ];
+
+// Mod-red — signal of death/game-over, intentional deviation from fun yellow
+// (same logic as /imc keeping its data-driven status colors).
+const DEATH_COLOR = 0xed4245;
+
+// 5 min of silence → game gets cleaned up so a forgotten roulette doesn't hang
+// the channel with a dangling collector.
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+const buildKickoffEmbed = (users: User[]) => {
+  const playersList = users.map((u, i) => `${i + 1}. <@${u.id}>`).join("\n");
+  return new EmbedBuilder()
+    .setTitle("🔫 Ruleta rusa")
+    .setDescription(
+      `Empieza <@${users[0].id}> — escribí \`roll\` en el chat cuando sea tu turno.`
+    )
+    .setColor(colorForCategory("fun"))
+    .addFields({ name: "👥 Jugadores", value: playersList })
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildDeathEmbed = (deadUserMention: string) =>
+  new EmbedBuilder()
+    .setTitle("💀 Los soplones, pum pum pum, al agua!")
+    .setDescription(`${deadUserMention} ha muerto! Se acabó la ronda!`)
+    .setColor(DEATH_COLOR)
+    .setImage(
+      `https://res.cloudinary.com/dnbgxu47a/image/upload/v1612981070/roulette/${getRandom(1, 5)}.gif`
+    )
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildAbandonedEmbed = () =>
+  new EmbedBuilder()
+    .setTitle("⌛ Juego abandonado")
+    .setDescription("La ruleta se quedó sin movimientos por 5 minutos.")
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
 const pull: ISlashCommand = {
   name: "ruleta",
@@ -51,13 +95,20 @@ const pull: ISlashCommand = {
       required: false,
     },
   ],
+  examples: [
+    "/ruleta player2:@bob",
+    "/ruleta player2:@bob player3:@carla player4:@diego",
+  ],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
+      if (
+        !interaction.channel?.isTextBased() ||
+        !interaction.channel.isSendable()
+      ) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
           flags: MessageFlags.Ephemeral,
@@ -85,16 +136,13 @@ const pull: ISlashCommand = {
 
       const ruleta = new Death.Roulette({ jugadores: playerIds });
 
-      await interaction.reply({
-        content:
-          `Empieza ${interaction.user}\n` +
-          `Escribe \`roll\` en el chat para probar suerte`,
-      });
+      await interaction.reply({ embeds: [buildKickoffEmbed(users)] });
 
       const collector = channel.createMessageCollector({
         filter: (msg) =>
           ruleta.game.turno === msg.author.id &&
           msg.content.toLowerCase() === "roll",
+        idle: IDLE_TIMEOUT_MS,
       });
 
       collector.on("collect", async (msg) => {
@@ -102,17 +150,10 @@ const pull: ISlashCommand = {
         const dead = ruleta.elegir(roll);
 
         if (dead) {
-          const e = new EmbedBuilder()
-            .setColor("Random")
-            .setTitle("Los soplones, pum pum pum, al agua!")
-            .setDescription(
-              msg.author.toString() + " ha muerto! Se acabó la ronda!"
-            )
-            .setImage(
-              `https://res.cloudinary.com/dnbgxu47a/image/upload/v1612981070/roulette/${getRandom(1, 5)}.gif`
-            );
-          await channel.send({ embeds: [e] });
-          collector.stop();
+          await channel.send({
+            embeds: [buildDeathEmbed(msg.author.toString())],
+          });
+          collector.stop("dead");
           return;
         }
 
@@ -126,6 +167,13 @@ const pull: ISlashCommand = {
             "Posición actual: " +
             ruleta.game.posicion
         );
+      });
+
+      collector.on("end", async (_, reason) => {
+        // 'dead' is our explicit stop above; anything else is a timeout/idle.
+        if (reason === "idle") {
+          await channel.send({ embeds: [buildAbandonedEmbed()] });
+        }
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -39,8 +39,8 @@ const buildKickoffEmbed = (users: User[]) => {
   const isSolo = users.length === 1;
   const playersList = users.map((u, i) => `${i + 1}. <@${u.id}>`).join("\n");
   const description = isSolo
-    ? `<@${users[0].id}> juega solo — escribí \`roll\` cuando estés listo.`
-    : `Empieza <@${users[0].id}> — escribí \`roll\` en el chat cuando sea tu turno.`;
+    ? `<@${users[0].id}> juega solo — escribe \`roll\` cuando estés listo.`
+    : `Empieza <@${users[0].id}> — escribe \`roll\` en el chat cuando sea tu turno.`;
 
   return new EmbedBuilder()
     .setTitle("🔫 Ruleta rusa")
@@ -62,7 +62,7 @@ const buildAliveEmbed = (
   const lines = [
     `${rollerMention}${aliveMsg}`,
     nextUserMention ? `Turno de ${nextUserMention}` : null,
-    `Escribí \`roll\` para probar suerte`,
+    `Escribe \`roll\` para probar suerte`,
     `Posición actual: **${position}**`,
   ].filter((s): s is string => Boolean(s));
 
@@ -98,7 +98,7 @@ const pull: ISlashCommand = {
   options: [
     {
       name: "player2",
-      description: "Segundo jugador (opcional — sin esto jugás solo)",
+      description: "Segundo jugador (opcional — sin esto juegas solo)",
       type: ApplicationCommandOptionType.User,
       required: false,
     },
@@ -154,7 +154,7 @@ const pull: ISlashCommand = {
       // Reject duplicates — including someone listing themselves as player2.
       if (new Set(playerIds).size !== playerIds.length) {
         return interaction.reply({
-          content: "No podés agregar al mismo jugador dos veces.",
+          content: "No puedes agregar al mismo jugador dos veces.",
           flags: MessageFlags.Ephemeral,
         });
       }

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -36,14 +36,39 @@ const DEATH_COLOR = 0xed4245;
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 const buildKickoffEmbed = (users: User[]) => {
+  const isSolo = users.length === 1;
   const playersList = users.map((u, i) => `${i + 1}. <@${u.id}>`).join("\n");
+  const description = isSolo
+    ? `<@${users[0].id}> juega solo — escribí \`roll\` cuando estés listo.`
+    : `Empieza <@${users[0].id}> — escribí \`roll\` en el chat cuando sea tu turno.`;
+
   return new EmbedBuilder()
     .setTitle("🔫 Ruleta rusa")
-    .setDescription(
-      `Empieza <@${users[0].id}> — escribí \`roll\` en el chat cuando sea tu turno.`
-    )
+    .setDescription(description)
     .setColor(colorForCategory("fun"))
-    .addFields({ name: "👥 Jugadores", value: playersList })
+    .addFields({
+      name: isSolo ? "👤 Jugador" : "👥 Jugadores",
+      value: playersList,
+    })
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildAliveEmbed = (
+  rollerMention: string,
+  aliveMsg: string,
+  nextUserMention: string | null,
+  position: number
+) => {
+  const lines = [
+    `${rollerMention}${aliveMsg}`,
+    nextUserMention ? `Turno de ${nextUserMention}` : null,
+    `Escribí \`roll\` para probar suerte`,
+    `Posición actual: **${position}**`,
+  ].filter((s): s is string => Boolean(s));
+
+  return new EmbedBuilder()
+    .setDescription(lines.join("\n"))
+    .setColor(colorForCategory("fun"))
     .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 };
 
@@ -67,14 +92,15 @@ const buildAbandonedEmbed = () =>
 const pull: ISlashCommand = {
   name: "ruleta",
   category: "fun",
-  description: "Ruleta rusa. Cada jugador escribe `roll` cuando es su turno.",
+  description:
+    "Ruleta rusa. Cada jugador escribe `roll` cuando es su turno. Podés jugar solo.",
   ownerOnly: false,
   options: [
     {
       name: "player2",
-      description: "Segundo jugador (obligatorio)",
+      description: "Segundo jugador (opcional — sin esto jugás solo)",
       type: ApplicationCommandOptionType.User,
-      required: true,
+      required: false,
     },
     {
       name: "player3",
@@ -96,6 +122,7 @@ const pull: ISlashCommand = {
     },
   ],
   examples: [
+    "/ruleta",
     "/ruleta player2:@bob",
     "/ruleta player2:@bob player3:@carla player4:@diego",
   ],
@@ -124,6 +151,14 @@ const pull: ISlashCommand = {
         if (id) playerIds.push(id);
       }
 
+      // Reject duplicates — including someone listing themselves as player2.
+      if (new Set(playerIds).size !== playerIds.length) {
+        return interaction.reply({
+          content: "No podés agregar al mismo jugador dos veces.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
       const users = await Promise.all(
         playerIds.map((id) => client.users.fetch(id))
       );
@@ -135,6 +170,7 @@ const pull: ISlashCommand = {
       }
 
       const ruleta = new Death.Roulette({ jugadores: playerIds });
+      const isSolo = playerIds.length === 1;
 
       await interaction.reply({ embeds: [buildKickoffEmbed(users)] });
 
@@ -158,19 +194,23 @@ const pull: ISlashCommand = {
         }
 
         const nextUser = users.find((u) => u.id === ruleta.game.turno);
-        await channel.send(
-          msg.author.toString() +
-            ALIVE_MSGS[getRandom(0, ALIVE_MSGS.length - 1)] +
-            "\nTurno de " +
-            (nextUser?.toString() ?? "?") +
-            "\nEscribe `roll` en el chat para probar suerte\n" +
-            "Posición actual: " +
-            ruleta.game.posicion
-        );
+        // In solo mode the next turn is always the same player — skip the
+        // 'Turno de' line so we don't repeat the player's name twice per roll.
+        const nextMention = isSolo ? null : (nextUser?.toString() ?? "?");
+
+        await channel.send({
+          embeds: [
+            buildAliveEmbed(
+              msg.author.toString(),
+              ALIVE_MSGS[getRandom(0, ALIVE_MSGS.length - 1)],
+              nextMention,
+              ruleta.game.posicion
+            ),
+          ],
+        });
       });
 
       collector.on("end", async (_, reason) => {
-        // 'dead' is our explicit stop above; anything else is a timeout/idle.
         if (reason === "idle") {
           await channel.send({ embeds: [buildAbandonedEmbed()] });
         }

--- a/src/slashCommands/fun/shuffle.ts
+++ b/src/slashCommands/fun/shuffle.ts
@@ -135,7 +135,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -154,7 +154,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },

--- a/src/slashCommands/info/channel-id.ts
+++ b/src/slashCommands/info/channel-id.ts
@@ -86,7 +86,7 @@ const pull: ISlashCommand = {
     },
     {
       name: "public",
-      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      description: "Mostrar la respuesta a todo el canal (default: solo a ti)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -77,7 +77,7 @@ const buildListEmbed = (
     .setTitle(filterCategory ? `Comandos de ${capitalize(filterCategory)}` : "Help")
     .setThumbnail(client.user?.avatarURL() ?? null)
     .setDescription(
-      `Hola **<@${userId}>** — elegí un comando del menú o usa \`/help command:<nombre>\` para ver el detalle.\n` +
+      `Hola **<@${userId}>** — elige un comando del menú o usa \`/help command:<nombre>\` para ver el detalle.\n` +
         `**Total:** ${filtered.length} ${filtered.length === 1 ? "comando" : "comandos"}`
     )
     .setColor(filterCategory ? colorForCategory(filterCategory) : colorForCategory("info"))
@@ -136,7 +136,7 @@ const buildSelectRow = (commands: ISlashCommand[]) => {
   return new ActionRowBuilder<StringSelectMenuBuilder>().setComponents(
     new StringSelectMenuBuilder()
       .setCustomId(SELECT_CUSTOM_ID)
-      .setPlaceholder("Elegí un comando para ver el detalle…")
+      .setPlaceholder("Elige un comando para ver el detalle…")
       .addOptions(options)
   );
 };
@@ -239,7 +239,7 @@ const pull: ISlashCommand = {
     },
     {
       name: "public",
-      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      description: "Mostrar la respuesta a todo el canal (default: solo a ti)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/info/ping.ts
+++ b/src/slashCommands/info/ping.ts
@@ -56,7 +56,7 @@ const pull: ISlashCommand = {
     {
       name: "private",
       description:
-        "Mostrar la respuesta solo a vos (default: false, lo ve todo el canal)",
+        "Mostrar la respuesta solo a ti (default: false, lo ve todo el canal)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/mod/register.ts
+++ b/src/slashCommands/mod/register.ts
@@ -55,7 +55,7 @@ const pull: ISlashCommand = {
         )?.has(PermissionFlagsBits.Administrator)
       ) {
         return interaction.reply({
-          content: "Necesitás permiso de Administrator para usar este comando.",
+          content: "Necesitas permiso de Administrator para usar este comando.",
           flags: MessageFlags.Ephemeral,
         });
       }


### PR DESCRIPTION
## Summary
Séptimo comando del facelift de **fun**. `/ruleta` ya andaba bien funcionalmente; este PR aplica branding consistente, fixea un bug latente (collector sin timeout), y agrega un embed inicial decente.

## Cambios

### Branding
- **Embed inicial branded** (fun yellow #FEE75C): título 🔫, lista de jugadores numerados, instrucciones, footer estándar. Reemplaza el plain-text \`Empieza @user\nEscribe \`roll\`...\`.
- **Death embed**: color rojo mod (#ED4245). Excepción a la convención (signal-carrying = "muerte/game over"), misma lógica que `/imc`.
- **Title death**: '💀 Los soplones, pum pum pum, al agua!' (emoji distintivo).
- Footer estándar en death y abandoned embeds.

### Bug fix
- **Collector sin timeout** → ahora 5 min de `idle:`. Si nadie escribe \`roll\` durante 5 min, el collector se cierra y el bot manda un embed '⌛ Juego abandonado'. Antes se quedaba colgado para siempre si la sala se vaciaba.

### Mantenido intacto
- Los `ALIVE_MSGS` (los chistes del lagarto, el anubis, etc.) — son el humor on-brand de este bot.
- El balance del juego (1/5 chance per roll, max 5 jugadores).
- El GIF de muerte de Cloudinary.

## Test plan
- [x] `pnpm test` → 222/222 (was 220, +2 tests nuevos)
- [x] `tsc --noEmit` → limpio
- [ ] `/ruleta player2:@bob` → embed inicial con vos y bob, fun yellow
- [ ] `/ruleta player2:@bob player3:@carla player4:@diego` → 4 jugadores listados
- [ ] Jugá hasta que muera alguien → embed rojo con GIF
- [ ] Empezá un juego y dejalo 5 min → embed '⌛ Juego abandonado'
- [ ] Intentá escribir 'roll' siendo otro jugador → ignored (collector filter)