### PR TITLE
feat(say): facelift — send-then-confirm ordering, cleaner copy

### DIFF
--- a/src/slashCommands/mod/say.test.ts
+++ b/src/slashCommands/mod/say.test.ts
@@ -5,18 +5,37 @@ import { arg, createMockClient, createMockInteraction } from "../../test-utils/d
 import say from "./say";
 
 describe("/say", () => {
-  it("relays the message as a plain channel send when as_embed is unset", async () => {
+  it("relays the message as a plain channel send when as_embed is unset, then confirms ephemerally", async () => {
     const interaction = createMockInteraction();
-    await say.run(createMockClient(), interaction, [arg("message", "hola mundo")]);
+    await say.run(createMockClient(), interaction, [
+      arg("message", "hola mundo"),
+    ]);
 
+    expect(interaction.channel.send).toHaveBeenCalledWith("hola mundo");
     expect(interaction.reply).toHaveBeenCalledWith({
-      content: "Listo.",
+      content: "✅ Mensaje enviado.",
       flags: MessageFlags.Ephemeral,
     });
-    expect(interaction.channel.send).toHaveBeenCalledWith("hola mundo");
   });
 
-  it("sends an embed when as_embed is true", async () => {
+  it("sends the channel message BEFORE the ephemeral reply (so reply can carry an error if send fails)", async () => {
+    const callOrder: string[] = [];
+    const interaction = createMockInteraction();
+    interaction.channel.send.mockImplementation(async () => {
+      callOrder.push("send");
+      return { id: "msg" };
+    });
+    interaction.reply.mockImplementation(async () => {
+      callOrder.push("reply");
+      return { id: "reply" };
+    });
+
+    await say.run(createMockClient(), interaction, [arg("message", "hola")]);
+
+    expect(callOrder).toEqual(["send", "reply"]);
+  });
+
+  it("sends a white-colored embed when as_embed is true (no brand footer — it's a moderator amplification, not a bot announcement)", async () => {
     const interaction = createMockInteraction();
     await say.run(createMockClient(), interaction, [
       arg("message", "hola"),
@@ -26,6 +45,10 @@ describe("/say", () => {
     expect(interaction.channel.send).toHaveBeenCalledOnce();
     const payload = (interaction.channel.send as any).mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    const embed = payload.embeds[0].data;
+    expect(embed.description).toBe("hola");
+    expect(embed.footer).toBeUndefined();
+    expect(embed.author).toBeUndefined();
   });
 
   it("rejects with an ephemeral notice when the member lacks ManageMessages", async () => {

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -1,34 +1,39 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
 const pull: ISlashCommand = {
   name: "say",
   category: "mod",
-  description: "Xiza Bot repite lo que dices",
+  description: "Repite un mensaje en el canal",
   ownerOnly: false,
   defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [
     {
       name: "message",
-      description: "Texto a repetir",
+      description: "Texto a publicar",
       type: ApplicationCommandOptionType.String,
       required: true,
     },
     {
       name: "as_embed",
-      description: "Mandarlo como embed",
+      description: "Publicar como embed (default: false)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
+  ],
+  examples: [
+    "/say message:hola a todos",
+    "/say message:Anuncio importante as_embed:true",
   ],
   run: async (
     _: ClientDiscord,
@@ -58,16 +63,22 @@ const pull: ISlashCommand = {
       const asEmbed =
         (args.find((a) => a.name === "as_embed")?.value as boolean) ?? false;
 
-      await interaction.reply({ content: "Listo.", flags: MessageFlags.Ephemeral });
-
+      // IMPORTANT: send first, confirm second. If channel.send fails (eg. bot
+      // missing Send permission), the catch fires and errorHandler can still
+      // reply because we haven't replied yet.
       if (asEmbed) {
-        const embed = new EmbedBuilder()
-          .setDescription(text)
-          .setColor("White");
+        // White color and no footer — the embed is meant to look like a
+        // moderator-amplified message, not a bot-branded announcement.
+        const embed = new EmbedBuilder().setDescription(text).setColor("White");
         await interaction.channel.send({ embeds: [embed] });
       } else {
         await interaction.channel.send(text);
       }
+
+      return interaction.reply({
+        content: "✅ Mensaje enviado.",
+        flags: MessageFlags.Ephemeral,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }


### PR DESCRIPTION
## Summary
Primer comando del facelift de **mod** (1/6). `/say` ya andaba bien funcionalmente; este PR aplica un fix de ordering relevante y limpia los strings.

## Cambios

### Behavior fix
`channel.send` ahora se ejecuta **antes** del `interaction.reply` de confirmación. Si el bot no tiene permiso `Send Messages` en el canal y `channel.send` falla, el catch dispara y `errorHandler` puede responder porque la interaction aún no fue replied. La versión anterior respondía 'Listo.' primero y dejaba al usuario sin saber que el mensaje nunca se publicó.

### Cosmético
- description: \`Xiza Bot repite lo que dices\` → \`Repite un mensaje en el canal\`
- options descriptions más claras
- confirmation: \`Listo.\` → \`✅ Mensaje enviado.\`
- examples agregados

### Branding decision (no aplico el footer)
El embed cuando \`as_embed:true\` mantiene **white color y sin footer Xiza Bot**. La convención de branding aplica a embeds de voz-del-bot; \`/say\` está amplificando un mensaje del moderador y debe leerse como tal, no como anuncio del bot.

## Test plan
- [x] \`pnpm test\` → 232/232 (was 231, +1 nuevo: send-before-reply ordering)
- [x] \`tsc --noEmit\` → limpio
- [ ] \`/say message:hola\` → mensaje plain en el canal + ephemeral '✅ Mensaje enviado.'
- [ ] \`/say message:hola as_embed:true\` → embed blanco con el texto, sin firma
- [ ] Sin perm ManageMessages → notice ephemeral