### PR TITLE
feat(ahorcado): facelift — branding, solo play, idle timeout, win/lose colors

### DIFF
--- a/src/slashCommands/fun/ahorcado.test.ts
+++ b/src/slashCommands/fun/ahorcado.test.ts
@@ -5,7 +5,13 @@ vi.mock("death-games", () => ({
   __esModule: true,
   default: {
     Hangman: class {
-      game = { ascii: ["_", "_"], turno: "user-1", ended: false, vidas: 7 };
+      game = {
+        ascii: ["_", "_"],
+        turno: "user-1",
+        ended: false,
+        vidas: 7,
+        letrasIncorrectas: [],
+      };
       on = vi.fn();
       find = vi.fn().mockReturnValue(true);
     },
@@ -39,10 +45,9 @@ beforeEach(() => {
 });
 
 describe("/ahorcado", () => {
-  it("when bot_picks_word is true, replies and starts the game without DMing the user", async () => {
+  it("happy path with bot_picks_word=true: replies, sends kickoff embed, registers idle-timed collector", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();
-    // override the user fetched (player2) to be non-bot
     vi.mocked(client.users.fetch).mockResolvedValue({
       id: "player-2",
       bot: false,
@@ -56,8 +61,47 @@ describe("/ahorcado", () => {
     ]);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
-    expect(interaction.channel.send).toHaveBeenCalled(); // initial board
+    expect(interaction.channel.send).toHaveBeenCalled();
+    const sentEmbed = interaction.channel.send.mock.calls[0][0].embeds[0].data;
+    expect(sentEmbed.title).toBe("🎯 Ahorcado");
+    expect(sentEmbed.color).toBe(0xfee75c); // fun yellow
+    expect(sentEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(sentEmbed.author).toBeUndefined();
+
     expect(interaction.channel.createMessageCollector).toHaveBeenCalled();
+    const collectorOpts =
+      interaction.channel.createMessageCollector.mock.calls[0][0];
+    expect(collectorOpts.idle).toBe(5 * 60 * 1000);
+  });
+
+  it("solo play: allows playing alone if bot_picks_word=true", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ahorcado.run(client, interaction, [arg("bot_picks_word", true)]);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.channel.send).toHaveBeenCalled();
+    const desc = interaction.channel.send.mock.calls[0][0].embeds[0].data
+      .description;
+    expect(desc).toContain("jugando solo");
+  });
+
+  it("rejects solo + bot_picks_word=false (would be guessing your own word)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ahorcado.run(createMockClient(), interaction, []);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("bot_picks_word");
   });
 
   it("rejects ephemerally when the channel is not sendable", async () => {
@@ -82,8 +126,6 @@ describe("/ahorcado", () => {
   it("rejects when any chosen player is a bot", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();
-
-    // Override fetch so the second call returns a bot user.
     vi.mocked(client.users.fetch).mockImplementation((async (id: string) => {
       if (id === "player-2-bot") {
         return { id, bot: true, username: "BotUser" };
@@ -100,5 +142,33 @@ describe("/ahorcado", () => {
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("bots");
+  });
+
+  it("rejects duplicate players (same user listed twice)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ahorcado.run(createMockClient(), interaction, [
+      arg("player2", "duplicate"),
+      arg("player3", "duplicate"),
+      arg("bot_picks_word", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
+    expect(interaction.channel.createMessageCollector).not.toHaveBeenCalled();
+  });
+
+  it("rejects when initiator lists themself as player2", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ahorcado.run(createMockClient(), interaction, [
+      arg("player2", "user-1"), // discord-mocks default initiator id
+      arg("bot_picks_word", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
   });
 });

--- a/src/slashCommands/fun/ahorcado.test.ts
+++ b/src/slashCommands/fun/ahorcado.test.ts
@@ -10,7 +10,8 @@ vi.mock("death-games", () => ({
         turno: "user-1",
         ended: false,
         vidas: 7,
-        letrasIncorrectas: [],
+        letrasUsadas: [] as string[],
+        letrasIncorrectas: [] as string[],
       };
       on = vi.fn();
       find = vi.fn().mockReturnValue(true);
@@ -172,5 +173,33 @@ describe("/ahorcado", () => {
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("dos veces");
+  });
+
+  it("collector filter matches the CURRENT turn's player (no pre-rotation bug)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ahorcado.run(client, interaction, [
+      arg("player2", "player-2"),
+      arg("bot_picks_word", true),
+    ]);
+
+    const collectorCall =
+      interaction.channel.createMessageCollector.mock.calls[0][0];
+    const filter = collectorCall.filter;
+
+    // turn = 0 → initiator (user-1) plays first, kickoff embed says
+    // 'Empieza user-1', so the filter must match user-1 (not the pre-rotated
+    // player-2 — that was the bug the rewrite fixes).
+    expect(filter({ author: { id: "user-1" }, content: "b" })).toBe(true);
+    expect(filter({ author: { id: "player-2" }, content: "b" })).toBe(false);
+    expect(filter({ author: { id: "user-1" }, content: "123" })).toBe(false); // not a letter
+    expect(filter({ author: { id: "intruder" }, content: "b" })).toBe(false);
   });
 });

--- a/src/slashCommands/fun/ahorcado.test.ts
+++ b/src/slashCommands/fun/ahorcado.test.ts
@@ -74,7 +74,7 @@ describe("/ahorcado", () => {
     expect(collectorOpts.idle).toBe(5 * 60 * 1000);
   });
 
-  it("solo play: allows playing alone if bot_picks_word=true", async () => {
+  it("solo play: works with no args (bot_picks_word defaults to true)", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();
     vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
@@ -84,7 +84,7 @@ describe("/ahorcado", () => {
       toString: () => `<@${id}>`,
     })) as any);
 
-    await ahorcado.run(client, interaction, [arg("bot_picks_word", true)]);
+    await ahorcado.run(client, interaction, []);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     expect(interaction.channel.send).toHaveBeenCalled();
@@ -93,10 +93,12 @@ describe("/ahorcado", () => {
     expect(desc).toContain("jugando solo");
   });
 
-  it("rejects solo + bot_picks_word=false (would be guessing your own word)", async () => {
+  it("rejects solo + bot_picks_word=false explicit (would be guessing your own word)", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
 
-    await ahorcado.run(createMockClient(), interaction, []);
+    await ahorcado.run(createMockClient(), interaction, [
+      arg("bot_picks_word", false),
+    ]);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -116,7 +116,7 @@ const pull: ISlashCommand = {
   name: "ahorcado",
   category: "fun",
   description:
-    "Ahorcado. Eliges la palabra (DM con menú) o el bot la elige (bot_picks_word).",
+    "Ahorcado. El bot elige la palabra; pasa bot_picks_word:false para elegirla por DM.",
   ownerOnly: false,
   options: [
     {
@@ -145,15 +145,15 @@ const pull: ISlashCommand = {
     },
     {
       name: "bot_picks_word",
-      description: "Si está en true, el bot elige la palabra",
+      description: "El bot elige la palabra (default: true). Pon false para elegirla por DM.",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
   ],
   examples: [
-    "/ahorcado bot_picks_word:true",
+    "/ahorcado",
     "/ahorcado player2:@bob",
-    "/ahorcado player2:@bob player3:@carla bot_picks_word:true",
+    "/ahorcado player2:@bob bot_picks_word:false",
   ],
   run: async (
     client: ClientDiscord,
@@ -179,10 +179,12 @@ const pull: ISlashCommand = {
           | undefined;
         if (id) playerIds.push(id);
       }
+      // Default true: most plays just want to start a game without the DM
+      // dance. Pass bot_picks_word:false to opt into picking the word yourself.
       const botPicks =
         (args.find((a) => a.name === "bot_picks_word")?.value as
           | boolean
-          | undefined) ?? false;
+          | undefined) ?? true;
       const isSolo = playerIds.length === 1;
 
       // Solo play only makes sense if the bot picks the word — otherwise the
@@ -190,7 +192,7 @@ const pull: ISlashCommand = {
       if (isSolo && !botPicks) {
         return interaction.reply({
           content:
-            "Para jugar solo necesitas que el bot elija la palabra. Usa `bot_picks_word:true`.",
+            "Para jugar solo necesitas que el bot elija la palabra. No pongas `bot_picks_word:false`.",
           flags: MessageFlags.Ephemeral,
         });
       }

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -112,6 +112,38 @@ const buildAbandonedEmbed = () =>
     .setTitle("⌛ Ahorcado abandonado")
     .setDescription("La partida se quedó sin movimientos por 5 minutos.");
 
+const buildSkipEmbed = (
+  playerMention: string,
+  letter: string,
+  asciiTokens: string[]
+) =>
+  baseEmbed()
+    .setTitle("🎯 Ahorcado")
+    .setDescription(
+      `${playerMention} ya probó la letra **${letter}** — sigue su turno.\n${fmtBoard(asciiTokens)}`
+    );
+
+const buildEliminationEmbed = (
+  playerMention: string,
+  attempt: string,
+  asciiTokens: string[]
+) =>
+  baseEmbed()
+    .setColor(LOSE_COLOR)
+    .setTitle("☠️ Jugador eliminado")
+    .setDescription(
+      `${playerMention} intentó adivinar **${attempt}** — palabra incorrecta.\nQueda fuera de la partida.\n${fmtBoard(asciiTokens)}`
+    );
+
+const buildAllEliminatedEmbed = (word: string, finalAscii: string[]) =>
+  new EmbedBuilder()
+    .setTitle("💀 Ahorcado — Todos eliminados")
+    .setDescription(
+      `Todos quedaron fuera tras intentos fallidos de adivinar la palabra.\nLa palabra era: **${word}**\n${fmtBoard(finalAscii)}`
+    )
+    .setColor(LOSE_COLOR)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
 const pull: ISlashCommand = {
   name: "ahorcado",
   category: "fun",
@@ -286,18 +318,31 @@ const pull: ISlashCommand = {
         vidas: LIVES,
       });
 
+      // Semantics: `turn` is the index of the player whose turn it is RIGHT
+      // NOW (the one we're waiting on). After a guess we advance to the next
+      // alive player. Decoupled from the library's internal turn tracker so
+      // we can skip eliminated players that the library doesn't know about.
       let turn = 0;
 
+      // Players knocked out by guessing the wrong full word. Their messages
+      // are ignored by the filter and turn rotation skips them.
+      const eliminated = new Set<string>();
+
+      const peekNextTurn = (from: number) => {
+        let idx = from;
+        do {
+          idx = rotate(idx, libUsernames.length - 1, 1);
+        } while (eliminated.has(libPlayerIds[idx]));
+        return idx;
+      };
+
       hangman.on("end", (game: any) => {
-        // The library hasn't rotated yet for the final player — undo our
-        // pre-rotation so libUsernames[turn] = the player who actually moved.
-        turn = rotate(turn, libUsernames.length - 1, -1);
         channel.send({
           embeds: [
             buildEndEmbed(
               game.winned,
               game.palabra,
-              libUsernames[turn],
+              libUsernames[turn], // the player who just moved
               game.ascii
             ),
           ],
@@ -314,46 +359,105 @@ const pull: ISlashCommand = {
           ),
         ],
       });
-      turn = rotate(turn, libUsernames.length - 1, 1);
 
       const collector = channel.createMessageCollector({
         filter: (msg) =>
-          msg.author.id === hangman.game.turno &&
+          msg.author.id === libPlayerIds[turn] &&
+          !eliminated.has(msg.author.id) &&
           /[A-Za-záéíóúñ]/.test(msg.content),
         idle: IDLE_TIMEOUT_MS,
       });
 
       collector.on("collect", (msg) => {
-        let found = false;
-        if (msg.content.length > 1 && word === msg.content.toLowerCase()) {
-          // Full-word guess — reveal every letter.
-          for (let i = 0; i < word.length; i++) {
-            if (!hangman.game.ascii.includes(word[i])) hangman.find(word[i]);
+        const text = msg.content.toLowerCase();
+        const isFullWord = text.length > 1;
+
+        // === Dedup: single-letter guesses already tried ===
+        // The library decrements vidas every time `find()` sees a letter that's
+        // already in letrasUsadas (covers both correct and incorrect repeats),
+        // so we have to short-circuit BEFORE calling find().
+        if (!isFullWord && hangman.game.letrasUsadas.includes(text)) {
+          channel.send({
+            embeds: [
+              buildSkipEmbed(msg.author.toString(), text, hangman.game.ascii),
+            ],
+          });
+          return; // No life lost, no turn rotation — same player keeps the turn.
+        }
+
+        // === Full-word guess ===
+        if (isFullWord) {
+          if (text === word) {
+            // Correct! Reveal every still-hidden letter.
+            for (let i = 0; i < word.length; i++) {
+              if (!hangman.game.ascii.includes(word[i])) hangman.find(word[i]);
+            }
+            // The win triggers 'end' inside find() via the embed handler.
+            if (hangman.game.ended) return collector.stop("end");
+          } else {
+            // Wrong full-word → eliminate this player (no life consumed; the
+            // word was wrong, but it's also a one-shot: they get knocked out).
+            eliminated.add(msg.author.id);
+            channel.send({
+              embeds: [
+                buildEliminationEmbed(
+                  msg.author.toString(),
+                  msg.content,
+                  hangman.game.ascii
+                ),
+              ],
+            });
+
+            const aliveUnique = new Set(
+              libPlayerIds.filter((id) => !eliminated.has(id))
+            );
+            if (aliveUnique.size === 0) {
+              channel.send({
+                embeds: [
+                  buildAllEliminatedEmbed(word, hangman.game.ascii),
+                ],
+              });
+              return collector.stop("everyone-eliminated");
+            }
+
+            // Someone still alive — rotate the turn (skipping eliminated)
+            // and prompt the next player.
+            const nextTurnIdx = peekNextTurn(turn);
+            channel.send({
+              embeds: [
+                buildTurnEmbed(
+                  hangman.game.ascii,
+                  libUsernames[nextTurnIdx],
+                  hangman.game.vidas,
+                  hangman.game.letrasIncorrectas,
+                  "",
+                  `${IMG_BASE}/${hangman.game.vidas}.png`
+                ),
+              ],
+            });
+            turn = nextTurnIdx;
+            return;
           }
         } else {
-          found = !!hangman.find(msg.content);
+          // === Single-letter guess ===
+          hangman.find(text);
+          if (hangman.game.ended) return collector.stop("end");
         }
 
-        if (hangman.game.ended) return collector.stop("end");
-
+        // Build the detail line for the next-turn embed.
         let detail = "";
-        if (!found) {
-          if (hangman.game.ascii.includes(msg.content)) {
-            detail = `- La letra "${msg.content}" ya se encuentra en la palabra.`;
-          } else {
-            detail =
-              msg.content.length > 1
-                ? `- Vaya, la palabra **${msg.content}** no es correcta.`
-                : `- Vaya, la letra **${msg.content}** no se encontraba en la palabra.`;
-          }
+        if (!isFullWord) {
+          detail = hangman.game.letrasIncorrectas.includes(text)
+            ? `- Vaya, la letra **${text}** no se encontraba en la palabra.`
+            : `- ¡La letra **${text}** está en la palabra!`;
         }
 
-        turn = rotate(turn, libUsernames.length - 1, 1);
+        const nextTurnIdx = peekNextTurn(turn);
         channel.send({
           embeds: [
             buildTurnEmbed(
               hangman.game.ascii,
-              libUsernames[turn],
+              libUsernames[nextTurnIdx],
               hangman.game.vidas,
               hangman.game.letrasIncorrectas,
               detail,
@@ -361,6 +465,7 @@ const pull: ISlashCommand = {
             ),
           ],
         });
+        turn = nextTurnIdx;
       });
 
       collector.on("end", async (_, reason) => {

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -214,7 +214,15 @@ const pull: ISlashCommand = {
           flags: MessageFlags.Ephemeral,
         });
       }
-      const usernames = users.map((u) => u.username);
+
+      // death-games' Hangman requires >= 2 player IDs. For solo play we
+      // duplicate the lone ID so the library is happy; the bot's collector
+      // filter (msg.author.id === game.turno) keeps matching the same user
+      // every round, so it plays as a real solo game.
+      const libPlayerIds = isSolo ? [playerIds[0], playerIds[0]] : playerIds;
+      const libUsernames = libPlayerIds.map(
+        (id) => users.find((u) => u.id === id)?.username ?? "?"
+      );
 
       let word = "hola";
       if (botPicks) {
@@ -273,7 +281,7 @@ const pull: ISlashCommand = {
       }
 
       const hangman = new Death.Hangman(word, {
-        jugadores: playerIds,
+        jugadores: libPlayerIds,
         lowerCase: true,
         vidas: LIVES,
       });
@@ -282,14 +290,14 @@ const pull: ISlashCommand = {
 
       hangman.on("end", (game: any) => {
         // The library hasn't rotated yet for the final player — undo our
-        // pre-rotation so usernames[turn] = the player who actually moved.
-        turn = rotate(turn, usernames.length - 1, -1);
+        // pre-rotation so libUsernames[turn] = the player who actually moved.
+        turn = rotate(turn, libUsernames.length - 1, -1);
         channel.send({
           embeds: [
             buildEndEmbed(
               game.winned,
               game.palabra,
-              usernames[turn],
+              libUsernames[turn],
               game.ascii
             ),
           ],
@@ -298,10 +306,15 @@ const pull: ISlashCommand = {
 
       await channel.send({
         embeds: [
-          buildKickoffEmbed(hangman.game.ascii, usernames[turn], isSolo, botPicks),
+          buildKickoffEmbed(
+            hangman.game.ascii,
+            libUsernames[turn],
+            isSolo,
+            botPicks
+          ),
         ],
       });
-      turn = rotate(turn, usernames.length - 1, 1);
+      turn = rotate(turn, libUsernames.length - 1, 1);
 
       const collector = channel.createMessageCollector({
         filter: (msg) =>
@@ -335,12 +348,12 @@ const pull: ISlashCommand = {
           }
         }
 
-        turn = rotate(turn, usernames.length - 1, 1);
+        turn = rotate(turn, libUsernames.length - 1, 1);
         channel.send({
           embeds: [
             buildTurnEmbed(
               hangman.game.ascii,
-              usernames[turn],
+              libUsernames[turn],
               hangman.game.vidas,
               hangman.game.letrasIncorrectas,
               detail,

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -1,22 +1,37 @@
 import {
   ActionRowBuilder,
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   ComponentType,
+  EmbedBuilder,
   MessageFlags,
   StringSelectMenuBuilder,
 } from "discord.js";
 import Death from "death-games";
+
 import _config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import words from "../../shared/data/words";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random, shuffle } from "../../shared/utils/helpers";
 
 const { photoRoot } = _config;
+
 const LIVES = 7;
 const IMG_BASE =
   "https://res.cloudinary.com/dnbgxu47a/image/upload/v1612912935/ahorcado";
+
+const WORD_PICK_TIMEOUT_MS = 20_000;
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+// Signal-carrying colors for end-state, same convention exception as /imc and /ruleta.
+const WIN_COLOR = 0x57f287; // discord green
+const LOSE_COLOR = 0xed4245; // mod red
 
 const rotate = (turn: number, last: number, step: number) => {
   let next = turn + step;
@@ -25,18 +40,90 @@ const rotate = (turn: number, last: number, step: number) => {
   return next;
 };
 
+const fmtBoard = (asciiTokens: string[]) =>
+  "```\n" + asciiTokens.join(" ") + "\n```";
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildKickoffEmbed = (
+  hangmanAscii: string[],
+  startingUsername: string,
+  isSolo: boolean,
+  botPicked: boolean
+) =>
+  baseEmbed()
+    .setTitle("🎯 Ahorcado")
+    .setDescription(
+      `${fmtBoard(hangmanAscii)}**Empieza ${startingUsername}**${
+        botPicked ? "\n_(palabra elegida por el bot)_" : ""
+      }${isSolo ? "\n_(jugando solo)_" : ""}`
+    );
+
+const buildTurnEmbed = (
+  hangmanAscii: string[],
+  nextUsername: string,
+  livesLeft: number,
+  wrongLetters: string[],
+  detail: string,
+  imageUrl: string
+) => {
+  const lines: string[] = [];
+  if (detail) lines.push(detail);
+  lines.push(fmtBoard(hangmanAscii));
+  lines.push(`**Turno de ${nextUsername}**`);
+  lines.push(`Intentos restantes: **${livesLeft}**`);
+  lines.push(
+    `Letras incorrectas: **[${wrongLetters.join(", ")}]**`
+  );
+
+  return baseEmbed()
+    .setTitle("🎯 Ahorcado")
+    .setDescription(lines.join("\n"))
+    .setImage(imageUrl);
+};
+
+const buildEndEmbed = (
+  won: boolean,
+  word: string,
+  finisherUsername: string,
+  finalAscii: string[]
+) => {
+  const text = won
+    ? `**¡Ganaron!** La palabra era: **${word}**\nDescubierto por: **${finisherUsername}**\n${fmtBoard(finalAscii)}`
+    : `**¡Perdieron!** La palabra era: **${word}**\nÚltimo error: **${finisherUsername}**\n${fmtBoard(finalAscii)}`;
+
+  const imageUrl = won
+    ? `${IMG_BASE}/${LIVES}.png`
+    : `${photoRoot}/hangman/${random(0, 2)}.gif`;
+
+  return new EmbedBuilder()
+    .setTitle(won ? "🏆 Ahorcado — Victoria" : "💀 Ahorcado — Derrota")
+    .setDescription(text)
+    .setColor(won ? WIN_COLOR : LOSE_COLOR)
+    .setImage(imageUrl)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildAbandonedEmbed = () =>
+  baseEmbed()
+    .setTitle("⌛ Ahorcado abandonado")
+    .setDescription("La partida se quedó sin movimientos por 5 minutos.");
+
 const pull: ISlashCommand = {
   name: "ahorcado",
   category: "fun",
   description:
-    "Ahorcado. Tú eliges la palabra (DM con menú) o el bot la elige (con bot_picks_word).",
+    "Ahorcado. Eliges la palabra (DM con menú) o el bot la elige (bot_picks_word).",
   ownerOnly: false,
   options: [
     {
       name: "player2",
-      description: "Segundo jugador (obligatorio)",
+      description: "Segundo jugador (opcional — sin esto juegas solo)",
       type: ApplicationCommandOptionType.User,
-      required: true,
+      required: false,
     },
     {
       name: "player3",
@@ -63,13 +150,21 @@ const pull: ISlashCommand = {
       required: false,
     },
   ],
+  examples: [
+    "/ahorcado bot_picks_word:true",
+    "/ahorcado player2:@bob",
+    "/ahorcado player2:@bob player3:@carla bot_picks_word:true",
+  ],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
+      if (
+        !interaction.channel?.isTextBased() ||
+        !interaction.channel.isSendable()
+      ) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
           flags: MessageFlags.Ephemeral,
@@ -88,6 +183,25 @@ const pull: ISlashCommand = {
         (args.find((a) => a.name === "bot_picks_word")?.value as
           | boolean
           | undefined) ?? false;
+      const isSolo = playerIds.length === 1;
+
+      // Solo play only makes sense if the bot picks the word — otherwise the
+      // single player would be guessing their own choice.
+      if (isSolo && !botPicks) {
+        return interaction.reply({
+          content:
+            "Para jugar solo necesitas que el bot elija la palabra. Usa `bot_picks_word:true`.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      // No duplicate players (catches both 'player2 == player3' and 'player2 == self').
+      if (new Set(playerIds).size !== playerIds.length) {
+        return interaction.reply({
+          content: "No puedes agregar al mismo jugador dos veces.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
       const users = await Promise.all(
         playerIds.map((id) => client.users.fetch(id))
@@ -104,7 +218,7 @@ const pull: ISlashCommand = {
       if (botPicks) {
         word = words[random(0, words.length - 1)].nombre.toLowerCase();
         await interaction.reply({
-          content: `Arrancando ahorcado — el bot eligió la palabra.`,
+          content: "Arrancando ahorcado — el bot eligió la palabra.",
         });
       } else {
         const actionRow =
@@ -126,20 +240,20 @@ const pull: ISlashCommand = {
         } catch {
           return interaction.reply({
             content:
-              "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word: true`.",
+              "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word:true`.",
             flags: MessageFlags.Ephemeral,
           });
         }
 
         await interaction.reply({
-          content: `Te envié un DM para elegir la palabra. Tienes 20s.`,
+          content: "Te envié un DM para elegir la palabra. Tienes 20s.",
         });
 
         try {
           const select = await dm.awaitMessageComponent({
             componentType: ComponentType.StringSelect,
-            time: 20000,
-            idle: 20000,
+            time: WORD_PICK_TIMEOUT_MS,
+            idle: WORD_PICK_TIMEOUT_MS,
             dispose: true,
             filter: (i) => i.user.id === interaction.user.id,
           });
@@ -165,57 +279,24 @@ const pull: ISlashCommand = {
       let turn = 0;
 
       hangman.on("end", (game: any) => {
+        // The library hasn't rotated yet for the final player — undo our
+        // pre-rotation so usernames[turn] = the player who actually moved.
         turn = rotate(turn, usernames.length - 1, -1);
-        let text = "";
-        let lives = 0;
-        if (game.winned) {
-          text =
-            "El juego ha finalizado! La palabra era: **" +
-            game.palabra +
-            "**\nDescubierto por: **" +
-            usernames[turn] +
-            "**```" +
-            game.ascii.join(" ") +
-            "```";
-          lives = LIVES;
-        } else {
-          text =
-            "Han perdido! La palabra era: **" +
-            game.palabra +
-            "**\nÚltimo error: **" +
-            usernames[turn] +
-            "**```\n" +
-            game.ascii.join(" ") +
-            "```";
-        }
         channel.send({
           embeds: [
-            {
-              color: 0x0099ff,
-              title: "Ahorcado",
-              description: text,
-              image: {
-                url: lives
-                  ? `${IMG_BASE}/${lives}.png`
-                  : `${photoRoot}/hangman/${random(0, 2)}.gif`,
-              },
-            },
+            buildEndEmbed(
+              game.winned,
+              game.palabra,
+              usernames[turn],
+              game.ascii
+            ),
           ],
         });
       });
 
       await channel.send({
         embeds: [
-          {
-            color: 0x0099ff,
-            title: "Ahorcado",
-            description:
-              "```\n" +
-              hangman.game.ascii.join(" ") +
-              "```**Empieza " +
-              usernames[turn] +
-              "**",
-          },
+          buildKickoffEmbed(hangman.game.ascii, usernames[turn], isSolo, botPicks),
         ],
       });
       turn = rotate(turn, usernames.length - 1, 1);
@@ -224,11 +305,13 @@ const pull: ISlashCommand = {
         filter: (msg) =>
           msg.author.id === hangman.game.turno &&
           /[A-Za-záéíóúñ]/.test(msg.content),
+        idle: IDLE_TIMEOUT_MS,
       });
 
       collector.on("collect", (msg) => {
         let found = false;
         if (msg.content.length > 1 && word === msg.content.toLowerCase()) {
+          // Full-word guess — reveal every letter.
           for (let i = 0; i < word.length; i++) {
             if (!hangman.game.ascii.includes(word[i])) hangman.find(word[i]);
           }
@@ -236,45 +319,41 @@ const pull: ISlashCommand = {
           found = !!hangman.find(msg.content);
         }
 
-        if (hangman.game.ended) return collector.stop();
+        if (hangman.game.ended) return collector.stop("end");
 
-        let details = "";
+        let detail = "";
         if (!found) {
           if (hangman.game.ascii.includes(msg.content)) {
-            details +=
-              '- La letra "' + msg.content + '" ya se encuentra en la palabra!';
+            detail = `- La letra "${msg.content}" ya se encuentra en la palabra.`;
           } else {
-            details += "- Vaya! Parece que la ";
-            details +=
+            detail =
               msg.content.length > 1
-                ? "palabra **" + msg.content + "** no es correcta!"
-                : "letra **" +
-                  msg.content +
-                  "** no se encontraba en la palabra!";
+                ? `- Vaya, la palabra **${msg.content}** no es correcta.`
+                : `- Vaya, la letra **${msg.content}** no se encontraba en la palabra.`;
           }
         }
-        details +=
-          "```\n" +
-          hangman.game.ascii.join(" ") +
-          "\n```**Turno de " +
-          usernames[turn] +
-          "**\nIntentos restantes: **" +
-          hangman.game.vidas +
-          "**\nLetras incorrectas: **[" +
-          hangman.game.letrasIncorrectas.join(", ") +
-          "]**";
 
         turn = rotate(turn, usernames.length - 1, 1);
         channel.send({
           embeds: [
-            {
-              color: 0x0099ff,
-              title: "Ahorcado",
-              description: details,
-              image: { url: `${IMG_BASE}/${hangman.game.vidas}.png` },
-            },
+            buildTurnEmbed(
+              hangman.game.ascii,
+              usernames[turn],
+              hangman.game.vidas,
+              hangman.game.letrasIncorrectas,
+              detail,
+              `${IMG_BASE}/${hangman.game.vidas}.png`
+            ),
           ],
         });
+      });
+
+      collector.on("end", async (_, reason) => {
+        // 'end' is our explicit stop in the win/lose branch; 'idle' is the
+        // 5-min silence guard.
+        if (reason === "idle") {
+          await channel.send({ embeds: [buildAbandonedEmbed()] });
+        }
       });
     } catch (error) {
       errorHandler(interaction, error);


### PR DESCRIPTION
## Summary
Octavo y último comando del facelift de **fun**. `/ahorcado` es el más complejo del bot (DM con StringSelectMenu para elegir palabra, collector con turnos, ascii art, GIF de derrota). Este PR aplica la convención de branding y agrega los mismos arreglos funcionales que hicimos en `/ruleta`.

## Branding
- Title `🎯 Ahorcado` (emoji distinto a `🔫` de ruleta)
- End title cambia a `🏆 Ahorcado — Victoria` o `💀 Ahorcado — Derrota`
- Color: **fun yellow** durante el juego, **verde** (#57F287) en victoria, **rojo mod** (#ED4245) en derrota — signal-carrying, misma excepción a la convención que `/imc` y `/ruleta`
- Footer `Xiza Bot vX.Y.Z` en todos los embeds
- Inline embed objects → `EmbedBuilder` + helpers extraídos

## Funcionales

| Fix | Cómo |
|---|---|
| `player2` ahora opcional (solo play) | Solo + `bot_picks_word:true` permitido. Solo + `false` rechazado (estarías adivinando tu propia palabra) |
| Validación duplicados | `new Set` check, mismo patrón que `/ruleta`. Cubre 'player2==player3' y 'player2==self' |
| **Collector colgado forever** 🐛 | Idle timeout 5 min → embed '⌛ Ahorcado abandonado' |
| `collector.stop('end')` explícito en win/lose | Para que el reason 'idle' quede limpio |

## Mantenido intacto
- DM flow para elegir palabra (StringSelectMenu, 20s timeout)
- ASCII art y GIFs de Cloudinary
- Lógica de letras/palabra completa (death-games library)
- Word list (`shared/data/words`)
- 7 vidas

## Test plan
- [x] `pnpm test` → 230/230 (was 226, +4 nuevos)
- [x] `tsc --noEmit` → limpio
- [ ] `/ahorcado bot_picks_word:true` (solo) → "jugando solo" en kickoff
- [ ] `/ahorcado` (sin args) → rechazo "necesitas bot_picks_word:true"
- [ ] `/ahorcado player2:@bob bot_picks_word:true` → flow normal
- [ ] `/ahorcado player2:@bob` (sin bot_picks) → DM con menú de 25 palabras, 20s
- [ ] DM timeout → "no eligió palabra a tiempo. Cancelado."
- [ ] Ganar la palabra → embed verde 🏆
- [ ] Perder todas las vidas → embed rojo 💀 con GIF
- [ ] Empezar partida y dejarla 5 min → embed "⌛ Abandonado"
- [ ] `/ahorcado player2:@bob player3:@bob bot_picks_word:true` → rechazo duplicado