### PR TITLE
feat(commands): add complementary set — /about, /uptime, /changelog, /feedback, /team, /cum

### DIFF
--- a/src/shared/constants/changelog.ts
+++ b/src/shared/constants/changelog.ts
@@ -1,0 +1,46 @@
+/**
+ * Hardcoded changelog source for the /changelog slash command.
+ *
+ * Curatorial — not a literal mapping of git history. Bump a new entry at
+ * the top of the array when a release ships something the server cares
+ * about. Older entries can stay or get trimmed; the command shows them
+ * newest-first.
+ */
+
+export type ChangelogEntry = {
+  version: string;
+  date: string; // ISO YYYY-MM-DD
+  highlights: string[];
+};
+
+export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: "0.4.0",
+    date: "2026-05-08",
+    highlights: [
+      "Facelift completo de los 18 slash commands con branding consistente (info azul, fun amarillo, mod rojo).",
+      "/help con autocomplete, dropdown y botón ‘volver al listado’.",
+      "/love con persistencia en Mongo y subcomandos owner para curar overrides.",
+      "/clear ahora DMea al moderador un recap con texto y archivos de lo eliminado.",
+      "Nuevos comandos: /about, /changelog, /uptime, /feedback, /team, /cum.",
+    ],
+  },
+  {
+    version: "0.3.2",
+    date: "2026-05-06",
+    highlights: [
+      "Migración completa a discord.js v14, Node 22, Mongoose 8, pnpm 10.",
+      "Loaders estáticos en lugar de readdir dinámico (compatible con tsx watch).",
+      "143 tests cubriendo el bot end-to-end, CI con GitHub Actions.",
+      "Strings del bot pasados a español neutral (tuteo).",
+    ],
+  },
+  {
+    version: "0.3.0",
+    date: "2026-04-22",
+    highlights: [
+      "Refactor del code base: dead code purge, DAO directo, separación de responsabilidades.",
+      "Tests co-locados al lado del código (*.test.ts).",
+    ],
+  },
+];

--- a/src/shared/utils/birthdayReminder.ts
+++ b/src/shared/utils/birthdayReminder.ts
@@ -1,41 +1,57 @@
+import { EmbedBuilder, User } from "discord.js";
+
 import _config from "../../config";
-import ClientDiscord from "../classes/ClientDiscord";
 import * as userDao from "../../api/dao/user.dao";
 import { ResponseData } from "../../handlers/ResponseData";
+import ClientDiscord from "../classes/ClientDiscord";
 import { channelSender, dateToUTC5 } from "./helpers";
-import { EmbedBuilder } from "discord.js";
 
-export const reminder = async (client: ClientDiscord) => {
+/**
+ * Builds the birthday-greeting embed used by both the daily cron and the
+ * /cum slash command. Single source of truth so the two paths can never
+ * drift visually.
+ */
+export const buildBirthdayGreetingEmbed = (user: User): EmbedBuilder =>
+  new EmbedBuilder()
+    .setColor("Random")
+    .setTitle("GangBang al CUMpleañero! 🥳🎂🎉")
+    .setDescription(`👑 Felicitaciones **<@${user.id}>**`)
+    .setThumbnail(user.avatarURL({ size: 64 }) ?? null)
+    .setImage(
+      "https://i.pinimg.com/736x/f8/28/57/f82857d4da012fba311ea8040e163d5e.jpg"
+    )
+    .setTimestamp(new Date());
+
+/**
+ * Walks the registered users, fires the greeting for everyone whose birthday
+ * matches today's date in UTC-5. Returns the number of greetings sent so the
+ * caller (the cron, or the /cum slash command) can report it.
+ */
+export const reminder = async (
+  client: ClientDiscord
+): Promise<{ count: number }> => {
+  let count = 0;
   try {
     const today = dateToUTC5(new Date());
 
     const res = await userDao.readUsers();
-    if (res.statusCode !== 200) return;
+    if (res.statusCode !== 200) return { count: 0 };
 
     const users: any = (res as ResponseData).data;
 
-    users.forEach(async (e: any) => {
-      if (today.day === e.birthdayDay && today.month === e.birthdayMonth) {
-        const user = await client.users.fetch(e.discordId);
-        const embed = new EmbedBuilder()
-          .setColor("Random")
-          .setTitle("GangBang al CUMpleañero! 🥳🎂🎉")
-          .setDescription(`👑 Felicitaciones **<@${user.id}>**`)
-          .setThumbnail(
-            user.avatarURL({
-              size: 64,
-            })!
-          )
-          .setImage(
-            "https://i.pinimg.com/736x/f8/28/57/f82857d4da012fba311ea8040e163d5e.jpg"
-          )
-          .setTimestamp(new Date());
-
-        channelSender(client, _config.gmi2Channel, {
-          embeds: [embed],
-          allowedMentions: { repliedUser: true },
-        });
+    for (const e of users) {
+      if (today.day !== e.birthdayDay || today.month !== e.birthdayMonth) {
+        continue;
       }
-    });
-  } catch (error) {}
+      const user = await client.users.fetch(e.discordId);
+      channelSender(client, _config.gmi2Channel, {
+        embeds: [buildBirthdayGreetingEmbed(user)],
+        allowedMentions: { repliedUser: true },
+      });
+      count++;
+    }
+  } catch {
+    // best-effort cron — don't blow up the daily run
+  }
+  return { count };
 };

--- a/src/slashCommands/fun/team.test.ts
+++ b/src/slashCommands/fun/team.test.ts
@@ -1,0 +1,104 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import team from "./team";
+
+describe("/team", () => {
+  it("splits a list into N balanced teams (round-robin distribution)", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana bob carla diego eve frank"),
+      arg("teams", 2),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🧑‍🤝‍🧑 Equipos");
+    expect(embed.color).toBe(0xfee75c);
+    expect(embed.fields).toHaveLength(2);
+    // 6 items / 2 teams = 3 each
+    embed.fields.forEach((f: any) => {
+      expect(f.name).toMatch(/^🏳️ Equipo \d+ \(3\)$/);
+    });
+  });
+
+  it("balances unequal divisions (max diff of 1 between team sizes)", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "a b c d e"),
+      arg("teams", 3),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    // 5 items / 3 teams → sizes 2, 2, 1 (or 2, 1, 2 depending on shuffle)
+    const sizes = embed.fields.map((f: any) =>
+      parseInt(f.name.match(/\((\d+)\)/)![1])
+    );
+    expect(sizes.reduce((a: number, b: number) => a + b, 0)).toBe(5);
+    expect(Math.max(...sizes) - Math.min(...sizes)).toBeLessThanOrEqual(1);
+  });
+
+  it("accepts comma-separated lists", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana,bob,carla,diego"),
+      arg("teams", 2),
+    ]);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.fields).toHaveLength(2);
+  });
+
+  it("rejects ephemerally when teams is out of range", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "a b c d"),
+      arg("teams", 99),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("entre 2 y 10");
+  });
+
+  it("rejects ephemerally when the list has fewer items than teams", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana bob"),
+      arg("teams", 5),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("No hay suficientes");
+  });
+
+  it("rejects ephemerally when the list has fewer than 2 items", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "solo"),
+      arg("teams", 2),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 2");
+  });
+
+  it("ephemeral when private:true", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana bob carla"),
+      arg("teams", 2),
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+});

--- a/src/slashCommands/fun/team.ts
+++ b/src/slashCommands/fun/team.ts
@@ -1,0 +1,128 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler, shuffle } from "../../shared/utils/helpers";
+
+const MIN_TEAMS = 2;
+const MAX_TEAMS = 10;
+const MIN_LIST_SIZE = 2;
+
+/**
+ * Splits a list into N teams via round-robin: shuffled list distributed one
+ * item at a time. Yields balanced sizes (max diff of 1) regardless of total.
+ */
+const splitIntoTeams = <T>(items: T[], teams: number): T[][] => {
+  const buckets: T[][] = Array.from({ length: teams }, () => []);
+  items.forEach((item, i) => buckets[i % teams].push(item));
+  return buckets;
+};
+
+const parseList = (raw: string): string[] =>
+  raw
+    .split(/[,;\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+const pull: ISlashCommand = {
+  name: "team",
+  category: "fun",
+  description: "Divide una lista en N equipos balanceados",
+  ownerOnly: false,
+  options: [
+    {
+      name: "list",
+      description: "Lista separada por espacios, comas o punto y coma",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+    },
+    {
+      name: "teams",
+      description: `Cantidad de equipos (${MIN_TEAMS}–${MAX_TEAMS})`,
+      type: ApplicationCommandOptionType.Integer,
+      required: true,
+    },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/team list:ana bob carla diego eve frank teams:2",
+    "/team list:ana,bob,carla,diego teams:2",
+  ],
+  run: async (
+    _: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const rawList = (args.find((a) => a.name === "list")?.value as string) ?? "";
+      const teams = args.find((a) => a.name === "teams")?.value as number;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      if (teams < MIN_TEAMS || teams > MAX_TEAMS) {
+        return interaction.reply({
+          content: `La cantidad de equipos debe estar entre ${MIN_TEAMS} y ${MAX_TEAMS}.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      const list = parseList(rawList);
+      if (list.length < MIN_LIST_SIZE) {
+        return interaction.reply({
+          content: `Necesito al menos ${MIN_LIST_SIZE} elementos. Separá la lista con espacios, comas o punto y coma.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+      if (list.length < teams) {
+        return interaction.reply({
+          content: `No hay suficientes elementos (${list.length}) para armar ${teams} equipos.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      const shuffled = shuffle(list);
+      const buckets = splitIntoTeams(shuffled, teams);
+
+      const fields = buckets.map((bucket, i) => ({
+        name: `🏳️ Equipo ${i + 1} (${bucket.length})`,
+        value: bucket.map((m, j) => `**${j + 1}.** ${m}`).join("\n"),
+        inline: true,
+      }));
+
+      const embed = new EmbedBuilder()
+        .setTitle("🧑‍🤝‍🧑 Equipos")
+        .setDescription(
+          `**${list.length}** ${list.length === 1 ? "persona" : "personas"} divididas en **${teams}** equipos.`
+        )
+        .setColor(colorForCategory("fun"))
+        .addFields(fields)
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/index.ts
+++ b/src/slashCommands/index.ts
@@ -19,13 +19,19 @@ import poke from "./fun/poke";
 import roll from "./fun/roll";
 import ruleta from "./fun/ruleta";
 import shuffle from "./fun/shuffle";
+import team from "./fun/team";
 
+import about from "./info/about";
+import changelog from "./info/changelog";
 import channelId from "./info/channel-id";
+import feedback from "./info/feedback";
 import gmi2 from "./info/gmi2";
 import help from "./info/help";
 import ping from "./info/ping";
+import uptime from "./info/uptime";
 
 import clear from "./mod/clear";
+import cum from "./mod/cum";
 import cums from "./mod/cums";
 import nextcum from "./mod/nextcum";
 import register from "./mod/register";
@@ -42,13 +48,19 @@ const slashCommands: ISlashCommand[] = [
   roll,
   ruleta,
   shuffle,
+  team,
   // info
+  about,
+  changelog,
   channelId,
+  feedback,
   gmi2,
   help,
   ping,
+  uptime,
   // mod
   clear,
+  cum,
   cums,
   nextcum,
   register,

--- a/src/slashCommands/info/about.test.ts
+++ b/src/slashCommands/info/about.test.ts
@@ -1,0 +1,37 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import about from "./about";
+
+describe("/about", () => {
+  it("renders an info-color embed with version, stack, and repo link", async () => {
+    const interaction = createMockInteraction();
+    await about.run(createMockClient(), interaction, []);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toMatch(/Xiza Bot/);
+    expect(embed.color).toBe(0x5865f2); // info blurple
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+
+    const fieldNames = embed.fields.map((f: any) => f.name);
+    expect(fieldNames).toContain("📦 Versión");
+    expect(fieldNames).toContain("⚙️ Stack");
+    expect(fieldNames).toContain("🔗 Código");
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    const i1 = createMockInteraction();
+    await about.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await about.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
+  });
+});

--- a/src/slashCommands/info/about.ts
+++ b/src/slashCommands/info/about.ts
@@ -1,0 +1,68 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const REPO_URL = "https://github.com/Xiza73/BotitoV2";
+
+const pull: ISlashCommand = {
+  name: "about",
+  category: "info",
+  description: "Información del bot",
+  ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/about", "/about private:true"],
+  run: async (
+    client: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      const embed = new EmbedBuilder()
+        .setTitle(`🤖 ${BOT_BRAND_NAME}`)
+        .setThumbnail(client.user?.avatarURL() ?? null)
+        .setDescription(
+          "Bot de Discord para el server de Gmi2. Cumpleaños, juegos, mod tools y un par de tonterías más."
+        )
+        .addFields(
+          { name: "📦 Versión", value: `\`${BOT_VERSION}\``, inline: true },
+          { name: "⚙️ Stack", value: "Node 22 · TS 5 · discord.js 14", inline: true },
+          { name: "🔗 Código", value: `[GitHub](${REPO_URL})`, inline: true }
+        )
+        .setColor(colorForCategory("info"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/info/changelog.test.ts
+++ b/src/slashCommands/info/changelog.test.ts
@@ -1,0 +1,82 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { CHANGELOG } from "../../shared/constants/changelog";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import changelog from "./changelog";
+
+describe("/changelog", () => {
+  it("by default, renders an embed listing all versions newest-first", async () => {
+    const interaction = createMockInteraction();
+    await changelog.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("📜 Changelog");
+    expect(embed.color).toBe(0x5865f2);
+    // The current top entry's version appears in the body
+    expect(embed.description).toContain(`v${CHANGELOG[0].version}`);
+  });
+
+  it("with a version arg, renders only that version", async () => {
+    const target = CHANGELOG[1] ?? CHANGELOG[0];
+    const interaction = createMockInteraction();
+    await changelog.run(createMockClient(), interaction, [
+      arg("version", target.version),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe(`📜 Changelog — v${target.version}`);
+    expect(embed.description).toContain(target.date);
+  });
+
+  it("rejects ephemerally when the requested version doesn't exist", async () => {
+    const interaction = createMockInteraction();
+    await changelog.run(createMockClient(), interaction, [
+      arg("version", "99.99.99"),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("99.99.99");
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    const i1 = createMockInteraction();
+    await changelog.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await changelog.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  describe("autocomplete", () => {
+    const buildAutocomplete = (focusedValue: string) =>
+      ({
+        options: {
+          getFocused: vi
+            .fn()
+            .mockReturnValue({ name: "version", value: focusedValue }),
+        },
+        respond: vi.fn().mockResolvedValue(undefined),
+      }) as any;
+
+    it("returns matching versions as choices", async () => {
+      const interaction = buildAutocomplete("0.4");
+      await changelog.autocomplete!(createMockClient(), interaction);
+      const choices = interaction.respond.mock.calls[0][0];
+      expect(choices.some((c: any) => c.value.startsWith("0.4"))).toBe(true);
+    });
+
+    it("returns the full list when query is empty", async () => {
+      const interaction = buildAutocomplete("");
+      await changelog.autocomplete!(createMockClient(), interaction);
+      const choices = interaction.respond.mock.calls[0][0];
+      expect(choices.length).toBe(CHANGELOG.length);
+    });
+  });
+});

--- a/src/slashCommands/info/changelog.ts
+++ b/src/slashCommands/info/changelog.ts
@@ -1,0 +1,126 @@
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { CHANGELOG, ChangelogEntry } from "../../shared/constants/changelog";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+// Discord embed description maxes out at 4096; we leave a margin for the
+// field-style version headers we render inline.
+const MAX_DESCRIPTION = 3800;
+
+const buildAllVersionsEmbed = () => {
+  const lines: string[] = [];
+  for (const entry of CHANGELOG) {
+    const header = `### \`v${entry.version}\` — ${entry.date}`;
+    const body = entry.highlights.map((h) => `• ${h}`).join("\n");
+    const block = `${header}\n${body}\n`;
+
+    if (lines.join("\n").length + block.length > MAX_DESCRIPTION) {
+      lines.push("\n_(versiones más viejas truncadas)_");
+      break;
+    }
+    lines.push(block);
+  }
+
+  return new EmbedBuilder()
+    .setTitle("📜 Changelog")
+    .setDescription(lines.join("\n").trim() || "_(sin entradas)_")
+    .setColor(colorForCategory("info"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildSingleVersionEmbed = (entry: ChangelogEntry) =>
+  new EmbedBuilder()
+    .setTitle(`📜 Changelog — v${entry.version}`)
+    .setDescription(`**${entry.date}**\n\n${entry.highlights.map((h) => `• ${h}`).join("\n")}`)
+    .setColor(colorForCategory("info"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const pull: ISlashCommand = {
+  name: "changelog",
+  category: "info",
+  description: "Lista los cambios y novedades del bot",
+  ownerOnly: false,
+  options: [
+    {
+      name: "version",
+      description: "Versión específica a mostrar (default: todas)",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: true,
+    },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/changelog", "/changelog version:0.4.0"],
+  autocomplete: async (
+    _: ClientDiscord,
+    interaction: AutocompleteInteraction
+  ) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== "version") {
+      await interaction.respond([]);
+      return;
+    }
+    const query = String(focused.value ?? "").toLowerCase();
+    const matches = CHANGELOG.filter((e) => e.version.includes(query))
+      .slice(0, 25)
+      .map((e) => ({ name: `v${e.version} (${e.date})`, value: e.version }));
+    await interaction.respond(matches);
+  },
+  run: async (
+    _: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const versionArg = args.find((a) => a.name === "version")?.value as
+        | string
+        | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
+
+      if (versionArg) {
+        const entry = CHANGELOG.find((e) => e.version === versionArg);
+        if (!entry) {
+          return interaction.reply({
+            content: `No encontré la versión \`${versionArg}\`.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        return interaction.reply({
+          embeds: [buildSingleVersionEmbed(entry)],
+          flags,
+        });
+      }
+
+      return interaction.reply({
+        embeds: [buildAllVersionsEmbed()],
+        flags,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/info/feedback.test.ts
+++ b/src/slashCommands/info/feedback.test.ts
@@ -1,0 +1,106 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import feedback from "./feedback";
+
+const setupClientWithOwner = () => {
+  const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
+  const ownerCreateDM = vi.fn().mockResolvedValue({ send: dmSend });
+  const client = createMockClient({
+    config: { ownerId: "owner-1" },
+    users: {
+      fetch: vi
+        .fn()
+        .mockResolvedValue({ id: "owner-1", createDM: ownerCreateDM }),
+    },
+  });
+  return { client, dmSend, ownerCreateDM };
+};
+
+describe("/feedback", () => {
+  it("DMs the owner with a branded embed and confirms ephemerally", async () => {
+    const { client, dmSend } = setupClientWithOwner();
+    const interaction = createMockInteraction({
+      user: {
+        id: "alice",
+        username: "alice",
+        tag: "alice#0001",
+        displayAvatarURL: () => "https://example.com/a.png",
+      },
+    });
+
+    await feedback.run(client, interaction, [
+      arg("message", "el bot está bárbaro"),
+    ]);
+
+    expect(dmSend).toHaveBeenCalledOnce();
+    const dmPayload = dmSend.mock.calls[0][0];
+    const embed = dmPayload.embeds[0].data;
+    expect(embed.title).toBe("📨 Feedback recibido");
+    expect(embed.description).toBe("el bot está bárbaro");
+    expect(embed.color).toBe(0x5865f2);
+
+    const fromField = embed.fields.find((f: any) => f.name === "👤 De");
+    expect(fromField.value).toContain("<@alice>");
+
+    const replyPayload = interaction.reply.mock.calls[0][0];
+    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
+    expect(replyPayload.content).toContain("gracias");
+  });
+
+  it("hides the author when anonymous:true is passed", async () => {
+    const { client, dmSend } = setupClientWithOwner();
+    const interaction = createMockInteraction({
+      user: {
+        id: "alice",
+        username: "alice",
+        tag: "alice#0001",
+        displayAvatarURL: () => "https://example.com/a.png",
+      },
+    });
+
+    await feedback.run(client, interaction, [
+      arg("message", "queja anónima"),
+      arg("anonymous", true),
+    ]);
+
+    const embed = dmSend.mock.calls[0][0].embeds[0].data;
+    const fromField = embed.fields.find((f: any) => f.name === "👤 De");
+    expect(fromField.value).toContain("anónimo");
+    expect(fromField.value).not.toContain("alice");
+  });
+
+  it("rejects ephemerally on empty message", async () => {
+    const { client } = setupClientWithOwner();
+    const interaction = createMockInteraction();
+    await feedback.run(client, interaction, [arg("message", "   ")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("vacío");
+  });
+
+  it("returns a friendly error if the owner DM can't be delivered", async () => {
+    const ownerCreateDM = vi.fn().mockRejectedValue(new Error("blocked"));
+    const client = createMockClient({
+      config: { ownerId: "owner-1" },
+      users: {
+        fetch: vi
+          .fn()
+          .mockResolvedValue({ id: "owner-1", createDM: ownerCreateDM }),
+      },
+    });
+    const interaction = createMockInteraction();
+
+    await feedback.run(client, interaction, [arg("message", "hola")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("No pude entregar");
+  });
+});

--- a/src/slashCommands/info/feedback.ts
+++ b/src/slashCommands/info/feedback.ts
@@ -1,0 +1,100 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const MAX_FEEDBACK = 1500;
+
+const pull: ISlashCommand = {
+  name: "feedback",
+  category: "info",
+  description: "Envía feedback o sugerencias al owner del bot",
+  ownerOnly: false,
+  options: [
+    {
+      name: "message",
+      description: "Tu feedback o sugerencia",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+    },
+    {
+      name: "anonymous",
+      description: "Enviar sin tu nombre (default: false)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/feedback message:falta el comando X",
+    "/feedback message:gran trabajo anonymous:true",
+  ],
+  run: async (
+    client: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const text = args.find((a) => a.name === "message")?.value as string;
+      const anonymous =
+        (args.find((a) => a.name === "anonymous")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      if (!text || text.trim().length === 0) {
+        return interaction.reply({
+          content: "El mensaje no puede estar vacío.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      const trimmed =
+        text.length > MAX_FEEDBACK ? text.slice(0, MAX_FEEDBACK) + "…" : text;
+
+      const embed = new EmbedBuilder()
+        .setTitle("📨 Feedback recibido")
+        .setDescription(trimmed)
+        .setColor(colorForCategory("info"))
+        .addFields({
+          name: "👤 De",
+          value: anonymous
+            ? "_(anónimo)_"
+            : `<@${interaction.user.id}> (\`${interaction.user.tag ?? interaction.user.username}\`)`,
+          inline: false,
+        })
+        .setTimestamp(new Date())
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      try {
+        const owner = await client.users.fetch(client.config.ownerId);
+        const dm = await owner.createDM();
+        await dm.send({ embeds: [embed], allowedMentions: { parse: [] } });
+      } catch {
+        return interaction.reply({
+          content:
+            "No pude entregar tu feedback al owner. Intenta de nuevo en un rato.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      return interaction.reply({
+        content: "✅ Listo, gracias por tu feedback.",
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/info/uptime.test.ts
+++ b/src/slashCommands/info/uptime.test.ts
@@ -1,0 +1,37 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import uptime from "./uptime";
+
+describe("/uptime", () => {
+  it("renders a branded embed with formatted uptime and a relative-time start", async () => {
+    const interaction = createMockInteraction();
+    await uptime.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("⏰ Uptime");
+    expect(embed.color).toBe(0x5865f2);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.description).toMatch(/`[\dsmhd ]+`/);
+
+    const startedField = embed.fields.find(
+      (f: any) => f.name === "🚀 Activo desde"
+    );
+    expect(startedField.value).toMatch(/^<t:\d+:R>$/);
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    const i1 = createMockInteraction();
+    await uptime.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await uptime.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
+  });
+});

--- a/src/slashCommands/info/uptime.ts
+++ b/src/slashCommands/info/uptime.ts
@@ -1,0 +1,68 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler, formatUptime } from "../../shared/utils/helpers";
+
+const pull: ISlashCommand = {
+  name: "uptime",
+  category: "info",
+  description: "Tiempo activo del bot desde el último deploy",
+  ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/uptime", "/uptime private:true"],
+  run: async (
+    _: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      const uptimeSec = process.uptime();
+      const startedTimestamp = Math.floor(
+        (Date.now() - uptimeSec * 1000) / 1000
+      );
+
+      const embed = new EmbedBuilder()
+        .setTitle("⏰ Uptime")
+        .setDescription(`\`${formatUptime(uptimeSec)}\``)
+        .addFields({
+          name: "🚀 Activo desde",
+          value: `<t:${startedTimestamp}:R>`,
+          inline: true,
+        })
+        .setColor(colorForCategory("info"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/mod/cum.test.ts
+++ b/src/slashCommands/mod/cum.test.ts
@@ -1,0 +1,59 @@
+import { MessageFlags } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../shared/utils/birthdayReminder");
+
+import * as birthdayReminder from "../../shared/utils/birthdayReminder";
+import {
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import cum from "./cum";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("/cum", () => {
+  it("calls reminder() and reports the count back to the moderator (ephemeral)", async () => {
+    vi.mocked(birthdayReminder.reminder).mockResolvedValue({ count: 2 });
+    const interaction = createMockInteraction();
+
+    await cum.run(createMockClient(), interaction, []);
+
+    expect(birthdayReminder.reminder).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("**2** saludos");
+  });
+
+  it("uses singular 'saludo' when only one greeting fired", async () => {
+    vi.mocked(birthdayReminder.reminder).mockResolvedValue({ count: 1 });
+    const interaction = createMockInteraction();
+
+    await cum.run(createMockClient(), interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.content).toContain("**1** saludo");
+    expect(payload.content).not.toContain("saludos");
+  });
+
+  it("returns a friendly notice when no birthday matches today", async () => {
+    vi.mocked(birthdayReminder.reminder).mockResolvedValue({ count: 0 });
+    const interaction = createMockInteraction();
+
+    await cum.run(createMockClient(), interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("nadie");
+  });
+
+  it("is marked owner-only at the schema level", () => {
+    expect(cum.ownerOnly).toBe(true);
+  });
+});

--- a/src/slashCommands/mod/cum.ts
+++ b/src/slashCommands/mod/cum.ts
@@ -1,0 +1,42 @@
+import {
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { reminder } from "../../shared/utils/birthdayReminder";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const pull: ISlashCommand = {
+  name: "cum",
+  category: "mod",
+  description: "[Owner] Dispara manualmente el saludo de cumpleaños del día",
+  ownerOnly: true,
+  examples: ["/cum"],
+  run: async (
+    client: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    _: Argument[]
+  ) => {
+    try {
+      const { count } = await reminder(client);
+
+      const message =
+        count === 0
+          ? "Hoy no es cumple de nadie registrado."
+          : count === 1
+            ? "Disparé **1** saludo."
+            : `Disparé **${count}** saludos.`;
+
+      return interaction.reply({
+        content: message,
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;


### PR DESCRIPTION
## Summary
Seis comandos complementarios después del facelift. Trae el bot de 18 → 24 comandos.

## Comandos nuevos

| Cmd | Categoría | Resumen |
|---|---|---|
| `/about` | info | Versión, stack, link al repo |
| `/uptime` | info | Tiempo activo + 'Activo desde' relativo |
| `/changelog` | info | Lista de cambios (hardcoded), autocomplete por versión |
| `/feedback` | info | DM al owner, opt-in `anonymous:` |
| `/team` | fun | Divide una lista en N equipos vía round-robin |
| `/cum` | mod (owner) | Dispara manualmente el cron de cumples del día |

## Detalles relevantes

### `/changelog`
- Source hardcoded en `src/shared/constants/changelog.ts`. **Curatorial**, no histórico literal — bumpear nueva entry arriba cuando algo importante salga.
- Sin args → todas las versiones, newest-first, truncado al budget del embed.
- Con `version:0.4.0` → solo esa versión.
- Autocomplete trae las versiones por substring.

### `/feedback`
- DM branded al owner con el message + autor (o `_(anónimo)_` si \`anonymous:true\`).
- Reply ephemeral con confirmación (\`✅ Listo, gracias\`) o error friendly si el DM al owner no se entrega.

### `/team`
- Round-robin después de shuffle → tamaños balanceados (max diff 1).
- Validaciones: \`teams ∈ [2, 10]\`, lista ≥ 2 items, lista ≥ teams.
- Mismo separador que `/shuffle` (coma, punto y coma, whitespace).

### `/cum`
- Owner-only.
- **Refactor de `birthdayReminder.ts`**:
  - \`buildBirthdayGreetingEmbed(user)\` extraído como helper exportado → cron y `/cum` comparten la fuente del embed.
  - \`reminder()\` ahora retorna \`{ count }\` en vez de \`void\`.
- Reply ephemeral: \`Disparé N saludos\` / \`Hoy no es cumple de nadie registrado\`.

## Test plan
- [x] \`pnpm test\` → 284/284 (was 259, +25)
- [x] \`tsc --noEmit\` → limpio
- [ ] \`/about\` → embed branded, version del package.json
- [ ] \`/uptime\` → tiempo formateado + relative \`Activo desde\`
- [ ] \`/changelog\` (sin args) → todas las versiones
- [ ] \`/changelog version:0.4.0\` → solo esa versión
- [ ] \`/changelog version:99\` → ephemeral notice
- [ ] \`/feedback message:test\` → DM al owner con autor visible
- [ ] \`/feedback message:test anonymous:true\` → DM con \`_(anónimo)_\`
- [ ] \`/team list:ana,bob,carla,diego teams:2\` → 2 equipos balanceados
- [ ] \`/team list:a,b teams:5\` → ephemeral 'no hay suficientes'
- [ ] \`/cum\` (owner, día sin cumples) → 'Hoy no es cumple de nadie'
- [ ] \`/cum\` (owner, día con cumples) → dispara saludo público + reply ephemeral con count