### PR TITLE
feat(mod): facelift /nextcum and /cums — branded embeds, private opt-in

### DIFF
--- a/src/shared/utils/helpers.ts
+++ b/src/shared/utils/helpers.ts
@@ -144,6 +144,24 @@ export const rangeHandler = (
 };
 
 /**
+ * Returns the next occurrence of (day/month) starting from `from`. If the
+ * birthday already happened this year, jumps to next year. Doesn't try to
+ * be clever about Feb 29 in non-leap years — JS Date will roll over (Feb 30
+ * → Mar 2), which is acceptable for a friend-server bot.
+ */
+export const nextBirthdayDate = (
+  day: number,
+  month: number,
+  from: Date = new Date()
+): Date => {
+  const candidate = new Date(from.getFullYear(), month - 1, day);
+  if (candidate.getTime() < from.getTime()) {
+    return new Date(from.getFullYear() + 1, month - 1, day);
+  }
+  return candidate;
+};
+
+/**
  * Formats a duration in seconds into a compact human-readable string.
  * Examples: 45s, 5m 30s, 2h 15m, 3d 4h 0m
  */

--- a/src/slashCommands/mod/cums.test.ts
+++ b/src/slashCommands/mod/cums.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../shared/services/birthday.service");
 
 import * as birthdayService from "../../shared/services/birthday.service";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import cums from "./cums";
 
 beforeEach(() => {
@@ -15,6 +19,7 @@ describe("/cums", () => {
   it("replies with all birthdays when no month option is given", async () => {
     vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
       Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+      Mayo: [{ name: "Ana", discordId: "222", birthdayDay: 5 }],
     });
 
     const interaction = createMockInteraction();
@@ -22,10 +27,12 @@ describe("/cums", () => {
 
     expect(birthdayService.getBirthdays).toHaveBeenCalledOnce();
     expect(birthdayService.getBirthdaysByMonth).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Cumpleaños del servidor");
+    expect(embed.description).toContain("**2** personas registradas");
   });
 
-  it("filters by month when the option is provided", async () => {
+  it("filters by month when the option is provided (passes 0-indexed month to the service)", async () => {
     vi.mocked(birthdayService.getBirthdaysByMonth).mockResolvedValue({
       Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
     });
@@ -33,28 +40,109 @@ describe("/cums", () => {
     const interaction = createMockInteraction();
     await cums.run(createMockClient(), interaction, [arg("month", 2)]);
 
-    expect(birthdayService.getBirthdaysByMonth).toHaveBeenCalledWith(1); // month - 1
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(birthdayService.getBirthdaysByMonth).toHaveBeenCalledWith(1); // Feb is 0-indexed 1
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Cumpleaños de Febrero");
   });
 
-  it("rejects ephemerally when the month option is out of range", async () => {
+  it("singular phrasing for a 1-person registration", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.description).toBe("**1** persona registrada");
+  });
+
+  it("rejects ephemerally when the month option is out of range (>12)", async () => {
     const interaction = createMockInteraction();
     await cums.run(createMockClient(), interaction, [arg("month", 13)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("entre 1 y 12");
+    expect(birthdayService.getBirthdaysByMonth).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when the month option is 0 or negative", async () => {
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, [arg("month", 0)]);
+
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
-  it("returns the empty-state notice when the filter has no results", async () => {
+  it("returns a branded empty embed when the filter has no results", async () => {
     vi.mocked(birthdayService.getBirthdaysByMonth).mockResolvedValue({});
 
     const interaction = createMockInteraction();
     await cums.run(createMockClient(), interaction, [arg("month", 2)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Sin cumpleaños en Febrero");
+    expect(embed.description).toContain("No hay cumpleaños");
+  });
+
+  it("returns a friendly embed when there are no registrations at all", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({});
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Sin cumpleaños registrados");
+    expect(embed.description).toContain("/register");
+  });
+
+  it("uses mod-red color and the brand footer (no setAuthor)", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.color).toBe(0xed4245);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+  });
+
+  it("ephemeral when private:true", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, [arg("private", true)]);
+
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
-    expect(payload.content).toContain("No hay cumpleaños");
+  });
+
+  it("sorts by day within a month", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [
+        { name: "Carla", discordId: "333", birthdayDay: "20" },
+        { name: "Diego", discordId: "111", birthdayDay: "5" },
+        { name: "Ana", discordId: "222", birthdayDay: "12" },
+      ],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const febField = embed.fields.find((f: any) => f.name === "Febrero");
+    const value = febField.value;
+    // Order: 5, 12, 20
+    const indexOf5 = value.indexOf("`5`");
+    const indexOf12 = value.indexOf("`12`");
+    const indexOf20 = value.indexOf("`20`");
+    expect(indexOf5).toBeLessThan(indexOf12);
+    expect(indexOf12).toBeLessThan(indexOf20);
   });
 });

--- a/src/slashCommands/mod/cums.ts
+++ b/src/slashCommands/mod/cums.ts
@@ -1,18 +1,64 @@
 import {
   APIEmbedField,
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import calendar from "../../shared/constants/calendar";
-import { Argument, CumData, ISlashCommand, Month } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
 import {
   getBirthdays,
   getBirthdaysByMonth,
 } from "../../shared/services/birthday.service";
+import { Argument, CumData, ISlashCommand, Month } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const baseEmbed = (title: string) =>
+  new EmbedBuilder()
+    .setTitle(title)
+    .setColor(colorForCategory("mod"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildBirthdaysEmbed = (response: CumData, monthName: string | null) => {
+  const totalCount = Object.values(response).reduce(
+    (sum, list) => sum + list.length,
+    0
+  );
+
+  const fields: APIEmbedField[] = [];
+  for (const month in response) {
+    const users = response[month]
+      .map((b: any) => ({ day: b.birthdayDay, mention: `<@${b.discordId}>` }))
+      .sort((a, b) => parseInt(a.day) - parseInt(b.day));
+
+    fields.push({
+      name: month,
+      value: users.map((u) => `\`${u.day}\` ${u.mention}`).join("\n"),
+      inline: true,
+    });
+  }
+
+  const title = monthName
+    ? `🎂 Cumpleaños de ${monthName}`
+    : "🎂 Cumpleaños del servidor";
+  const description = `**${totalCount}** ${
+    totalCount === 1 ? "persona registrada" : "personas registradas"
+  }`;
+
+  return baseEmbed(title).setDescription(description).addFields(fields);
+};
+
+const buildEmptyMonthEmbed = (monthName: string) =>
+  baseEmbed(`🎂 Sin cumpleaños en ${monthName}`).setDescription(
+    "No hay cumpleaños registrados para este mes."
+  );
 
 const pull: ISlashCommand = {
   name: "cums",
@@ -26,7 +72,14 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Integer,
       required: false,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
   ],
+  examples: ["/cums", "/cums month:5", "/cums private:true"],
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
@@ -36,49 +89,49 @@ const pull: ISlashCommand = {
       const monthInput = args.find((a) => a.name === "month")?.value as
         | number
         | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
 
       let response: CumData = {};
+      let monthName: string | null = null;
+
       if (monthInput !== undefined) {
-        const month = (monthInput - 1) as Month;
-        if (month < 0 || month > 11) {
+        if (monthInput < 1 || monthInput > 12) {
           return interaction.reply({
-            content: "El mes debe estar entre 1 y 12",
+            content: "El mes debe estar entre 1 y 12.",
             flags: MessageFlags.Ephemeral,
           });
         }
-        response = await getBirthdaysByMonth(month);
+        const monthIdx = (monthInput - 1) as Month;
+        monthName = calendar.months[monthIdx];
+        response = await getBirthdaysByMonth(monthIdx);
         if (Object.keys(response).length === 0) {
           return interaction.reply({
-            content: `No hay cumpleaños en ${calendar.months[month]}`,
-            flags: MessageFlags.Ephemeral,
+            embeds: [buildEmptyMonthEmbed(monthName)],
+            flags,
           });
         }
       } else {
         response = await getBirthdays();
+        if (Object.keys(response).length === 0) {
+          return interaction.reply({
+            embeds: [
+              baseEmbed("🎂 Sin cumpleaños registrados").setDescription(
+                "Todavía no hay nadie con cumpleaños registrado en el bot. Usa `/register` para empezar."
+              ),
+            ],
+            flags,
+          });
+        }
       }
-
-      const embed = new EmbedBuilder({
-        title: "Cumpleaños 🎂",
-        color: 0x00ff00,
-      });
-
-      const fields: APIEmbedField[] = [];
-      for (const monthName in response) {
-        const users = response[monthName].map(
-          (b: any) => ` \`${b.birthdayDay}\` <@${b.discordId}>`
-        );
-        users.sort((a, b) => {
-          const dayA = parseInt(a.split(" ")[1].replace("`", ""));
-          const dayB = parseInt(b.split(" ")[1].replace("`", ""));
-          return dayA - dayB;
-        });
-        fields.push({ name: monthName, value: users.join("\n"), inline: true });
-      }
-      embed.addFields(fields);
 
       return interaction.reply({
-        embeds: [embed],
-        allowedMentions: { repliedUser: false },
+        embeds: [buildBirthdaysEmbed(response, monthName)],
+        flags,
+        allowedMentions: { parse: [] },
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/mod/nextcum.test.ts
+++ b/src/slashCommands/mod/nextcum.test.ts
@@ -4,21 +4,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../shared/services/birthday.service");
 
 import * as birthdayService from "../../shared/services/birthday.service";
-import { createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import nextcum from "./nextcum";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const sample = {
+  name: "Diego",
+  discordId: "111",
+  birthdayDay: 17,
+  birthdayMonth: 2,
+};
+
 describe("/nextcum", () => {
   it("fetches the user and replies with the upcoming-birthday embed", async () => {
-    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue({
-      name: "Diego",
-      discordId: "111",
-      birthdayDay: 17,
-      birthdayMonth: 2,
-    });
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
 
     const interaction = createMockInteraction();
     const client = createMockClient();
@@ -28,6 +34,7 @@ describe("/nextcum", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(payload.allowedMentions).toEqual({ parse: [] });
   });
 
   it("replies ephemerally when no birthday is registered", async () => {
@@ -39,5 +46,47 @@ describe("/nextcum", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("renders the canonical fields: real name, mention, fecha, faltan", async () => {
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+
+    const interaction = createMockInteraction();
+    await nextcum.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Próximo cumple");
+    expect(embed.description).toContain("Diego");
+    expect(embed.description).toContain("<@111>");
+
+    const fechaField = embed.fields.find((f: any) => f.name === "📅 Fecha");
+    expect(fechaField.value).toContain("17 de Febrero");
+
+    const faltanField = embed.fields.find((f: any) => f.name === "⏳ Faltan");
+    expect(faltanField.value).toMatch(/^<t:\d+:R>$/);
+  });
+
+  it("uses mod-red color and the brand footer (no setAuthor)", async () => {
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+
+    const interaction = createMockInteraction();
+    await nextcum.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.color).toBe(0xed4245);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+
+    const i1 = createMockInteraction();
+    await nextcum.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await nextcum.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/nextcum.ts
+++ b/src/slashCommands/mod/nextcum.ts
@@ -1,30 +1,51 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import calendar from "../../shared/constants/calendar";
+import { getNextBirthday } from "../../shared/services/birthday.service";
 import {
   Argument,
   CumUser,
   ISlashCommand,
   Month,
 } from "../../shared/types";
-import { errorHandler, mentionUser } from "../../shared/utils/helpers";
-import { getNextBirthday } from "../../shared/services/birthday.service";
+import { errorHandler, nextBirthdayDate } from "../../shared/utils/helpers";
 
 const pull: ISlashCommand = {
   name: "nextcum",
   category: "mod",
-  description: "Próximo cumpleaños registrado",
+  description: "Muestra el próximo cumpleaños registrado",
   ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/nextcum", "/nextcum private:true"],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
-    _: Argument[]
+    args: Argument[]
   ) => {
     try {
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
       const response: CumUser = await getNextBirthday();
       if (!response?.discordId) {
         return interaction.reply({
@@ -34,28 +55,37 @@ const pull: ISlashCommand = {
       }
 
       const user = await client.users.fetch(response.discordId);
+      const day = response.birthdayDay!;
+      const monthIdx = (response.birthdayMonth! - 1) as Month;
+      const monthName = calendar.months[monthIdx];
+      const next = nextBirthdayDate(day, response.birthdayMonth!);
+      const relativeSeconds = Math.floor(next.getTime() / 1000);
 
-      const embed = new EmbedBuilder({
-        title: "Próximo cumpleaños 🎂",
-        color: 0x00ff00,
-        description: mentionUser(response.discordId),
-        thumbnail: { url: user.avatarURL() ?? "" },
-      }).addFields([
-        {
-          name: "Día",
-          value: `\`${response.birthdayDay!.toString()}\``,
-          inline: true,
-        },
-        {
-          name: "Mes",
-          value: `\`${calendar.months[(response.birthdayMonth! - 1) as Month]}\``,
-          inline: true,
-        },
-      ]);
+      const embed = new EmbedBuilder()
+        .setTitle("🎂 Próximo cumple")
+        .setThumbnail(user.avatarURL() ?? null)
+        .setDescription(
+          `**${response.name}** — <@${response.discordId}>`
+        )
+        .addFields(
+          {
+            name: "📅 Fecha",
+            value: `\`${day} de ${monthName}\``,
+            inline: true,
+          },
+          {
+            name: "⏳ Faltan",
+            value: `<t:${relativeSeconds}:R>`,
+            inline: true,
+          }
+        )
+        .setColor(colorForCategory("mod"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
       return interaction.reply({
         embeds: [embed],
-        allowedMentions: { repliedUser: false },
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+        allowedMentions: { parse: [] },
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/mod/who.ts
+++ b/src/slashCommands/mod/who.ts
@@ -18,21 +18,7 @@ import {
   getUserByName,
 } from "../../shared/services/user.service";
 import { Argument, ISlashCommand, Month } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
-
-/**
- * Returns the next occurrence of (day/month) starting from `from`. If the
- * birthday already happened this year, jumps to next year. Doesn't try to
- * be clever about Feb 29 in non-leap years — JS Date will roll over (Feb 30
- * → Mar 2), which is acceptable for a friend-server bot.
- */
-const nextBirthdayDate = (day: number, month: number, from: Date): Date => {
-  const candidate = new Date(from.getFullYear(), month - 1, day);
-  if (candidate.getTime() < from.getTime()) {
-    return new Date(from.getFullYear() + 1, month - 1, day);
-  }
-  return candidate;
-};
+import { errorHandler, nextBirthdayDate } from "../../shared/utils/helpers";
 
 const discordRelative = (date: Date | number) => {
   const seconds = Math.floor(
@@ -119,7 +105,7 @@ const pull: ISlashCommand = {
       const day = parseInt(res.birthdayDay);
       const month = parseInt(res.birthdayMonth);
       const monthName = calendar.months[(month - 1) as Month] ?? "?";
-      const nextBday = nextBirthdayDate(day, month, new Date());
+      const nextBday = nextBirthdayDate(day, month);
 
       const fields: { name: string; value: string; inline?: boolean }[] = [
         {


### PR DESCRIPTION
## Summary
Último batch del facelift de **mod** — los dos comandos que listan cumpleaños. Después de esto, los 18 comandos quedan faceliftados (info 4/4 ✅, fun 8/8 ✅, mod 6/6 ✅).

## /nextcum
- Title `🎂 Próximo cumple` (antes `Próximo cumpleaños 🎂`, emoji al inicio según convención)
- Color hardcoded green `0x00ff00` → mod red
- Description ahora con nombre real + mention (antes solo mention)
- **Nuevo field `⏳ Faltan`** con Discord `<t:UNIX:R>` para tiempo relativo localizado (ej. \"in 8 months\")
- Brand footer + `allowedMentions: { parse: [] }` para no pingar al próximo cumpleañero
- Nuevo \`private:\` opt-in

## /cums
- Title `🎂 Cumpleaños del servidor` o `🎂 Cumpleaños de Febrero` cuando filtra (antes `Cumpleaños 🎂`)
- Color mod red, brand footer, sin setAuthor
- Description con count y plural correcto: `**1** persona registrada` / `**N** personas registradas`
- **Empty-states** branded:
  - Filtro sin resultados: `🎂 Sin cumpleaños en Febrero`
  - Sin registros en absoluto: `🎂 Sin cumpleaños registrados` con apuntador a `/register`
- **Bug fix**: rechazo de mes out-of-range ahora también captura 0 y negativos (antes solo `> 12`)
- Nuevo \`private:\` opt-in
- `allowedMentions: { parse: [] }` para que las menciones del field no pinguen

## Helper compartido
`nextBirthdayDate(day, month, from?)` extraído a `shared/utils/helpers.ts` — lo usan `/who` y `/nextcum`. \`/who\` refactoreado para importarlo de ahí.

## Test plan
- [x] `pnpm test` → 259/259 (was 248, +11 nuevos)
- [x] `tsc --noEmit` → limpio
- [ ] `/nextcum` → embed con nombre, mention, fecha, faltan-tiempo
- [ ] `/nextcum private:true` → solo lo ves vos
- [ ] `/cums` → todos los cumples agrupados por mes, ordenados por día dentro de cada mes
- [ ] `/cums month:5` → solo Mayo, title \"de Mayo\"
- [ ] `/cums month:13` / \`month:0\` → notice ephemeral
- [ ] `/cums month:11` (mes vacío) → embed \"Sin cumpleaños en Noviembre\"