### PR TITLE
feat(mod): facelift /clear, /who, /register — branding + bug fixes

### DIFF
--- a/src/events/message/messageDelete.test.ts
+++ b/src/events/message/messageDelete.test.ts
@@ -82,11 +82,11 @@ describe("messageDelete", () => {
     const payload = send.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
     const embed = payload.embeds[0].data;
-    expect(embed.title).toBe("🗑️ Mensaje eliminado");
+    expect(embed.title).toBeUndefined();
     expect(embed.description).toBe("test message");
     expect(embed.color).toBe(0xed4245); // mod red
     expect(embed.author.name).toBe("Diego");
-    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.footer.text).toMatch(/🗑️ Eliminado · Xiza Bot v\d+/);
   });
 
   it("DMs the owner with the file attached AND the same branded embed when the deleted message had an image", async () => {
@@ -104,7 +104,7 @@ describe("messageDelete", () => {
     expect(payload.files).toEqual(["https://example.com/img.png"]);
     // Embed shape consistent with the text-only case
     const embed = payload.embeds[0].data;
-    expect(embed.title).toBe("🗑️ Mensaje eliminado");
+    expect(embed.title).toBeUndefined();
     expect(embed.description).toBe("look at this");
     expect(embed.color).toBe(0xed4245);
   });

--- a/src/events/message/messageDelete.test.ts
+++ b/src/events/message/messageDelete.test.ts
@@ -86,7 +86,7 @@ describe("messageDelete", () => {
     expect(embed.description).toBe("test message");
     expect(embed.color).toBe(0xed4245); // mod red
     expect(embed.author.name).toBe("Diego");
-    expect(embed.footer.text).toMatch(/🗑️ Eliminado · Xiza Bot v\d+/);
+    expect(embed.footer.text).toBe("🗑️ Eliminado");
   });
 
   it("DMs the owner with the file attached AND the same branded embed when the deleted message had an image", async () => {

--- a/src/events/message/messageDelete.test.ts
+++ b/src/events/message/messageDelete.test.ts
@@ -28,9 +28,7 @@ const ownerMock = (overrides: Record<string, any> = {}) => {
   return {
     client: createMockClient({
       users: {
-        fetch: vi
-          .fn()
-          .mockResolvedValue({ send, ...overrides }),
+        fetch: vi.fn().mockResolvedValue({ send, ...overrides }),
       },
     }),
     send,
@@ -55,7 +53,10 @@ describe("messageDelete", () => {
 
   it("ignores messages with no content and no attachment", async () => {
     const { client, send } = ownerMock();
-    const message = createMessage({ content: "", attachments: { at: () => undefined } });
+    const message = createMessage({
+      content: "",
+      attachments: { at: () => undefined },
+    });
 
     await messageDelete.execute(message as any, client);
 
@@ -71,7 +72,7 @@ describe("messageDelete", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("DMs the owner with a content embed for a regular text message", async () => {
+  it("DMs the owner with a branded embed for a regular text message", async () => {
     const { client, send } = ownerMock();
     const message = createMessage({ content: "test message" });
 
@@ -80,9 +81,35 @@ describe("messageDelete", () => {
     expect(send).toHaveBeenCalledOnce();
     const payload = send.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    const embed = payload.embeds[0].data;
+    expect(embed.title).toBe("🗑️ Mensaje eliminado");
+    expect(embed.description).toBe("test message");
+    expect(embed.color).toBe(0xed4245); // mod red
+    expect(embed.author.name).toBe("Diego");
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
   });
 
-  it("DMs the owner with the file attached when the deleted message had an image", async () => {
+  it("DMs the owner with the file attached AND the same branded embed when the deleted message had an image", async () => {
+    const { client, send } = ownerMock();
+    const message = createMessage({
+      content: "look at this",
+      attachments: { at: () => ({ url: "https://example.com/img.png" }) },
+    });
+
+    await messageDelete.execute(message as any, client);
+
+    expect(send).toHaveBeenCalledOnce();
+    const payload = send.mock.calls[0][0];
+    // Re-uploads the URL as a fresh file so it survives the source delete
+    expect(payload.files).toEqual(["https://example.com/img.png"]);
+    // Embed shape consistent with the text-only case
+    const embed = payload.embeds[0].data;
+    expect(embed.title).toBe("🗑️ Mensaje eliminado");
+    expect(embed.description).toBe("look at this");
+    expect(embed.color).toBe(0xed4245);
+  });
+
+  it("when the deleted message had ONLY an image (no text), the embed has no description", async () => {
     const { client, send } = ownerMock();
     const message = createMessage({
       content: "",
@@ -91,8 +118,20 @@ describe("messageDelete", () => {
 
     await messageDelete.execute(message as any, client);
 
-    expect(send).toHaveBeenCalledOnce();
     const payload = send.mock.calls[0][0];
     expect(payload.files).toEqual(["https://example.com/img.png"]);
+    expect(payload.embeds[0].data.description).toBeUndefined();
+  });
+
+  it("truncates very long messages to fit the embed description budget", async () => {
+    const { client, send } = ownerMock();
+    const longContent = "x".repeat(5000);
+    const message = createMessage({ content: longContent });
+
+    await messageDelete.execute(message as any, client);
+
+    const desc = send.mock.calls[0][0].embeds[0].data.description;
+    expect(desc.length).toBeLessThanOrEqual(4001);
+    expect(desc.endsWith("…")).toBe(true);
   });
 });

--- a/src/events/message/messageDelete.ts
+++ b/src/events/message/messageDelete.ts
@@ -1,67 +1,57 @@
 import { EmbedBuilder, Message } from "discord.js";
+
 import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+} from "../../shared/constants/branding";
+
+const DELETE_COLOR = 0xed4245; // mod red — signal of removal
+const MAX_DESCRIPTION = 4000;
 
 export default {
   name: "messageDelete",
   type: "message",
-  // just work on the first message update, and just in gmi2 channel
+  /**
+   * Fires for individual message deletions. discord.js emits this event for
+   * every cached message in a bulkDelete too, so /clear's recap code skips
+   * the single-text-only case to avoid duplicating what this listener already
+   * sends.
+   */
   async execute(message: Message, client: ClientDiscord) {
-    if (message?.author?.bot) {
-      console.log("is bot");
+    if (message?.author?.bot) return;
 
-      return;
-    }
+    const attachmentUrl = message?.attachments?.at(0)?.url;
+    if (!message?.content && !attachmentUrl) return;
+    if (message?.channel?.id !== config.gmi2Channel) return;
 
-    if (!message?.content && !message?.attachments?.at(0)?.url) {
-      console.log("no content");
+    const trimmedContent = message.content
+      ? message.content.slice(0, MAX_DESCRIPTION) +
+        (message.content.length > MAX_DESCRIPTION ? "…" : "")
+      : "";
 
-      return;
-    }
+    const owner = await client.users.fetch(config.ownerId, { cache: false });
 
-    if (message?.channel?.id !== config.gmi2Channel) {
-      console.log("not gmi2 channel");
-
-      return;
-    }
-
-    const count = 4096;
-
-    const deletedMesaage =
-      message.content?.slice(0, count) +
-      (message.content?.length > count ? "..." : "") +
-      (message.attachments?.at(0)?.url
-        ? `\n${message.attachments?.at(0)?.url}`
-        : "");
-
-    const image = message.attachments?.at(0)?.url;
-
-    const user = await client.users.fetch(config.ownerId, {
-      cache: false,
-    });
-
-    if (image) {
-      await user.send({
-        content: `**${message.author.username}** ha borrado un mensaje con un imagen.`,
-        files: [image],
-      });
-
-      return;
-    }
-
-    const attachmentUrl = message.attachments?.at(0)?.url;
-    const log = new EmbedBuilder({
-      author: {
+    const embed = new EmbedBuilder()
+      .setTitle("🗑️ Mensaje eliminado")
+      .setAuthor({
         name: message.author.username || message.author.tag,
         iconURL: message.author.displayAvatarURL(),
-      },
-      description: deletedMesaage,
-      timestamp: new Date().toISOString(),
-      ...(attachmentUrl && {
-        image: { url: attachmentUrl },
-      }),
-    }).setColor("Red");
+      })
+      .setColor(DELETE_COLOR)
+      .setTimestamp(new Date())
+      .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
-    await user.send({ embeds: [log] });
+    if (trimmedContent) embed.setDescription(trimmedContent);
+
+    // Re-upload the attachment as a fresh file (not just the URL) so it
+    // survives Discord dropping the deleted-message CDN URL.
+    if (attachmentUrl) {
+      await owner.send({ embeds: [embed], files: [attachmentUrl] });
+      return;
+    }
+
+    await owner.send({ embeds: [embed] });
   },
 };

--- a/src/events/message/messageDelete.ts
+++ b/src/events/message/messageDelete.ts
@@ -2,11 +2,6 @@ import { EmbedBuilder, Message } from "discord.js";
 
 import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import {
-  BOT_BRAND_NAME,
-  BOT_VERSION,
-} from "../../shared/constants/branding";
-
 const DELETE_COLOR = 0xed4245; // mod red — signal of removal
 const MAX_DESCRIPTION = 4000;
 
@@ -44,7 +39,9 @@ export default {
       })
       .setColor(DELETE_COLOR)
       .setTimestamp(message.createdTimestamp ?? new Date())
-      .setFooter({ text: `🗑️ Eliminado · ${BOT_BRAND_NAME} ${BOT_VERSION}` });
+      // Footer-only hint (no brand) so the embed reads as the message itself,
+      // not as a Xiza-Bot announcement of a deletion.
+      .setFooter({ text: "🗑️ Eliminado" });
 
     if (trimmedContent) embed.setDescription(trimmedContent);
 

--- a/src/events/message/messageDelete.ts
+++ b/src/events/message/messageDelete.ts
@@ -33,15 +33,18 @@ export default {
 
     const owner = await client.users.fetch(config.ownerId, { cache: false });
 
+    // Layout choice: no title up top so the embed reads like the original
+    // message preserved (avatar + name + content + timestamp). The 'deleted'
+    // hint goes in the footer alongside the brand, so the visual illusion of
+    // 'this is the message' isn't broken at first glance.
     const embed = new EmbedBuilder()
-      .setTitle("🗑️ Mensaje eliminado")
       .setAuthor({
         name: message.author.username || message.author.tag,
         iconURL: message.author.displayAvatarURL(),
       })
       .setColor(DELETE_COLOR)
-      .setTimestamp(new Date())
-      .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+      .setTimestamp(message.createdTimestamp ?? new Date())
+      .setFooter({ text: `🗑️ Eliminado · ${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
     if (trimmedContent) embed.setDescription(trimmedContent);
 

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -1,4 +1,4 @@
-import { MessageFlags } from "discord.js";
+import { Collection, MessageFlags } from "discord.js";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -8,12 +8,35 @@ import {
 } from "../../test-utils/discord-mocks";
 import clear from "./clear";
 
+const fakeMessage = (overrides: Partial<any> = {}) =>
+  ({
+    content: "hola",
+    author: { username: "tester" },
+    createdTimestamp: Date.now(),
+    attachments: new Collection<string, any>(),
+    ...overrides,
+  }) as any;
+
+const fakeBulkDeleteResult = (messages: any[]) => {
+  const col = new Collection<string, any>();
+  messages.forEach((m, i) => col.set(`msg-${i}`, m));
+  return col;
+};
+
 describe("/clear", () => {
-  it("bulk-deletes the requested amount, replies ephemerally with the count, and posts a public auto-deleting notice", async () => {
+  it("replies ephemerally with a recap embed listing each deleted message, then posts a public auto-deleting count notice", async () => {
     vi.useFakeTimers();
     const noticeDelete = vi.fn().mockResolvedValue(undefined);
     const send = vi.fn().mockResolvedValue({ delete: noticeDelete });
-    const bulkDelete = vi.fn().mockResolvedValue({ size: 4 });
+    const messages = [
+      fakeMessage({ content: "hola", author: { username: "ana" } }),
+      fakeMessage({ content: "qué onda", author: { username: "bob" } }),
+      fakeMessage({ content: "te leí", author: { username: "ana" } }),
+      fakeMessage({ content: "🥲", author: { username: "carla" } }),
+    ];
+    const bulkDelete = vi
+      .fn()
+      .mockResolvedValue(fakeBulkDeleteResult(messages));
     const interaction = createMockInteraction({
       channel: { isSendable: () => true, send, bulkDelete },
     });
@@ -22,29 +45,35 @@ describe("/clear", () => {
 
     expect(bulkDelete).toHaveBeenCalledWith(4, true);
 
-    // Ephemeral reply with branded embed
+    // Ephemeral recap reply to the moderator
     const replyPayload = interaction.reply.mock.calls[0][0];
     expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
-    expect(replyPayload.embeds[0].data.title).toBe("🧹 Chat limpiado");
-    expect(replyPayload.embeds[0].data.description).toContain("4");
+    expect(replyPayload.allowedMentions).toEqual({ parse: [] });
+    const recap = replyPayload.embeds[0].data;
+    expect(recap.title).toBe("📋 Eliminados (4)");
+    expect(recap.description).toContain("ana");
+    expect(recap.description).toContain("bob");
+    expect(recap.description).toContain("carla");
 
-    // Public notice posted to channel
+    // Public count notice posted to the channel
     expect(send).toHaveBeenCalledOnce();
     const sentEmbed = send.mock.calls[0][0].embeds[0].data;
     expect(sentEmbed.title).toBe("🧹 Chat limpiado");
     expect(sentEmbed.color).toBe(0xed4245); // mod red
     expect(sentEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
 
-    // After 5s, the public notice deletes itself
+    // After 5s the public notice deletes itself
     await vi.advanceTimersByTimeAsync(5_000);
     expect(noticeDelete).toHaveBeenCalled();
 
     vi.useRealTimers();
   });
 
-  it("uses singular phrasing for a 1-message delete", async () => {
+  it("public count notice uses singular phrasing for a 1-message delete", async () => {
     const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
-    const bulkDelete = vi.fn().mockResolvedValue({ size: 1 });
+    const bulkDelete = vi
+      .fn()
+      .mockResolvedValue(fakeBulkDeleteResult([fakeMessage()]));
     const interaction = createMockInteraction({
       channel: { isSendable: () => true, send, bulkDelete },
     });
@@ -52,8 +81,58 @@ describe("/clear", () => {
     await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
 
     const description = send.mock.calls[0][0].embeds[0].data.description;
-    // Singular: '... **1** mensaje.' — no trailing 's' on 'mensaje'
     expect(description).toMatch(/\*\*1\*\*\s+mensaje\.$/);
+  });
+
+  it("re-uploads image attachments as files (not URLs) so the recap survives the source delete", async () => {
+    const fakeAttachment = {
+      url: "https://cdn.discordapp.com/example.png",
+      name: "example.png",
+    };
+    const att = new Collection<string, any>([["att-1", fakeAttachment]]);
+    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
+    const bulkDelete = vi.fn().mockResolvedValue(
+      fakeBulkDeleteResult([
+        fakeMessage({ content: "look at this", attachments: att }),
+      ])
+    );
+    const interaction = createMockInteraction({
+      channel: { isSendable: () => true, send, bulkDelete },
+    });
+
+    // Mock global fetch to return a tiny buffer
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
+      })
+    );
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    const replyPayload = interaction.reply.mock.calls[0][0];
+    expect(replyPayload.files).toHaveLength(1);
+    expect(replyPayload.files[0].name).toBe("example.png");
+    expect(Buffer.isBuffer(replyPayload.files[0].attachment)).toBe(true);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to a friendly empty embed when bulkDelete returns 0 messages", async () => {
+    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
+    const bulkDelete = vi.fn().mockResolvedValue(fakeBulkDeleteResult([]));
+    const interaction = createMockInteraction({
+      channel: { isSendable: () => true, send, bulkDelete },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.embeds[0].data.title).toBe("🧹 Nada para limpiar");
+    // No public notice when nothing got deleted
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("rejects ephemerally when the member lacks ManageMessages", async () => {

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -24,7 +24,7 @@ const fakeBulkDeleteResult = (messages: any[]) => {
 };
 
 describe("/clear", () => {
-  it("replies ephemerally with a recap embed listing each deleted message, then posts a public auto-deleting count notice", async () => {
+  it("DMs the recap to the invoker, replies with a brief ephemeral confirmation, and posts a public auto-deleting count notice", async () => {
     vi.useFakeTimers();
     const noticeDelete = vi.fn().mockResolvedValue(undefined);
     const send = vi.fn().mockResolvedValue({ delete: noticeDelete });
@@ -37,29 +37,41 @@ describe("/clear", () => {
     const bulkDelete = vi
       .fn()
       .mockResolvedValue(fakeBulkDeleteResult(messages));
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
     const interaction = createMockInteraction({
       channel: { isSendable: () => true, send, bulkDelete },
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
+      },
     });
 
     await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
 
     expect(bulkDelete).toHaveBeenCalledWith(4, true);
 
-    // Ephemeral recap reply to the moderator
-    const replyPayload = interaction.reply.mock.calls[0][0];
-    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
-    expect(replyPayload.allowedMentions).toEqual({ parse: [] });
-    const recap = replyPayload.embeds[0].data;
+    // Recap delivered via DM, NOT in the channel and NOT in the ephemeral reply
+    expect(interaction.user.createDM).toHaveBeenCalledOnce();
+    expect(dmSend).toHaveBeenCalledOnce();
+    const dmPayload = dmSend.mock.calls[0][0];
+    expect(dmPayload.allowedMentions).toEqual({ parse: [] });
+    const recap = dmPayload.embeds[0].data;
     expect(recap.title).toBe("📋 Eliminados (4)");
     expect(recap.description).toContain("ana");
     expect(recap.description).toContain("bob");
     expect(recap.description).toContain("carla");
 
+    // Brief ephemeral confirmation (no embed — the data went to DM)
+    const replyPayload = interaction.reply.mock.calls[0][0];
+    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
+    expect(replyPayload.content).toContain("DM");
+    expect(replyPayload.embeds).toBeUndefined();
+
     // Public count notice posted to the channel
     expect(send).toHaveBeenCalledOnce();
     const sentEmbed = send.mock.calls[0][0].embeds[0].data;
     expect(sentEmbed.title).toBe("🧹 Chat limpiado");
-    expect(sentEmbed.color).toBe(0xed4245); // mod red
+    expect(sentEmbed.color).toBe(0xed4245);
     expect(sentEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
 
     // After 5s the public notice deletes itself
@@ -67,6 +79,30 @@ describe("/clear", () => {
     expect(noticeDelete).toHaveBeenCalled();
 
     vi.useRealTimers();
+  });
+
+  it("falls back to ephemeral recap when the moderator's DMs are disabled", async () => {
+    const noticeDelete = vi.fn().mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue({ delete: noticeDelete });
+    const bulkDelete = vi
+      .fn()
+      .mockResolvedValue(fakeBulkDeleteResult([fakeMessage()]));
+    const interaction = createMockInteraction({
+      channel: { isSendable: () => true, send, bulkDelete },
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockRejectedValue(new Error("DMs blocked")),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    const replyPayload = interaction.reply.mock.calls[0][0];
+    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
+    expect(replyPayload.content).toContain("DM");
+    // Recap embed shown inline as fallback
+    expect(replyPayload.embeds).toBeDefined();
+    expect(replyPayload.embeds[0].data.title).toBe("📋 Eliminados (1)");
   });
 
   it("public count notice uses singular phrasing for a 1-message delete", async () => {
@@ -84,7 +120,7 @@ describe("/clear", () => {
     expect(description).toMatch(/\*\*1\*\*\s+mensaje\.$/);
   });
 
-  it("re-uploads image attachments as files (not URLs) so the recap survives the source delete", async () => {
+  it("re-uploads image attachments as files in the DM recap (not URLs) so they survive the source delete", async () => {
     const fakeAttachment = {
       url: "https://cdn.discordapp.com/example.png",
       name: "example.png",
@@ -96,11 +132,15 @@ describe("/clear", () => {
         fakeMessage({ content: "look at this", attachments: att }),
       ])
     );
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
     const interaction = createMockInteraction({
       channel: { isSendable: () => true, send, bulkDelete },
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
+      },
     });
 
-    // Mock global fetch to return a tiny buffer
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -111,10 +151,10 @@ describe("/clear", () => {
 
     await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
 
-    const replyPayload = interaction.reply.mock.calls[0][0];
-    expect(replyPayload.files).toHaveLength(1);
-    expect(replyPayload.files[0].name).toBe("example.png");
-    expect(Buffer.isBuffer(replyPayload.files[0].attachment)).toBe(true);
+    const dmPayload = dmSend.mock.calls[0][0];
+    expect(dmPayload.files).toHaveLength(1);
+    expect(dmPayload.files[0].name).toBe("example.png");
+    expect(Buffer.isBuffer(dmPayload.files[0].attachment)).toBe(true);
 
     vi.unstubAllGlobals();
   });

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -1,5 +1,5 @@
 import { Collection, MessageFlags } from "discord.js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   arg,
@@ -8,87 +8,181 @@ import {
 } from "../../test-utils/discord-mocks";
 import clear from "./clear";
 
-const fakeMessage = (overrides: Partial<any> = {}) =>
-  ({
+const fakeMessage = (overrides: Partial<any> = {}) => {
+  const id = overrides.id ?? `msg-${Math.random().toString(36).slice(2)}`;
+  return {
+    id,
     content: "hola",
     author: { username: "tester" },
     createdTimestamp: Date.now(),
     attachments: new Collection<string, any>(),
     ...overrides,
-  }) as any;
+  } as any;
+};
 
-const fakeBulkDeleteResult = (messages: any[]) => {
+const fakeFetchResult = (messages: any[]) => {
+  // Discord returns newest-first; test fixtures pass them oldest-first for
+  // readability, so reverse to mimic real API order.
   const col = new Collection<string, any>();
-  messages.forEach((m, i) => col.set(`msg-${i}`, m));
+  [...messages].reverse().forEach((m) => col.set(m.id, m));
   return col;
 };
 
+const fakeBulkResult = (messages: any[]) => {
+  const col = new Collection<string, any>();
+  messages.forEach((m) => col.set(m.id, m));
+  return col;
+};
+
+const setupChannel = (messages: any[], opts: { send?: any } = {}) => {
+  const send = opts.send ?? vi.fn().mockResolvedValue({ delete: vi.fn() });
+  const fetch = vi.fn().mockResolvedValue(fakeFetchResult(messages));
+  const bulkDelete = vi.fn().mockResolvedValue(fakeBulkResult(messages));
+  return {
+    channel: {
+      isSendable: () => true,
+      send,
+      messages: { fetch },
+      bulkDelete,
+    },
+    send,
+    fetch,
+    bulkDelete,
+  };
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
 describe("/clear", () => {
-  it("DMs the recap to the invoker, replies with a brief ephemeral confirmation, and posts a public auto-deleting count notice", async () => {
+  it("defers, downloads attachments BEFORE bulkDelete, then DMs the recap and posts the public count", async () => {
     vi.useFakeTimers();
-    const noticeDelete = vi.fn().mockResolvedValue(undefined);
-    const send = vi.fn().mockResolvedValue({ delete: noticeDelete });
     const messages = [
-      fakeMessage({ content: "hola", author: { username: "ana" } }),
-      fakeMessage({ content: "qué onda", author: { username: "bob" } }),
-      fakeMessage({ content: "te leí", author: { username: "ana" } }),
-      fakeMessage({ content: "🥲", author: { username: "carla" } }),
+      fakeMessage({
+        id: "m1",
+        content: "hola",
+        author: { username: "ana" },
+      }),
+      fakeMessage({
+        id: "m2",
+        content: "qué onda",
+        author: { username: "bob" },
+      }),
+      fakeMessage({
+        id: "m3",
+        content: "🥲",
+        author: { username: "carla" },
+      }),
     ];
-    const bulkDelete = vi
-      .fn()
-      .mockResolvedValue(fakeBulkDeleteResult(messages));
+    const { channel, send, fetch, bulkDelete } = setupChannel(messages);
+
     const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
     const interaction = createMockInteraction({
-      channel: { isSendable: () => true, send, bulkDelete },
+      channel,
       user: {
         id: "mod-1",
         createDM: vi.fn().mockResolvedValue({ send: dmSend }),
       },
     });
 
-    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
+    await clear.run(createMockClient(), interaction, [arg("amount", 3)]);
 
-    expect(bulkDelete).toHaveBeenCalledWith(4, true);
+    // 1. Defers immediately so we don't hit the 3s 'Unknown interaction' timeout
+    expect(interaction.deferReply).toHaveBeenCalledOnce();
 
-    // Recap delivered via DM, NOT in the channel and NOT in the ephemeral reply
-    expect(interaction.user.createDM).toHaveBeenCalledOnce();
+    // 2. Fetches messages BEFORE deleting (so CDN URLs are still valid)
+    expect(fetch).toHaveBeenCalledWith({ limit: 3 });
+
+    // 3. bulkDelete is called by ID array, in chronological order
+    const deleteCall = bulkDelete.mock.calls[0];
+    expect(deleteCall[0]).toEqual(["m1", "m2", "m3"]);
+    expect(deleteCall[1]).toBe(true);
+
+    // 4. Recap delivered via DM (with all 3 messages)
     expect(dmSend).toHaveBeenCalledOnce();
     const dmPayload = dmSend.mock.calls[0][0];
-    expect(dmPayload.allowedMentions).toEqual({ parse: [] });
     const recap = dmPayload.embeds[0].data;
-    expect(recap.title).toBe("📋 Eliminados (4)");
+    expect(recap.title).toBe("📋 Eliminados (3)");
     expect(recap.description).toContain("ana");
     expect(recap.description).toContain("bob");
     expect(recap.description).toContain("carla");
+    expect(dmPayload.allowedMentions).toEqual({ parse: [] });
 
-    // Brief ephemeral confirmation (no embed — the data went to DM)
-    const replyPayload = interaction.reply.mock.calls[0][0];
-    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
-    expect(replyPayload.content).toContain("DM");
-    expect(replyPayload.embeds).toBeUndefined();
-
-    // Public count notice posted to the channel
+    // 5. Public count notice posted in channel
     expect(send).toHaveBeenCalledOnce();
-    const sentEmbed = send.mock.calls[0][0].embeds[0].data;
-    expect(sentEmbed.title).toBe("🧹 Chat limpiado");
-    expect(sentEmbed.color).toBe(0xed4245);
-    expect(sentEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
+    const noticeEmbed = send.mock.calls[0][0].embeds[0].data;
+    expect(noticeEmbed.title).toBe("🧹 Chat limpiado");
+    expect(noticeEmbed.description).toContain("3");
 
-    // After 5s the public notice deletes itself
-    await vi.advanceTimersByTimeAsync(5_000);
-    expect(noticeDelete).toHaveBeenCalled();
-
-    vi.useRealTimers();
+    // 6. Happy-path: deleteReply removes the deferred ephemeral
+    expect(interaction.deleteReply).toHaveBeenCalledOnce();
+    // No editReply — the deferred reply was simply deleted, not filled
+    expect(interaction.editReply).not.toHaveBeenCalled();
   });
 
-  it("falls back to ephemeral recap when the moderator's DMs are disabled", async () => {
-    const noticeDelete = vi.fn().mockResolvedValue(undefined);
-    const send = vi.fn().mockResolvedValue({ delete: noticeDelete });
-    const bulkDelete = vi
-      .fn()
-      .mockResolvedValue(fakeBulkDeleteResult([fakeMessage()]));
+  it("downloads attachments via fetch BEFORE bulkDelete and re-uploads them as files in the DM", async () => {
+    const att = new Collection<string, any>([
+      [
+        "a1",
+        {
+          url: "https://cdn.discordapp.com/example.png",
+          name: "example.png",
+        },
+      ],
+    ]);
+    const messages = [
+      fakeMessage({
+        id: "m1",
+        content: "look",
+        attachments: att,
+      }),
+    ];
+    const { channel, bulkDelete } = setupChannel(messages);
+
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
     const interaction = createMockInteraction({
-      channel: { isSendable: () => true, send, bulkDelete },
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
+      },
+    });
+
+    // Track call order: fetch must complete before bulkDelete is called.
+    const callOrder: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => {
+        callOrder.push("attachment-fetch");
+        return {
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
+        };
+      })
+    );
+    bulkDelete.mockImplementation(async (ids: any) => {
+      callOrder.push("bulk-delete");
+      return fakeBulkResult(messages);
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    expect(callOrder).toEqual(["attachment-fetch", "bulk-delete"]);
+
+    const dmPayload = dmSend.mock.calls[0][0];
+    expect(dmPayload.files).toHaveLength(1);
+    expect(dmPayload.files[0].name).toBe("example.png");
+    expect(Buffer.isBuffer(dmPayload.files[0].attachment)).toBe(true);
+  });
+
+  it("falls back to inline ephemeral when DMs are disabled", async () => {
+    const messages = [fakeMessage({ id: "m1" })];
+    const { channel } = setupChannel(messages);
+
+    const interaction = createMockInteraction({
+      channel,
       user: {
         id: "mod-1",
         createDM: vi.fn().mockRejectedValue(new Error("DMs blocked")),
@@ -97,85 +191,15 @@ describe("/clear", () => {
 
     await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
 
-    const replyPayload = interaction.reply.mock.calls[0][0];
-    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
-    expect(replyPayload.content).toContain("DM");
-    // Recap embed shown inline as fallback
-    expect(replyPayload.embeds).toBeDefined();
-    expect(replyPayload.embeds[0].data.title).toBe("📋 Eliminados (1)");
+    // The deferReply gets edited (not deleted) so the moderator still sees the recap
+    expect(interaction.deleteReply).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
+    expect(payload.content).toContain("DM");
+    expect(payload.embeds[0].data.title).toBe("📋 Eliminados (1)");
   });
 
-  it("public count notice uses singular phrasing for a 1-message delete", async () => {
-    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
-    const bulkDelete = vi
-      .fn()
-      .mockResolvedValue(fakeBulkDeleteResult([fakeMessage()]));
-    const interaction = createMockInteraction({
-      channel: { isSendable: () => true, send, bulkDelete },
-    });
-
-    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
-
-    const description = send.mock.calls[0][0].embeds[0].data.description;
-    expect(description).toMatch(/\*\*1\*\*\s+mensaje\.$/);
-  });
-
-  it("re-uploads image attachments as files in the DM recap (not URLs) so they survive the source delete", async () => {
-    const fakeAttachment = {
-      url: "https://cdn.discordapp.com/example.png",
-      name: "example.png",
-    };
-    const att = new Collection<string, any>([["att-1", fakeAttachment]]);
-    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
-    const bulkDelete = vi.fn().mockResolvedValue(
-      fakeBulkDeleteResult([
-        fakeMessage({ content: "look at this", attachments: att }),
-      ])
-    );
-    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
-    const interaction = createMockInteraction({
-      channel: { isSendable: () => true, send, bulkDelete },
-      user: {
-        id: "mod-1",
-        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
-      },
-    });
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
-      })
-    );
-
-    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
-
-    const dmPayload = dmSend.mock.calls[0][0];
-    expect(dmPayload.files).toHaveLength(1);
-    expect(dmPayload.files[0].name).toBe("example.png");
-    expect(Buffer.isBuffer(dmPayload.files[0].attachment)).toBe(true);
-
-    vi.unstubAllGlobals();
-  });
-
-  it("falls back to a friendly empty embed when bulkDelete returns 0 messages", async () => {
-    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
-    const bulkDelete = vi.fn().mockResolvedValue(fakeBulkDeleteResult([]));
-    const interaction = createMockInteraction({
-      channel: { isSendable: () => true, send, bulkDelete },
-    });
-
-    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
-
-    const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.flags).toBe(MessageFlags.Ephemeral);
-    expect(payload.embeds[0].data.title).toBe("🧹 Nada para limpiar");
-    // No public notice when nothing got deleted
-    expect(send).not.toHaveBeenCalled();
-  });
-
-  it("rejects ephemerally when the member lacks ManageMessages", async () => {
+  it("rejects ephemerally when the member lacks ManageMessages (no defer needed — fast path)", async () => {
     const interaction = createMockInteraction({
       member: { permissions: { has: vi.fn().mockReturnValue(false) } },
     });
@@ -186,30 +210,68 @@ describe("/clear", () => {
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("permisos");
+    expect(interaction.deferReply).not.toHaveBeenCalled();
   });
 
-  it("rejects ephemerally when amount is zero or negative", async () => {
+  it("rejects ephemerally when amount <= 0", async () => {
     const interaction = createMockInteraction();
     await clear.run(createMockClient(), interaction, [arg("amount", 0)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("mayor a 0");
+    expect(interaction.deferReply).not.toHaveBeenCalled();
   });
 
-  it("replies with an error embed when bulkDelete throws (eg. messages too old)", async () => {
-    const bulkDelete = vi
-      .fn()
-      .mockRejectedValue(new Error("You can only bulk delete messages younger than 14 days"));
+  it("editReplies a friendly empty embed when bulkDelete returns 0 messages (e.g. all >14d)", async () => {
+    const messages = [fakeMessage({ id: "m1" })];
+    const channel = {
+      isSendable: () => true,
+      send: vi.fn().mockResolvedValue({ delete: vi.fn() }),
+      messages: { fetch: vi.fn().mockResolvedValue(fakeFetchResult(messages)) },
+      bulkDelete: vi.fn().mockResolvedValue(fakeBulkResult([])), // 0 deleted
+    };
     const interaction = createMockInteraction({
-      channel: { isSendable: () => true, send: vi.fn(), bulkDelete },
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
     });
 
     await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
 
-    const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
+    expect(payload.embeds[0].data.title).toBe("🧹 Nada para limpiar");
+    // Public notice not sent — nothing actually happened
+    expect(channel.send).not.toHaveBeenCalled();
+  });
+
+  it("editReplies an error embed when bulkDelete throws", async () => {
+    const messages = [fakeMessage({ id: "m1" })];
+    const channel = {
+      isSendable: () => true,
+      send: vi.fn().mockResolvedValue({ delete: vi.fn() }),
+      messages: { fetch: vi.fn().mockResolvedValue(fakeFetchResult(messages)) },
+      bulkDelete: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("You can only bulk delete messages younger than 14 days")
+        ),
+    };
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
+
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
     expect(payload.embeds[0].data.title).toBe("❌ No se pudo limpiar el chat");
     expect(payload.embeds[0].data.description).toContain("14 days");
   });

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -1,24 +1,59 @@
 import { MessageFlags } from "discord.js";
 import { describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import clear from "./clear";
 
 describe("/clear", () => {
-  it("bulk-deletes the requested amount and posts a public count notice", async () => {
-    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
+  it("bulk-deletes the requested amount, replies ephemerally with the count, and posts a public auto-deleting notice", async () => {
+    vi.useFakeTimers();
+    const noticeDelete = vi.fn().mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue({ delete: noticeDelete });
     const bulkDelete = vi.fn().mockResolvedValue({ size: 4 });
     const interaction = createMockInteraction({
-      channel: {
-        isSendable: () => true,
-        send,
-        bulkDelete,
-      },
+      channel: { isSendable: () => true, send, bulkDelete },
     });
 
     await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
 
     expect(bulkDelete).toHaveBeenCalledWith(4, true);
+
+    // Ephemeral reply with branded embed
+    const replyPayload = interaction.reply.mock.calls[0][0];
+    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
+    expect(replyPayload.embeds[0].data.title).toBe("🧹 Chat limpiado");
+    expect(replyPayload.embeds[0].data.description).toContain("4");
+
+    // Public notice posted to channel
+    expect(send).toHaveBeenCalledOnce();
+    const sentEmbed = send.mock.calls[0][0].embeds[0].data;
+    expect(sentEmbed.title).toBe("🧹 Chat limpiado");
+    expect(sentEmbed.color).toBe(0xed4245); // mod red
+    expect(sentEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
+
+    // After 5s, the public notice deletes itself
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(noticeDelete).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("uses singular phrasing for a 1-message delete", async () => {
+    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
+    const bulkDelete = vi.fn().mockResolvedValue({ size: 1 });
+    const interaction = createMockInteraction({
+      channel: { isSendable: () => true, send, bulkDelete },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    const description = send.mock.calls[0][0].embeds[0].data.description;
+    // Singular: '... **1** mensaje.' — no trailing 's' on 'mensaje'
+    expect(description).toMatch(/\*\*1\*\*\s+mensaje\.$/);
   });
 
   it("rejects ephemerally when the member lacks ManageMessages", async () => {
@@ -34,12 +69,29 @@ describe("/clear", () => {
     expect(payload.content).toContain("permisos");
   });
 
-  it("rejects ephemerally when amount is invalid (zero or negative)", async () => {
+  it("rejects ephemerally when amount is zero or negative", async () => {
     const interaction = createMockInteraction();
     await clear.run(createMockClient(), interaction, [arg("amount", 0)]);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("mayor a 0");
+  });
+
+  it("replies with an error embed when bulkDelete throws (eg. messages too old)", async () => {
+    const bulkDelete = vi
+      .fn()
+      .mockRejectedValue(new Error("You can only bulk delete messages younger than 14 days"));
+    const interaction = createMockInteraction({
+      channel: { isSendable: () => true, send: vi.fn(), bulkDelete },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.embeds[0].data.title).toBe("❌ No se pudo limpiar el chat");
+    expect(payload.embeds[0].data.description).toContain("14 days");
   });
 });

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -122,6 +122,66 @@ describe("/clear", () => {
     expect(interaction.editReply).not.toHaveBeenCalled();
   });
 
+  it("skips the DM recap entirely for /clear amount:1 with a text-only message (the messageDelete listener already covers it)", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "asf", author: { username: "ana" } }),
+    ];
+    const { channel } = setupChannel(messages);
+
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
+    const createDM = vi.fn().mockResolvedValue({ send: dmSend });
+    const interaction = createMockInteraction({
+      channel,
+      user: { id: "mod-1", createDM },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    // No DM at all — the listener already handles single text deletes
+    expect(createDM).not.toHaveBeenCalled();
+    expect(dmSend).not.toHaveBeenCalled();
+
+    // Public count notice still posts
+    expect(channel.send).toHaveBeenCalledOnce();
+    // Deferred ephemeral cleared
+    expect(interaction.deleteReply).toHaveBeenCalledOnce();
+  });
+
+  it("DOES DM the recap for /clear amount:1 when the single message has an attachment", async () => {
+    const att = new Collection<string, any>([
+      ["a1", { url: "https://cdn.discordapp.com/x.png", name: "x.png" }],
+    ]);
+    const messages = [
+      fakeMessage({ id: "m1", content: "look", attachments: att }),
+    ];
+    const { channel } = setupChannel(messages);
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
+      })
+    );
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    // DM with the recap and the re-uploaded file
+    expect(dmSend).toHaveBeenCalledOnce();
+    const dmPayload = dmSend.mock.calls[0][0];
+    expect(dmPayload.files).toHaveLength(1);
+    expect(dmPayload.embeds[0].data.title).toBe("📋 Eliminados (1)");
+    expect(dmPayload.embeds[0].data.description).toContain("look");
+  });
+
   it("downloads attachments via fetch BEFORE bulkDelete and re-uploads them as files in the DM", async () => {
     const att = new Collection<string, any>([
       [
@@ -177,8 +237,11 @@ describe("/clear", () => {
     expect(Buffer.isBuffer(dmPayload.files[0].attachment)).toBe(true);
   });
 
-  it("falls back to inline ephemeral when DMs are disabled", async () => {
-    const messages = [fakeMessage({ id: "m1" })];
+  it("falls back to inline ephemeral when DMs are disabled (multi-message path so DM is actually attempted)", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "uno" }),
+      fakeMessage({ id: "m2", content: "dos" }),
+    ];
     const { channel } = setupChannel(messages);
 
     const interaction = createMockInteraction({
@@ -189,14 +252,14 @@ describe("/clear", () => {
       },
     });
 
-    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+    await clear.run(createMockClient(), interaction, [arg("amount", 2)]);
 
     // The deferReply gets edited (not deleted) so the moderator still sees the recap
     expect(interaction.deleteReply).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenCalledOnce();
     const payload = interaction.editReply.mock.calls[0][0];
     expect(payload.content).toContain("DM");
-    expect(payload.embeds[0].data.title).toBe("📋 Eliminados (1)");
+    expect(payload.embeds[0].data.title).toBe("📋 Eliminados (2)");
   });
 
   it("rejects ephemerally when the member lacks ManageMessages (no defer needed — fast path)", async () => {

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -147,6 +147,46 @@ describe("/clear", () => {
     expect(interaction.deleteReply).toHaveBeenCalledOnce();
   });
 
+  it("public count notice uses singular Spanish for a 1-message delete ('Se eliminó', not 'Se eliminaron')", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "asf", author: { username: "ana" } }),
+    ];
+    const { channel, send } = setupChannel(messages);
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    const description = send.mock.calls[0][0].embeds[0].data.description;
+    expect(description).toBe("Se eliminó **1** mensaje.");
+  });
+
+  it("public count notice uses plural Spanish for a multi-message delete", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "uno" }),
+      fakeMessage({ id: "m2", content: "dos" }),
+      fakeMessage({ id: "m3", content: "tres" }),
+    ];
+    const { channel, send } = setupChannel(messages);
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 3)]);
+
+    const description = send.mock.calls[0][0].embeds[0].data.description;
+    expect(description).toBe("Se eliminaron **3** mensajes.");
+  });
+
   it("DOES DM the recap for /clear amount:1 when the single message has an attachment", async () => {
     const att = new Collection<string, any>([
       ["a1", { url: "https://cdn.discordapp.com/x.png", name: "x.png" }],

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -32,7 +32,9 @@ const buildPublicNoticeEmbed = (deletedCount: number) =>
   baseEmbed()
     .setTitle("🧹 Chat limpiado")
     .setDescription(
-      `Se eliminaron **${deletedCount}** ${deletedCount === 1 ? "mensaje" : "mensajes"}.`
+      deletedCount === 1
+        ? `Se eliminó **1** mensaje.`
+        : `Se eliminaron **${deletedCount}** mensajes.`
     );
 
 const buildErrorEmbed = (reason: string) =>

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -1,97 +1,121 @@
-import Discord, { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits, PermissionsBitField } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Message,
+  MessageFlags,
+  PermissionFlagsBits,
+  PermissionsBitField,
+  TextChannel,
+} from "discord.js";
+
+import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
-import config from "../../config";
+
+const NOTICE_TTL_MS = 5_000;
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("mod"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildNoticeEmbed = (deletedCount: number) =>
+  baseEmbed()
+    .setTitle("🧹 Chat limpiado")
+    .setDescription(
+      `Se eliminaron **${deletedCount}** ${deletedCount === 1 ? "mensaje" : "mensajes"}.`
+    );
+
+const buildErrorEmbed = (reason: string) =>
+  baseEmbed()
+    .setTitle("❌ No se pudo limpiar el chat")
+    .setDescription(reason);
 
 const pull: ISlashCommand = {
   name: "clear",
   category: "mod",
-  description: "Limpia el chat",
+  description: "Limpia mensajes del canal en bloque",
   ownerOnly: false,
   defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [
     {
       name: "amount",
-      description: "Cantidad de mensajes a borrar",
+      description: `Cantidad de mensajes a borrar (1–${config.maxDeleteMessages}, default: 1)`,
       type: ApplicationCommandOptionType.Integer,
       required: false,
     },
   ],
+  examples: ["/clear", "/clear amount:10"],
   run: async (
-    client: ClientDiscord,
+    _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      // Member doesn't have permissions
       if (
-        !(interaction.member!.permissions as Readonly<PermissionsBitField>).has(
+        !(interaction.member?.permissions as Readonly<PermissionsBitField>)?.has(
           PermissionFlagsBits.ManageMessages
         )
       ) {
         return interaction.reply({
-          content: "No tienes permisos para eliminar mensajes...",
+          content: "No tienes permisos para eliminar mensajes.",
           flags: MessageFlags.Ephemeral,
         });
       }
 
-      const arg = args[0]?.value || 1;
+      const requested = (args.find((a) => a.name === "amount")?.value as
+        | number
+        | undefined) ?? 1;
 
-      // Check if args[0] is a number
-      if (isNaN(parseInt(arg.toString())) || parseInt(arg.toString()) <= 0) {
+      if (requested <= 0) {
         return interaction.reply({
           content:
-            "Por favor selecciona una cantidad de mensajes a eliminar apropiada.",
+            "La cantidad debe ser un número mayor a 0.",
           flags: MessageFlags.Ephemeral,
         });
       }
 
-      // Maybe the bot can't delete messages
-      if (
-        !(interaction.member?.permissions as Readonly<PermissionsBitField>).has(
-          PermissionFlagsBits.ManageMessages
-        )
-      ) {
+      const amountToDelete = Math.min(requested, config.maxDeleteMessages);
+      const channel = interaction.channel as TextChannel;
+
+      // bulkDelete first, then confirm. If it throws (eg. messages older than
+      // 14 days, or bot missing perms), the catch fires and errorHandler can
+      // still reply because the interaction hasn't been replied yet.
+      try {
+        const deleted = await channel.bulkDelete(amountToDelete, true);
+        await interaction.reply({
+          embeds: [buildNoticeEmbed(deleted.size)],
+          flags: MessageFlags.Ephemeral,
+        });
+
+        // Public, auto-deleting confirmation in the channel so users see what
+        // happened without the moderator having to repeat it.
+        const notice = await channel.send({
+          embeds: [buildNoticeEmbed(deleted.size)],
+        });
+        setTimeout(() => {
+          (notice as Message).delete().catch(() => {});
+        }, NOTICE_TTL_MS);
+      } catch (bulkErr: any) {
+        // Discord throws when trying to bulk-delete >14d old messages or when
+        // the bot lacks ManageMessages itself.
         return interaction.reply({
-          content: "No cuento con permisos para eliminar mensajes.",
+          embeds: [
+            buildErrorEmbed(
+              bulkErr?.message ??
+                "Discord rechazó la operación. ¿Mensajes muy viejos (>14 días) o falta de permisos del bot?"
+            ),
+          ],
           flags: MessageFlags.Ephemeral,
         });
       }
-
-      const amount = parseInt(arg.toString());
-      if (!amount) {
-        return interaction.reply({
-          content: "Por favor selecciona una cantidad de mensajes a borrar.",
-        });
-      }
-
-      const amountToDelete =
-        amount > config.maxDeleteMessages ? config.maxDeleteMessages : amount;
-
-      const channel: Discord.TextChannel = <Discord.TextChannel>(
-        interaction.channel
-      );
-
-      await interaction.reply({
-        content: "Limpiando chat...",
-        flags: MessageFlags.Ephemeral,
-      });
-
-      channel
-        .bulkDelete(amountToDelete, true)
-        .then(async (deleted) => {
-          const notice = await channel.send(
-            `\`${deleted.size}\` mensajes borrados.`
-          );
-          setTimeout(() => {
-            notice.delete().catch(() => {});
-          }, 5000);
-        })
-        .catch((err) =>
-          interaction.editReply(`Error: ${err}`).catch(() => {})
-        );
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -20,13 +20,18 @@ import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
 const NOTICE_TTL_MS = 5_000;
+// Discord caps a single message at 10 attachments. We cap our recap there too.
+const MAX_RECAP_ATTACHMENTS = 10;
+// Embed description max is 4096; leave a margin for the trailing truncation
+// notice and any markdown overhead.
+const MAX_RECAP_DESCRIPTION = 3800;
 
 const baseEmbed = () =>
   new EmbedBuilder()
     .setColor(colorForCategory("mod"))
     .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
-const buildNoticeEmbed = (deletedCount: number) =>
+const buildPublicNoticeEmbed = (deletedCount: number) =>
   baseEmbed()
     .setTitle("🧹 Chat limpiado")
     .setDescription(
@@ -37,6 +42,71 @@ const buildErrorEmbed = (reason: string) =>
   baseEmbed()
     .setTitle("❌ No se pudo limpiar el chat")
     .setDescription(reason);
+
+const buildEmptyEmbed = () =>
+  baseEmbed()
+    .setTitle("🧹 Nada para limpiar")
+    .setDescription(
+      "No había mensajes recientes para eliminar (Discord no permite borrar mensajes de más de 14 días en bloque)."
+    );
+
+/**
+ * Build the moderator-only recap of what got deleted: an embed listing each
+ * message and a list of File payloads to re-upload its image attachments
+ * (downloaded into Buffers because Discord's CDN URLs expire shortly after
+ * the source message is deleted).
+ *
+ * Returns: { embed, files } ready to drop into interaction.reply().
+ */
+const buildRecap = async (deleted: Message[]) => {
+  const lines: string[] = [];
+  const files: { attachment: Buffer; name: string }[] = [];
+  let truncated = false;
+
+  for (const msg of deleted) {
+    const ts = `<t:${Math.floor(msg.createdTimestamp / 1000)}:t>`;
+    const author = `**${msg.author.username}**`;
+    const body =
+      msg.content?.trim() ||
+      (msg.attachments.size > 0 ? "_(solo adjuntos)_" : "_(mensaje vacío)_");
+    const line = `${ts} ${author}: ${body}`;
+
+    // Stop adding text lines once we'd overflow the embed description.
+    if (lines.join("\n").length + line.length + 1 > MAX_RECAP_DESCRIPTION) {
+      truncated = true;
+      break;
+    }
+    lines.push(line);
+
+    // Re-upload image/file attachments as fresh files so the mod can still
+    // see them after Discord drops the original CDN URLs.
+    for (const att of msg.attachments.values()) {
+      if (files.length >= MAX_RECAP_ATTACHMENTS) {
+        truncated = true;
+        break;
+      }
+      try {
+        const res = await fetch(att.url);
+        if (!res.ok) continue;
+        const buf = Buffer.from(await res.arrayBuffer());
+        files.push({ attachment: buf, name: att.name });
+      } catch {
+        // CDN URL expired or download failed — skip silently.
+      }
+    }
+    if (files.length >= MAX_RECAP_ATTACHMENTS) truncated = true;
+  }
+
+  if (truncated) {
+    lines.push("\n_(recap truncado por límites de Discord)_");
+  }
+
+  const embed = baseEmbed()
+    .setTitle(`📋 Eliminados (${deleted.length})`)
+    .setDescription(lines.join("\n") || "_(sin contenido)_");
+
+  return { embed, files };
+};
 
 const pull: ISlashCommand = {
   name: "clear",
@@ -70,14 +140,13 @@ const pull: ISlashCommand = {
         });
       }
 
-      const requested = (args.find((a) => a.name === "amount")?.value as
-        | number
-        | undefined) ?? 1;
+      const requested =
+        (args.find((a) => a.name === "amount")?.value as number | undefined) ??
+        1;
 
       if (requested <= 0) {
         return interaction.reply({
-          content:
-            "La cantidad debe ser un número mayor a 0.",
+          content: "La cantidad debe ser un número mayor a 0.",
           flags: MessageFlags.Ephemeral,
         });
       }
@@ -85,27 +154,10 @@ const pull: ISlashCommand = {
       const amountToDelete = Math.min(requested, config.maxDeleteMessages);
       const channel = interaction.channel as TextChannel;
 
-      // bulkDelete first, then confirm. If it throws (eg. messages older than
-      // 14 days, or bot missing perms), the catch fires and errorHandler can
-      // still reply because the interaction hasn't been replied yet.
+      let deletedCollection;
       try {
-        const deleted = await channel.bulkDelete(amountToDelete, true);
-        await interaction.reply({
-          embeds: [buildNoticeEmbed(deleted.size)],
-          flags: MessageFlags.Ephemeral,
-        });
-
-        // Public, auto-deleting confirmation in the channel so users see what
-        // happened without the moderator having to repeat it.
-        const notice = await channel.send({
-          embeds: [buildNoticeEmbed(deleted.size)],
-        });
-        setTimeout(() => {
-          (notice as Message).delete().catch(() => {});
-        }, NOTICE_TTL_MS);
+        deletedCollection = await channel.bulkDelete(amountToDelete, true);
       } catch (bulkErr: any) {
-        // Discord throws when trying to bulk-delete >14d old messages or when
-        // the bot lacks ManageMessages itself.
         return interaction.reply({
           embeds: [
             buildErrorEmbed(
@@ -116,6 +168,36 @@ const pull: ISlashCommand = {
           flags: MessageFlags.Ephemeral,
         });
       }
+
+      // bulkDelete returns newest-first; show the recap chronologically.
+      const deletedMessages = [...deletedCollection.values()].reverse() as Message[];
+
+      if (deletedMessages.length === 0) {
+        return interaction.reply({
+          embeds: [buildEmptyEmbed()],
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      const { embed: recapEmbed, files } = await buildRecap(deletedMessages);
+
+      // Ephemeral recap to the moderator (so they can review what got nuked).
+      // Mentions inside the recap are neutralized: this is a private review,
+      // not a re-broadcast.
+      await interaction.reply({
+        embeds: [recapEmbed],
+        files,
+        flags: MessageFlags.Ephemeral,
+        allowedMentions: { parse: [] },
+      });
+
+      // Public auto-deleting notice in the channel: just the count, no detail.
+      const notice = await channel.send({
+        embeds: [buildPublicNoticeEmbed(deletedMessages.length)],
+      });
+      setTimeout(() => {
+        (notice as Message).delete().catch(() => {});
+      }, NOTICE_TTL_MS);
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -209,6 +209,14 @@ const pull: ISlashCommand = {
         return interaction.editReply({ embeds: [buildEmptyEmbed()] });
       }
 
+      // Skip the DM recap when it would just duplicate what the messageDelete
+      // listener (events/message/messageDelete.ts) already DMs the owner.
+      // The listener handles single-message deletes one-by-one with full
+      // fidelity, so /clear only needs to add value when there's bulk context
+      // OR an attachment that the listener might miss.
+      const hasAttachments = downloaded.length > 0;
+      const skipRecap = messageArr.length === 1 && !hasAttachments;
+
       // Recap is built from the messages we captured pre-delete (and their
       // pre-downloaded attachments) — not from bulkDelete's return, which
       // strips message bodies for messages older than 14 days.
@@ -218,15 +226,17 @@ const pull: ISlashCommand = {
       // history, invisible to the rest of the server regardless of who ran
       // the command.
       let dmDelivered = true;
-      try {
-        const dm = await interaction.user.createDM();
-        await dm.send({
-          embeds: [recapEmbed],
-          files,
-          allowedMentions: { parse: [] },
-        });
-      } catch {
-        dmDelivered = false;
+      if (!skipRecap) {
+        try {
+          const dm = await interaction.user.createDM();
+          await dm.send({
+            embeds: [recapEmbed],
+            files,
+            allowedMentions: { parse: [] },
+          });
+        } catch {
+          dmDelivered = false;
+        }
       }
 
       // Public auto-deleting notice in the channel: just the count, no detail.
@@ -240,7 +250,7 @@ const pull: ISlashCommand = {
       // Happy path: drop the deferred ephemeral so the moderator gets no
       // visible reply in the channel — the recap is in their DM, the count
       // notice is in the channel for context. Both already cover the UX.
-      if (dmDelivered) {
+      if (skipRecap || dmDelivered) {
         try {
           await interaction.deleteReply();
         } catch {

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -181,15 +181,39 @@ const pull: ISlashCommand = {
 
       const { embed: recapEmbed, files } = await buildRecap(deletedMessages);
 
-      // Ephemeral recap to the moderator (so they can review what got nuked).
-      // Mentions inside the recap are neutralized: this is a private review,
-      // not a re-broadcast.
-      await interaction.reply({
-        embeds: [recapEmbed],
-        files,
-        flags: MessageFlags.Ephemeral,
-        allowedMentions: { parse: [] },
-      });
+      // Recap goes by DM — it's an internal log of what got nuked, persists
+      // in the moderator's DM history, and stays invisible to the rest of
+      // the server regardless of who ran the command.
+      let dmDelivered = true;
+      try {
+        const dm = await interaction.user.createDM();
+        await dm.send({
+          embeds: [recapEmbed],
+          files,
+          allowedMentions: { parse: [] },
+        });
+      } catch {
+        dmDelivered = false;
+      }
+
+      // Ephemeral confirmation to the invoker. If the DM made it through,
+      // it's just a 'done'. If it didn't (DMs disabled), fall back to
+      // showing the recap inline so the moderator still has the data.
+      if (dmDelivered) {
+        await interaction.reply({
+          content: "✅ Listo. Te envié el detalle por DM.",
+          flags: MessageFlags.Ephemeral,
+        });
+      } else {
+        await interaction.reply({
+          content:
+            "No te pude enviar DM (¿los tenés desactivados?). Te dejo el detalle acá:",
+          embeds: [recapEmbed],
+          files,
+          flags: MessageFlags.Ephemeral,
+          allowedMentions: { parse: [] },
+        });
+      }
 
       // Public auto-deleting notice in the channel: just the count, no detail.
       const notice = await channel.send({

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -20,10 +20,7 @@ import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
 const NOTICE_TTL_MS = 5_000;
-// Discord caps a single message at 10 attachments. We cap our recap there too.
 const MAX_RECAP_ATTACHMENTS = 10;
-// Embed description max is 4096; leave a margin for the trailing truncation
-// notice and any markdown overhead.
 const MAX_RECAP_DESCRIPTION = 3800;
 
 const baseEmbed = () =>
@@ -50,20 +47,54 @@ const buildEmptyEmbed = () =>
       "No había mensajes recientes para eliminar (Discord no permite borrar mensajes de más de 14 días en bloque)."
     );
 
-/**
- * Build the moderator-only recap of what got deleted: an embed listing each
- * message and a list of File payloads to re-upload its image attachments
- * (downloaded into Buffers because Discord's CDN URLs expire shortly after
- * the source message is deleted).
- *
- * Returns: { embed, files } ready to drop into interaction.reply().
- */
-const buildRecap = async (deleted: Message[]) => {
-  const lines: string[] = [];
-  const files: { attachment: Buffer; name: string }[] = [];
-  let truncated = false;
+type DownloadedAttachment = {
+  msgId: string;
+  name: string;
+  buffer: Buffer;
+};
 
-  for (const msg of deleted) {
+/**
+ * Fetch every attachment binary in parallel BEFORE the messages get deleted.
+ * Discord's CDN URLs become invalid the moment the source message is deleted,
+ * so any download has to happen first or it fails silently.
+ */
+const downloadAttachments = async (
+  messages: Message[]
+): Promise<DownloadedAttachment[]> => {
+  const tasks = messages.flatMap((msg) =>
+    [...msg.attachments.values()].map(
+      async (att): Promise<DownloadedAttachment | null> => {
+        try {
+          const res = await fetch(att.url);
+          if (!res.ok) return null;
+          return {
+            msgId: msg.id,
+            name: att.name,
+            buffer: Buffer.from(await res.arrayBuffer()),
+          };
+        } catch {
+          return null;
+        }
+      }
+    )
+  );
+  const settled = await Promise.all(tasks);
+  return settled.filter((x): x is DownloadedAttachment => x !== null);
+};
+
+/**
+ * Build the moderator-only DM recap: embed listing every deleted message
+ * (chronological) plus the re-uploaded attachment Buffers Discord can serve
+ * as fresh files.
+ */
+const buildRecap = (
+  messages: Message[],
+  downloaded: DownloadedAttachment[]
+) => {
+  const lines: string[] = [];
+  let textTruncated = false;
+
+  for (const msg of messages) {
     const ts = `<t:${Math.floor(msg.createdTimestamp / 1000)}:t>`;
     const author = `**${msg.author.username}**`;
     const body =
@@ -71,38 +102,25 @@ const buildRecap = async (deleted: Message[]) => {
       (msg.attachments.size > 0 ? "_(solo adjuntos)_" : "_(mensaje vacío)_");
     const line = `${ts} ${author}: ${body}`;
 
-    // Stop adding text lines once we'd overflow the embed description.
     if (lines.join("\n").length + line.length + 1 > MAX_RECAP_DESCRIPTION) {
-      truncated = true;
+      textTruncated = true;
       break;
     }
     lines.push(line);
-
-    // Re-upload image/file attachments as fresh files so the mod can still
-    // see them after Discord drops the original CDN URLs.
-    for (const att of msg.attachments.values()) {
-      if (files.length >= MAX_RECAP_ATTACHMENTS) {
-        truncated = true;
-        break;
-      }
-      try {
-        const res = await fetch(att.url);
-        if (!res.ok) continue;
-        const buf = Buffer.from(await res.arrayBuffer());
-        files.push({ attachment: buf, name: att.name });
-      } catch {
-        // CDN URL expired or download failed — skip silently.
-      }
-    }
-    if (files.length >= MAX_RECAP_ATTACHMENTS) truncated = true;
   }
 
-  if (truncated) {
+  // Cap attachments at Discord's per-message ceiling.
+  const filesTruncated = downloaded.length > MAX_RECAP_ATTACHMENTS;
+  const files = downloaded
+    .slice(0, MAX_RECAP_ATTACHMENTS)
+    .map((d) => ({ attachment: d.buffer, name: d.name }));
+
+  if (textTruncated || filesTruncated) {
     lines.push("\n_(recap truncado por límites de Discord)_");
   }
 
   const embed = baseEmbed()
-    .setTitle(`📋 Eliminados (${deleted.length})`)
+    .setTitle(`📋 Eliminados (${messages.length})`)
     .setDescription(lines.join("\n") || "_(sin contenido)_");
 
   return { embed, files };
@@ -143,7 +161,6 @@ const pull: ISlashCommand = {
       const requested =
         (args.find((a) => a.name === "amount")?.value as number | undefined) ??
         1;
-
       if (requested <= 0) {
         return interaction.reply({
           content: "La cantidad debe ser un número mayor a 0.",
@@ -154,36 +171,52 @@ const pull: ISlashCommand = {
       const amountToDelete = Math.min(requested, config.maxDeleteMessages);
       const channel = interaction.channel as TextChannel;
 
-      let deletedCollection;
+      // Defer immediately. The fetch + parallel attachment downloads can
+      // easily blow past Discord's 3s acknowledgement window — without this
+      // the user gets 'Unknown interaction' on anything non-trivial.
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      // Fetch the candidate messages BEFORE deleting them — the CDN URLs
+      // for their attachments are only valid while the source still exists.
+      const candidates = await channel.messages.fetch({
+        limit: amountToDelete,
+      });
+      // fetch() returns newest-first; bulkDelete and the recap want chronological.
+      const messageArr = [...candidates.values()].reverse();
+
+      // Download every attachment binary in parallel, then bulk-delete by ID.
+      const downloaded = await downloadAttachments(messageArr);
+
+      let deletedCount: number;
       try {
-        deletedCollection = await channel.bulkDelete(amountToDelete, true);
+        const result = await channel.bulkDelete(
+          messageArr.map((m) => m.id),
+          true
+        );
+        deletedCount = result.size;
       } catch (bulkErr: any) {
-        return interaction.reply({
+        return interaction.editReply({
           embeds: [
             buildErrorEmbed(
               bulkErr?.message ??
                 "Discord rechazó la operación. ¿Mensajes muy viejos (>14 días) o falta de permisos del bot?"
             ),
           ],
-          flags: MessageFlags.Ephemeral,
         });
       }
 
-      // bulkDelete returns newest-first; show the recap chronologically.
-      const deletedMessages = [...deletedCollection.values()].reverse() as Message[];
-
-      if (deletedMessages.length === 0) {
-        return interaction.reply({
-          embeds: [buildEmptyEmbed()],
-          flags: MessageFlags.Ephemeral,
-        });
+      if (deletedCount === 0) {
+        return interaction.editReply({ embeds: [buildEmptyEmbed()] });
       }
 
-      const { embed: recapEmbed, files } = await buildRecap(deletedMessages);
+      // Recap is built from the messages we captured pre-delete (and their
+      // pre-downloaded attachments) — not from bulkDelete's return, which
+      // strips message bodies for messages older than 14 days.
+      const { embed: recapEmbed, files } = buildRecap(messageArr, downloaded);
 
-      // Recap goes by DM — it's an internal log of what got nuked, persists
-      // in the moderator's DM history, and stays invisible to the rest of
-      // the server regardless of who ran the command.
+      // Recap goes by DM — internal log persisted in the moderator's DM
+      // history, invisible to the rest of the server regardless of who ran
+      // the command.
       let dmDelivered = true;
       try {
         const dm = await interaction.user.createDM();
@@ -196,32 +229,35 @@ const pull: ISlashCommand = {
         dmDelivered = false;
       }
 
-      // Ephemeral confirmation to the invoker. If the DM made it through,
-      // it's just a 'done'. If it didn't (DMs disabled), fall back to
-      // showing the recap inline so the moderator still has the data.
-      if (dmDelivered) {
-        await interaction.reply({
-          content: "✅ Listo. Te envié el detalle por DM.",
-          flags: MessageFlags.Ephemeral,
-        });
-      } else {
-        await interaction.reply({
-          content:
-            "No te pude enviar DM (¿los tenés desactivados?). Te dejo el detalle acá:",
-          embeds: [recapEmbed],
-          files,
-          flags: MessageFlags.Ephemeral,
-          allowedMentions: { parse: [] },
-        });
-      }
-
       // Public auto-deleting notice in the channel: just the count, no detail.
       const notice = await channel.send({
-        embeds: [buildPublicNoticeEmbed(deletedMessages.length)],
+        embeds: [buildPublicNoticeEmbed(deletedCount)],
       });
       setTimeout(() => {
         (notice as Message).delete().catch(() => {});
       }, NOTICE_TTL_MS);
+
+      // Happy path: drop the deferred ephemeral so the moderator gets no
+      // visible reply in the channel — the recap is in their DM, the count
+      // notice is in the channel for context. Both already cover the UX.
+      if (dmDelivered) {
+        try {
+          await interaction.deleteReply();
+        } catch {
+          // Token expired or already deleted — nothing left to do.
+        }
+        return;
+      }
+
+      // DM fallback: when the moderator has DMs disabled, surface the recap
+      // inline as the only place to see what got nuked.
+      return interaction.editReply({
+        content:
+          "No te pude enviar DM (¿los tienes desactivados?). Te dejo el detalle acá:",
+        embeds: [recapEmbed],
+        files,
+        allowedMentions: { parse: [] },
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/register.test.ts
+++ b/src/slashCommands/mod/register.test.ts
@@ -4,27 +4,33 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../api/dao/user.dao");
 
 import * as userDao from "../../api/dao/user.dao";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import register from "./register";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const validArgs = [
+  arg("name", "Diego"),
+  arg("user", "user-1"),
+  arg("day", 17),
+  arg("month", 2),
+];
+
 describe("/register", () => {
-  it("calls userDao.addUser with the parsed args and replies with the result embed", async () => {
+  it("calls userDao.addUser with the parsed args and replies with a success embed", async () => {
     vi.mocked(userDao.addUser).mockResolvedValue({
       statusCode: 200,
       message: "Usuario agregado",
     } as any);
 
     const interaction = createMockInteraction();
-    await register.run(createMockClient(), interaction, [
-      arg("name", "Diego"),
-      arg("user", "user-1"),
-      arg("day", 17),
-      arg("month", 2),
-    ]);
+    await register.run(createMockClient(), interaction, validArgs);
 
     expect(userDao.addUser).toHaveBeenCalledWith({
       name: "Diego",
@@ -32,28 +38,83 @@ describe("/register", () => {
       birthdayDay: "17",
       birthdayMonth: "2",
     });
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.embeds).toHaveLength(1);
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("✅ Miembro registrado");
+    expect(embed.color).toBe(0xed4245); // mod red
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+  });
+
+  it("renders an error title when the DAO returns non-200", async () => {
+    vi.mocked(userDao.addUser).mockResolvedValue({
+      statusCode: 422,
+      message: "Datos insuficientes",
+    } as any);
+
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, validArgs);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("❌ Error al registrar");
+    expect(embed.description).toContain("Datos insuficientes");
   });
 
   it("rejects ephemerally when the member lacks Administrator", async () => {
-    vi.mocked(userDao.addUser).mockResolvedValue({} as any);
-
     const interaction = createMockInteraction({
       member: { permissions: { has: vi.fn().mockReturnValue(false) } },
     });
 
-    await register.run(createMockClient(), interaction, [
-      arg("name", "Diego"),
-      arg("user", "user-1"),
-      arg("day", 17),
-      arg("month", 2),
-    ]);
+    await register.run(createMockClient(), interaction, validArgs);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(userDao.addUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when day is out of range", async () => {
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, [
+      arg("name", "Diego"),
+      arg("user", "user-1"),
+      arg("day", 99),
+      arg("month", 2),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("día");
+    expect(userDao.addUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when month is out of range", async () => {
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, [
+      arg("name", "Diego"),
+      arg("user", "user-1"),
+      arg("day", 17),
+      arg("month", 13),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("mes");
+    expect(userDao.addUser).not.toHaveBeenCalled();
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    vi.mocked(userDao.addUser).mockResolvedValue({
+      statusCode: 200,
+      message: "ok",
+    } as any);
+
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, [
+      ...validArgs,
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/register.ts
+++ b/src/slashCommands/mod/register.ts
@@ -1,15 +1,26 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
+
+import * as userDao from "../../api/dao/user.dao";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
-import * as userDao from "../../api/dao/user.dao";
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("mod"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
 const pull: ISlashCommand = {
   name: "register",
@@ -42,6 +53,16 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Integer,
       required: true,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/register name:Diego user:@diego day:17 month:2",
+    "/register name:Carlos user:@carlos day:5 month:11 private:true",
   ],
   run: async (
     client: ClientDiscord,
@@ -64,6 +85,25 @@ const pull: ISlashCommand = {
       const userId = args.find((a) => a.name === "user")?.value as string;
       const day = args.find((a) => a.name === "day")?.value as number;
       const month = args.find((a) => a.name === "month")?.value as number;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      // Validate ranges before hitting the DAO so we get a friendly error
+      // instead of letting bad data sneak into Mongo.
+      if (day < 1 || day > 31) {
+        return interaction.reply({
+          content: "El día debe estar entre 1 y 31.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+      if (month < 1 || month > 12) {
+        return interaction.reply({
+          content: "El mes debe estar entre 1 y 12.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
       const user = await client.users.fetch(userId);
       const data = await userDao.addUser({
@@ -73,13 +113,21 @@ const pull: ISlashCommand = {
         birthdayMonth: month.toString(),
       });
 
-      const embed = new EmbedBuilder({
-        title: `Status: ${data.statusCode}`,
-        description: data.message,
-        timestamp: new Date().toISOString(),
-      }).setColor("Random");
+      const success = data.statusCode === 200;
+      const embed = baseEmbed()
+        .setTitle(success ? "✅ Miembro registrado" : "❌ Error al registrar")
+        .setDescription(data.message)
+        .addFields(
+          { name: "👤 Miembro", value: `<@${user.id}> (**${name}**)`, inline: true },
+          { name: "🎂 Cumpleaños", value: `\`${day}/${month}\``, inline: true }
+        )
+        .setTimestamp(new Date());
 
-      return interaction.reply({ embeds: [embed] });
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+        allowedMentions: { users: [] },
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/who.test.ts
+++ b/src/slashCommands/mod/who.test.ts
@@ -1,9 +1,14 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/services/user.service");
 
 import * as userService from "../../shared/services/user.service";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import who from "./who";
 
 beforeEach(() => {
@@ -45,5 +50,35 @@ describe("/who", () => {
     await who.run(createMockClient(), interaction, []);
 
     expect(userService.getUserById).toHaveBeenCalledWith("caller-1");
+  });
+
+  it("renders the branded CUMpleaños embed with mod-red color and brand footer", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+
+    const interaction = createMockInteraction();
+    await who.run(createMockClient(), interaction, [arg("user", "111")]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 CUMpleaños");
+    expect(embed.color).toBe(0xed4245); // mod red
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+    const fechaField = embed.fields.find((f: any) => f.name === "📅 Fecha");
+    expect(fechaField.value).toContain("17 de Febrero");
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+
+    const i1 = createMockInteraction();
+    await who.run(createMockClient(), i1, [arg("user", "111")]);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await who.run(createMockClient(), i2, [
+      arg("user", "111"),
+      arg("private", true),
+    ]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/who.test.ts
+++ b/src/slashCommands/mod/who.test.ts
@@ -1,4 +1,4 @@
-import { MessageFlags } from "discord.js";
+import { Collection, MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/services/user.service");
@@ -15,19 +15,32 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("/who", () => {
-  const sampleUser = {
-    name: "Diego",
-    discordId: "111",
-    birthdayDay: "17",
-    birthdayMonth: "2",
-  };
+const sampleUser = {
+  name: "Pineappletooth",
+  discordId: "111",
+  birthdayDay: "5",
+  birthdayMonth: "5",
+};
 
+const stubFetchedUser = (client: any, overrides: Partial<any> = {}) => {
+  vi.mocked(client.users.fetch).mockResolvedValue({
+    id: "111",
+    tag: "PaviCasado#0001",
+    username: "PaviCasado",
+    avatarURL: () => "https://example.com/avatar.png",
+    createdTimestamp: new Date(2020, 0, 15).getTime(),
+    ...overrides,
+  } as any);
+};
+
+describe("/who", () => {
   it("looks up by user option when provided", async () => {
     vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const interaction = createMockInteraction();
-    await who.run(createMockClient(), interaction, [arg("user", "111")]);
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("user", "111")]);
 
     expect(userService.getUserById).toHaveBeenCalledWith("111");
     expect(interaction.reply).toHaveBeenCalledOnce();
@@ -35,50 +48,117 @@ describe("/who", () => {
 
   it("looks up by name when only the name option is provided", async () => {
     vi.mocked(userService.getUserByName).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const interaction = createMockInteraction();
-    await who.run(createMockClient(), interaction, [arg("name", "Diego")]);
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("name", "Pineappletooth")]);
 
-    expect(userService.getUserByName).toHaveBeenCalledWith("Diego");
+    expect(userService.getUserByName).toHaveBeenCalledWith("Pineappletooth");
     expect(interaction.reply).toHaveBeenCalledOnce();
   });
 
   it("falls back to the caller's discordId when neither option is provided", async () => {
     vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const interaction = createMockInteraction({ user: { id: "caller-1" } });
-    await who.run(createMockClient(), interaction, []);
+    const interaction = createMockInteraction({
+      user: { id: "caller-1" },
+      guild: null,
+    });
+    await who.run(client, interaction, []);
 
     expect(userService.getUserById).toHaveBeenCalledWith("caller-1");
   });
 
-  it("renders the branded CUMpleaños embed with mod-red color and brand footer", async () => {
+  it("uses the real name as the embed title (not 'CUMpleaños')", async () => {
     vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const interaction = createMockInteraction();
-    await who.run(createMockClient(), interaction, [arg("user", "111")]);
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("user", "111")]);
 
     const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
-    expect(embed.title).toBe("🎂 CUMpleaños");
-    expect(embed.color).toBe(0xed4245); // mod red
+    expect(embed.title).toBe("Pineappletooth");
+    expect(embed.color).toBe(0xed4245);
     expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
     expect(embed.author).toBeUndefined();
-    const fechaField = embed.fields.find((f: any) => f.name === "📅 Fecha");
-    expect(fechaField.value).toContain("17 de Febrero");
+  });
+
+  it("renders the canonical fields: Discord, birthday, next birthday, account created", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
+
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("user", "111")]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const names = embed.fields.map((f: any) => f.name);
+    expect(names).toContain("👤 Discord");
+    expect(names).toContain("🎂 Cumpleaños");
+    expect(names).toContain("📅 Próximo cumple");
+    expect(names).toContain("📆 Cuenta creada");
+
+    const cumple = embed.fields.find((f: any) => f.name === "🎂 Cumpleaños");
+    expect(cumple.value).toContain("5 de Mayo");
+
+    // Discord relative time format used for next birthday
+    const next = embed.fields.find((f: any) => f.name === "📅 Próximo cumple");
+    expect(next.value).toMatch(/^<t:\d+:R>$/);
+  });
+
+  it("includes guild-specific fields (joined-at + top roles) when in a guild", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
+
+    const fakeRoles = new Collection<string, any>([
+      ["everyone", { id: "@e", name: "@everyone", position: 0 }],
+      ["mod", { id: "modrole", name: "Mod", position: 5 }],
+      ["fan", { id: "fanrole", name: "Fan", position: 2 }],
+    ]);
+
+    const guildMember = {
+      joinedTimestamp: new Date(2022, 5, 1).getTime(),
+      roles: { cache: fakeRoles },
+    };
+
+    const interaction = createMockInteraction({
+      guild: {
+        members: { fetch: vi.fn().mockResolvedValue(guildMember) },
+      },
+    });
+
+    await who.run(client, interaction, [arg("user", "111")]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const names = embed.fields.map((f: any) => f.name);
+    expect(names).toContain("🎉 En el servidor desde");
+    expect(names).toContain("✨ Roles principales");
+
+    // @everyone filtered out, top role first
+    const rolesField = embed.fields.find(
+      (f: any) => f.name === "✨ Roles principales"
+    );
+    expect(rolesField.value).toContain("<@&modrole>");
+    expect(rolesField.value).toContain("<@&fanrole>");
+    expect(rolesField.value).not.toContain("@everyone");
   });
 
   it("public by default, ephemeral when private:true", async () => {
     vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const i1 = createMockInteraction();
-    await who.run(createMockClient(), i1, [arg("user", "111")]);
+    const i1 = createMockInteraction({ guild: null });
+    await who.run(client, i1, [arg("user", "111")]);
     expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
 
-    const i2 = createMockInteraction();
-    await who.run(createMockClient(), i2, [
-      arg("user", "111"),
-      arg("private", true),
-    ]);
+    const i2 = createMockInteraction({ guild: null });
+    await who.run(client, i2, [arg("user", "111"), arg("private", true)]);
     expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/who.ts
+++ b/src/slashCommands/mod/who.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
+  GuildMember,
   MessageFlags,
 } from "discord.js";
 
@@ -17,7 +18,44 @@ import {
   getUserByName,
 } from "../../shared/services/user.service";
 import { Argument, ISlashCommand, Month } from "../../shared/types";
-import { errorHandler, mentionUser } from "../../shared/utils/helpers";
+import { errorHandler } from "../../shared/utils/helpers";
+
+/**
+ * Returns the next occurrence of (day/month) starting from `from`. If the
+ * birthday already happened this year, jumps to next year. Doesn't try to
+ * be clever about Feb 29 in non-leap years — JS Date will roll over (Feb 30
+ * → Mar 2), which is acceptable for a friend-server bot.
+ */
+const nextBirthdayDate = (day: number, month: number, from: Date): Date => {
+  const candidate = new Date(from.getFullYear(), month - 1, day);
+  if (candidate.getTime() < from.getTime()) {
+    return new Date(from.getFullYear() + 1, month - 1, day);
+  }
+  return candidate;
+};
+
+const discordRelative = (date: Date | number) => {
+  const seconds = Math.floor(
+    (typeof date === "number" ? date : date.getTime()) / 1000
+  );
+  return `<t:${seconds}:R>`;
+};
+
+const discordDate = (date: Date | number) => {
+  const seconds = Math.floor(
+    (typeof date === "number" ? date : date.getTime()) / 1000
+  );
+  return `<t:${seconds}:D>`;
+};
+
+const formatTopRoles = (member: GuildMember): string | null => {
+  const roles = member.roles.cache
+    .filter((r) => r.name !== "@everyone")
+    .sort((a, b) => b.position - a.position)
+    .first(3);
+  if (roles.length === 0) return null;
+  return roles.map((r) => `<@&${r.id}>`).join(" ");
+};
 
 const pull: ISlashCommand = {
   name: "who",
@@ -74,24 +112,69 @@ const pull: ISlashCommand = {
       if (!res) throw new Error("No se encontró usuario");
 
       const user = await client.users.fetch(res.discordId);
+      const guildMember = interaction.guild
+        ? await interaction.guild.members.fetch(res.discordId).catch(() => null)
+        : null;
 
-      const monthIndex = (parseInt(res.birthdayMonth) - 1) as Month;
-      const monthName = calendar.months[monthIndex] ?? "?";
+      const day = parseInt(res.birthdayDay);
+      const month = parseInt(res.birthdayMonth);
+      const monthName = calendar.months[(month - 1) as Month] ?? "?";
+      const nextBday = nextBirthdayDate(day, month, new Date());
+
+      const fields: { name: string; value: string; inline?: boolean }[] = [
+        {
+          name: "👤 Discord",
+          value: `<@${res.discordId}> (\`${user.tag ?? user.username}\`)`,
+          inline: false,
+        },
+        {
+          name: "🎂 Cumpleaños",
+          value: `\`${day} de ${monthName}\``,
+          inline: true,
+        },
+        {
+          name: "📅 Próximo cumple",
+          value: discordRelative(nextBday),
+          inline: true,
+        },
+        {
+          name: "📆 Cuenta creada",
+          value: discordDate(user.createdTimestamp),
+          inline: true,
+        },
+      ];
+
+      if (guildMember?.joinedTimestamp) {
+        fields.push({
+          name: "🎉 En el servidor desde",
+          value: discordDate(guildMember.joinedTimestamp),
+          inline: true,
+        });
+      }
+
+      if (guildMember) {
+        const topRoles = formatTopRoles(guildMember);
+        if (topRoles) {
+          fields.push({
+            name: "✨ Roles principales",
+            value: topRoles,
+            inline: false,
+          });
+        }
+      }
 
       const embed = new EmbedBuilder()
-        .setTitle("🎂 CUMpleaños")
+        .setTitle(res.name)
         .setThumbnail(user.avatarURL() ?? null)
-        .setDescription(`${mentionUser(res.discordId)} — **${res.name}**`)
-        .addFields({
-          name: "📅 Fecha",
-          value: `\`${res.birthdayDay} de ${monthName}\``,
-        })
+        .setDescription(`<@${res.discordId}>`)
+        .addFields(fields)
         .setColor(colorForCategory("mod"))
         .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
       return interaction.reply({
         embeds: [embed],
         flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+        allowedMentions: { parse: [] },
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/mod/who.ts
+++ b/src/slashCommands/mod/who.ts
@@ -163,10 +163,12 @@ const pull: ISlashCommand = {
         }
       }
 
+      // No setDescription here on purpose: the '👤 Discord' field already
+      // carries the mention (and the tag), so a description with just the
+      // mention was redundant.
       const embed = new EmbedBuilder()
         .setTitle(res.name)
         .setThumbnail(user.avatarURL() ?? null)
-        .setDescription(`<@${res.discordId}>`)
         .addFields(fields)
         .setColor(colorForCategory("mod"))
         .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });

--- a/src/slashCommands/mod/who.ts
+++ b/src/slashCommands/mod/who.ts
@@ -1,18 +1,28 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import calendar from "../../shared/constants/calendar";
-import { Argument, ISlashCommand, Month } from "../../shared/types";
-import { errorHandler, mentionUser } from "../../shared/utils/helpers";
 import {
   getUserById,
   getUserByName,
 } from "../../shared/services/user.service";
+import { Argument, ISlashCommand, Month } from "../../shared/types";
+import { errorHandler, mentionUser } from "../../shared/utils/helpers";
 
 const pull: ISlashCommand = {
   name: "who",
   category: "mod",
-  description: "Leer datos de un miembro de Gmi2",
+  description: "Muestra los datos de un miembro de Gmi2",
   ownerOnly: false,
   options: [
     {
@@ -27,7 +37,14 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.String,
       required: false,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
   ],
+  examples: ["/who", "/who user:@diego", "/who name:Diego", "/who private:true"],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
@@ -40,40 +57,42 @@ const pull: ISlashCommand = {
       const name = args.find((a) => a.name === "name")?.value as
         | string
         | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
 
       let res;
-      let userIdToFetch: string;
-
       if (userId) {
         res = await getUserById(userId);
-        userIdToFetch = res.discordId;
       } else if (name) {
         res = await getUserByName(name);
-        userIdToFetch = res.discordId;
       } else {
         res = await getUserById(interaction.user.id);
-        userIdToFetch = res.discordId;
       }
 
       if (!res) throw new Error("No se encontró usuario");
 
-      const user = await client.users.fetch(userIdToFetch);
+      const user = await client.users.fetch(res.discordId);
 
-      const embed = new EmbedBuilder({
-        title: "CUMpleaños 🎂",
-        thumbnail: { url: user.avatarURL() ?? "" },
-        description: mentionUser(res.discordId),
-        fields: [
-          {
-            name: " ",
-            value: `\`${res.birthdayDay} de ${
-              calendar.months[(parseInt(res.birthdayMonth) - 1) as Month]
-            }\``,
-          },
-        ],
-      }).setColor("Random");
+      const monthIndex = (parseInt(res.birthdayMonth) - 1) as Month;
+      const monthName = calendar.months[monthIndex] ?? "?";
 
-      return interaction.reply({ embeds: [embed] });
+      const embed = new EmbedBuilder()
+        .setTitle("🎂 CUMpleaños")
+        .setThumbnail(user.avatarURL() ?? null)
+        .setDescription(`${mentionUser(res.discordId)} — **${res.name}**`)
+        .addFields({
+          name: "📅 Fecha",
+          value: `\`${res.birthdayDay} de ${monthName}\``,
+        })
+        .setColor(colorForCategory("mod"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -28,6 +28,9 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
       id: "user-1",
       tag: "tester#0001",
       displayAvatarURL: () => "https://example.com/avatar.png",
+      createDM: vi.fn().mockResolvedValue({
+        send: vi.fn().mockResolvedValue({ id: "dm-msg" }),
+      }),
     },
     member: {
       permissions: {

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -14,6 +14,7 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
   const reply = vi.fn().mockResolvedValue({ id: "reply-msg" });
   const deferReply = vi.fn().mockResolvedValue(undefined);
   const editReply = vi.fn().mockResolvedValue({ id: "edited-msg" });
+  const deleteReply = vi.fn().mockResolvedValue(undefined);
   const channelSend = vi.fn().mockResolvedValue({
     id: "channel-msg",
     createdAt: new Date(),
@@ -24,6 +25,7 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
     reply,
     deferReply,
     editReply,
+    deleteReply,
     user: {
       id: "user-1",
       tag: "tester#0001",


### PR DESCRIPTION
## Summary
Batch del facelift de **mod** — la mitad destructiva/admin. La otra mitad (`/cums` y `/nextcum`) va en un PR separado.

## /clear
- 🧹 **Embed branded** (mod red, footer estándar): \`Chat limpiado\` — uno ephemeral al mod y otro público autoborrado en el canal
- ❌ **Error embed amistoso** cuando \`bulkDelete\` falla (mensajes >14 días o el bot sin permisos): \`No se pudo limpiar el chat\` con el motivo
- **Bug**: removido el código muerto (triple parseInt, \`if (!amount)\` inalcanzable) y la doble validación de permisos que chequeaba **al member** dos veces con el comentario \"Maybe the bot can't delete messages\" que no matcheaba la lógica
- description más clara: \`Limpia el chat\` → \`Limpia mensajes del canal en bloque\`

## /who
- 🎂 Embed branded (mod red, footer). Title \`🎂 CUMpleaños\` se queda — el juego de palabras es la gracia.
- **Bug**: el field name era un espacio en blanco \` \` como hack de layout. Ahora \`📅 Fecha\`.
- Description ahora muestra mention + nombre real
- Nuevo \`private:\` opt-in (default: público — los cumples se comparten)

## /register
- ✅/❌ **Embed branded** (mod red, footer) según resultado: \`Miembro registrado\` / \`Error al registrar\`
- **Validación de rangos antes del DAO**: \`day\` 1–31, \`month\` 1–12 → notice ephemeral. Antes podía colar fechas inválidas a Mongo.
- Fields \`👤 Miembro\` y \`🎂 Cumpleaños\` con \`allowedMentions: { users: [] }\` para no pingar al registrado
- Nuevo \`private:\` opt-in (default: público — operación admin visible al equipo)

## Test plan
- [x] \`pnpm test\` → 239/239 (was 229, +10 nuevos: clear x5, who x2, register x3)
- [x] \`tsc --noEmit\` → limpio

### Smoke en Discord
- [ ] \`/clear amount:5\` → ephemeral al mod + notice público que se borra a los 5s
- [ ] \`/clear amount:0\` → notice ephemeral
- [ ] \`/clear\` (default 1) → borra 1 mensaje, notice singular
- [ ] \`/clear\` con mensajes >14 días → embed de error friendly
- [ ] \`/who user:@diego\` → embed CUMpleaños rojo
- [ ] \`/who name:Diego\` → idem
- [ ] \`/who\` (sin args) → tu propio cumple
- [ ] \`/who user:@diego private:true\` → solo lo ves vos
- [ ] \`/register name:John user:@john day:5 month:11\` → ✅
- [ ] \`/register name:John user:@john day:99 month:5\` → ephemeral 'día'
- [ ] \`/register name:John user:@john day:5 month:13\` → ephemeral 'mes'

> Nota: este PR no toca \`/say\` (PR #59 lo hace). Mergear en cualquier orden.