### PR TITLE
release: v0.4.0 — facelift completo + 6 comandos complementarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botito",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botito",
-  "version": "1.0.0",
+  "version": "0.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/api/dao/love.dao.test.ts
+++ b/src/api/dao/love.dao.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { setupInMemoryMongo } from "../../test-utils/setup-mongo";
+import * as loveDao from "./love.dao";
+
+setupInMemoryMongo();
+
+describe("love.dao (against in-memory mongo)", () => {
+  describe("buildPairKey + computeAutoPercentage", () => {
+    it("buildPairKey is order-independent", () => {
+      expect(loveDao.buildPairKey("a", "b")).toBe(loveDao.buildPairKey("b", "a"));
+    });
+
+    it("buildPairKey sorts lexicographically", () => {
+      expect(loveDao.buildPairKey("zzz", "aaa")).toBe("aaa-zzz");
+    });
+
+    it("computeAutoPercentage returns the same value for the same pair", () => {
+      const a = loveDao.computeAutoPercentage("user-a", "user-b");
+      const b = loveDao.computeAutoPercentage("user-b", "user-a");
+      expect(a).toBe(b);
+    });
+
+    it("computeAutoPercentage stays in [0, 100]", () => {
+      for (let i = 0; i < 100; i++) {
+        const pct = loveDao.computeAutoPercentage(`a${i}`, `b${i}`);
+        expect(pct).toBeGreaterThanOrEqual(0);
+        expect(pct).toBeLessThanOrEqual(100);
+      }
+    });
+  });
+
+  describe("getOrCreatePair", () => {
+    it("creates a row with the auto-computed percentage on first call", async () => {
+      const result = await loveDao.getOrCreatePair("u1", "u2");
+      expect(result.statusCode).toBe(200);
+      const data = (result as any).data;
+      expect(data.user1).toBe("u1");
+      expect(data.user2).toBe("u2");
+      expect(data.percentage).toBe(loveDao.computeAutoPercentage("u1", "u2"));
+      expect(data.isOverride).toBe(false);
+      expect(data.verdict).toBeNull();
+    });
+
+    it("returns the same row on the second call (no duplicate inserts)", async () => {
+      const first = await loveDao.getOrCreatePair("u1", "u2");
+      const second = await loveDao.getOrCreatePair("u1", "u2");
+      expect((first as any).data._id.toString()).toBe(
+        (second as any).data._id.toString()
+      );
+    });
+
+    it("normalizes argument order via the pairKey", async () => {
+      await loveDao.getOrCreatePair("u1", "u2");
+      const flipped = await loveDao.getOrCreatePair("u2", "u1");
+      expect((flipped as any).data.pairKey).toBe(
+        loveDao.buildPairKey("u1", "u2")
+      );
+    });
+
+    it("returns 400 when an ID is missing", async () => {
+      const result = await loveDao.getOrCreatePair("", "u2");
+      expect(result.statusCode).toBe(400);
+    });
+  });
+
+  describe("setOverride", () => {
+    it("creates the row and marks it as overridden when no row exists yet", async () => {
+      const result = await loveDao.setOverride(
+        "u1",
+        "u2",
+        88,
+        "Tortolitos del server",
+        "owner-1"
+      );
+      expect(result.statusCode).toBe(200);
+      const data = (result as any).data;
+      expect(data.percentage).toBe(88);
+      expect(data.verdict).toBe("Tortolitos del server");
+      expect(data.isOverride).toBe(true);
+      expect(data.setBy).toBe("owner-1");
+    });
+
+    it("upgrades an auto-populated row to an override", async () => {
+      await loveDao.getOrCreatePair("u1", "u2"); // auto row first
+      const result = await loveDao.setOverride("u1", "u2", 50, null, "owner-1");
+      const data = (result as any).data;
+      expect(data.percentage).toBe(50);
+      expect(data.isOverride).toBe(true);
+      expect(data.verdict).toBeNull();
+    });
+
+    it("rejects out-of-range percentages", async () => {
+      const high = await loveDao.setOverride("u1", "u2", 101, null, "owner-1");
+      const low = await loveDao.setOverride("u1", "u2", -5, null, "owner-1");
+      expect(high.statusCode).toBe(422);
+      expect(low.statusCode).toBe(422);
+    });
+  });
+
+  describe("resetPair", () => {
+    it("removes an existing pair so it can be auto-computed again", async () => {
+      await loveDao.setOverride("u1", "u2", 88, "Custom", "owner-1");
+
+      const reset = await loveDao.resetPair("u1", "u2");
+      expect(reset.statusCode).toBe(200);
+
+      const recreated = await loveDao.getOrCreatePair("u1", "u2");
+      const data = (recreated as any).data;
+      expect(data.isOverride).toBe(false);
+      expect(data.percentage).toBe(loveDao.computeAutoPercentage("u1", "u2"));
+    });
+
+    it("returns 404 when the pair never existed", async () => {
+      const reset = await loveDao.resetPair("ghost1", "ghost2");
+      expect(reset.statusCode).toBe(404);
+    });
+  });
+});

--- a/src/api/dao/love.dao.ts
+++ b/src/api/dao/love.dao.ts
@@ -1,0 +1,122 @@
+import ErrorHandler from "../../handlers/ErrorHandler";
+import ResponseBase from "../../handlers/ResponseBase";
+import ResponseData from "../../handlers/ResponseData";
+import Love, { ILove } from "../models/Love";
+
+/**
+ * Stable key for a pair of user IDs. Sort first so the order of arguments
+ * is irrelevant: pairKey("a","b") === pairKey("b","a").
+ */
+export const buildPairKey = (id1: string, id2: string): string =>
+  [id1, id2].sort().join("-");
+
+/**
+ * djb2-ish 32-bit hash, deterministic per input string.
+ * Lives here (not in the slash command) so DAO test fixtures can predict
+ * the auto-populated percentage.
+ */
+const hashString = (s: string): number => {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h << 5) - h + s.charCodeAt(i);
+    h = h | 0;
+  }
+  return Math.abs(h);
+};
+
+export const computeAutoPercentage = (id1: string, id2: string): number =>
+  hashString(buildPairKey(id1, id2)) % 101;
+
+/**
+ * Reads the pair from Mongo. If it doesn't exist, creates it with the
+ * auto-computed percentage. Either way, returns the persisted document.
+ */
+export const getOrCreatePair = async (id1: string, id2: string) => {
+  try {
+    if (!id1 || !id2) {
+      return new ErrorHandler(400, "Faltan los IDs de usuario");
+    }
+
+    const pairKey = buildPairKey(id1, id2);
+    const existing = await Love.findOne({ pairKey });
+    if (existing) {
+      return ResponseData(200, "Pareja encontrada", existing);
+    }
+
+    const created: ILove = new Love({
+      pairKey,
+      user1: id1,
+      user2: id2,
+      percentage: computeAutoPercentage(id1, id2),
+      verdict: null,
+      isOverride: false,
+      setBy: null,
+    });
+    await created.save();
+    return ResponseData(200, "Pareja creada", created);
+  } catch (err) {
+    return new ErrorHandler(500, "Error al obtener/crear la pareja");
+  }
+};
+
+/**
+ * Marks the pair as admin-overridden. Upserts: works even if the pair has
+ * never been queried before. Used by /love set.
+ */
+export const setOverride = async (
+  id1: string,
+  id2: string,
+  percentage: number,
+  verdict: string | null,
+  setBy: string
+) => {
+  try {
+    if (!id1 || !id2) {
+      return new ErrorHandler(400, "Faltan los IDs de usuario");
+    }
+    if (percentage < 0 || percentage > 100) {
+      return new ErrorHandler(422, "El porcentaje debe estar entre 0 y 100");
+    }
+
+    const pairKey = buildPairKey(id1, id2);
+    const updated = await Love.findOneAndUpdate(
+      { pairKey },
+      {
+        $set: {
+          user1: id1,
+          user2: id2,
+          percentage,
+          verdict,
+          isOverride: true,
+          setBy,
+        },
+        $setOnInsert: { pairKey },
+      },
+      { new: true, upsert: true }
+    );
+    return ResponseData(200, "Override aplicado", updated);
+  } catch (err) {
+    return new ErrorHandler(500, "Error al aplicar el override");
+  }
+};
+
+/**
+ * Removes the pair from Mongo. The next /love call will re-create it from
+ * the deterministic hash. Used by /love reset.
+ */
+export const resetPair = async (id1: string, id2: string) => {
+  try {
+    if (!id1 || !id2) {
+      return new ErrorHandler(400, "Faltan los IDs de usuario");
+    }
+
+    const pairKey = buildPairKey(id1, id2);
+    const deleted = await Love.findOneAndDelete({ pairKey });
+    if (!deleted) {
+      return new ErrorHandler(404, "La pareja no estaba registrada");
+    }
+    return ResponseBase(200, "Pareja reseteada");
+  } catch (err) {
+    return new ErrorHandler(500, "Error al resetear la pareja");
+  }
+};

--- a/src/api/models/Love.ts
+++ b/src/api/models/Love.ts
@@ -1,0 +1,31 @@
+import { Document, Schema, model } from "mongoose";
+
+export interface ILove extends Document {
+  /** Sorted "userIdA-userIdB". Unique key for a pair regardless of arg order. */
+  pairKey: string;
+  user1: string;
+  user2: string;
+  /** 0–100 inclusive. Either auto-computed from a deterministic hash or admin-overridden. */
+  percentage: number;
+  /** Custom verdict text. `null` means use the bucket-based phrase from /love code. */
+  verdict: string | null;
+  /** True when an admin manually edited percentage/verdict. False = auto-populated. */
+  isOverride: boolean;
+  /** Discord ID of the admin who set the override. Null when auto-populated. */
+  setBy: string | null;
+}
+
+const LoveSchema = new Schema<ILove>(
+  {
+    pairKey: { type: String, required: true, unique: true, index: true },
+    user1: { type: String, required: true },
+    user2: { type: String, required: true },
+    percentage: { type: Number, required: true, min: 0, max: 100 },
+    verdict: { type: String, default: null },
+    isOverride: { type: Boolean, default: false },
+    setBy: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+export default model<ILove>("Love", LoveSchema);

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1,16 +1,11 @@
 import { Router } from "express";
-import { readdirSync } from "fs";
-import path from "path";
+
+import routes from "./routes";
 
 const _router: Router = Router();
 
-(async () => {
-  const routes = readdirSync(path.resolve(__dirname, "./routes"));
-  for (const route of routes) {
-    const routeFile = await import(`./routes/${route}`);
-    const routePath = `/${route.split(".")[0]}`;
-    _router.use(routePath, routeFile.default);
-  }
-})();
+for (const { path, router } of routes) {
+  _router.use(path, router);
+}
 
 export default _router;

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -1,0 +1,29 @@
+// Manifest estático de routes de Express.
+//
+// Este array es la única fuente de verdad para qué rutas monta el router de
+// `/api`. Si agregás una route nueva:
+//   1. Crearla en `src/api/routes/<recurso>.router.ts` con `export default Router`
+//   2. Importarla arriba y agregar la entrada con `path` y `router`
+//
+// No usamos `readdirSync` + `import()` dinámico — ver
+// `src/slashCommands/index.ts` para el por qué.
+// Bonus: el loader anterior corría en una IIFE async, lo que generaba una
+// race condition contra `app.listen`. Con imports estáticos las rutas se
+// montan sincrónicamente antes de que arranque el server.
+
+import { Router } from "express";
+
+import birthdayRouter from "./birthday.router";
+import userRouter from "./user.router";
+
+export interface RouteEntry {
+  path: string;
+  router: Router;
+}
+
+const routes: RouteEntry[] = [
+  { path: "/birthday", router: birthdayRouter },
+  { path: "/user", router: userRouter },
+];
+
+export default routes;

--- a/src/events/client/interactionCreate.test.ts
+++ b/src/events/client/interactionCreate.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType } from "discord.js";
+import { ApplicationCommandOptionType, MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createMockClient } from "../../test-utils/discord-mocks";
@@ -8,6 +8,7 @@ const createInteraction = (overrides: Record<string, any> = {}) => {
   const reply = vi.fn().mockResolvedValue(undefined);
   return {
     reply,
+    isAutocomplete: () => false,
     isChatInputCommand: () => true,
     command: { id: "cmd" },
     commandName: "ping",
@@ -66,7 +67,7 @@ describe("interactionCreate", () => {
     expect(command.run).not.toHaveBeenCalled();
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("dispatches to command.run with parsed args on the happy path", () => {
@@ -93,6 +94,54 @@ describe("interactionCreate", () => {
     expect(passedClient).toBe(client);
     expect(passedInteraction).toBe(interaction);
     expect(args).toEqual([{ name: "foo", type: 3, value: "bar" }]);
+  });
+
+  describe("autocomplete", () => {
+    it("routes to command.autocomplete when interaction.isAutocomplete() is true", () => {
+      const client = createMockClient();
+      const command = {
+        name: "help",
+        autocomplete: vi.fn().mockResolvedValue(undefined),
+        run: vi.fn(),
+      };
+      client.slashCommands.set("help", command);
+
+      const interaction = createInteraction({
+        isAutocomplete: () => true,
+        commandName: "help",
+      });
+
+      interactionCreate.execute(interaction, client);
+
+      expect(command.autocomplete).toHaveBeenCalledOnce();
+      expect(command.run).not.toHaveBeenCalled();
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the autocompleted command isn't registered", () => {
+      const interaction = createInteraction({
+        isAutocomplete: () => true,
+        commandName: "ghost",
+      });
+
+      interactionCreate.execute(interaction, createMockClient());
+
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the registered command has no autocomplete handler", () => {
+      const client = createMockClient();
+      client.slashCommands.set("plain", { name: "plain", run: vi.fn() });
+
+      const interaction = createInteraction({
+        isAutocomplete: () => true,
+        commandName: "plain",
+      });
+
+      interactionCreate.execute(interaction, client);
+
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
   });
 
   it("expands subcommand option arrays into the args[].args field", () => {

--- a/src/events/client/interactionCreate.ts
+++ b/src/events/client/interactionCreate.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   CommandInteractionOption,
   Interaction,
+  MessageFlags,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { Argument, ISlashCommand } from "../../shared/types";
@@ -10,6 +11,23 @@ export default {
   name: "interactionCreate",
   type: "client",
   execute(interaction: Interaction, client: ClientDiscord) {
+    // Autocomplete interactions: route to the command's autocomplete handler
+    // if it declared one. They MUST respond within 3s with up to 25 choices,
+    // and they cannot reply with messages — only with respond().
+    if (interaction.isAutocomplete()) {
+      const command: ISlashCommand | undefined = client.slashCommands.get(
+        interaction.commandName
+      );
+      if (command?.autocomplete) {
+        try {
+          command.autocomplete(client, interaction);
+        } catch {
+          // Best-effort; autocomplete has no error reply channel.
+        }
+      }
+      return;
+    }
+
     if (!interaction.isChatInputCommand()) return;
     if (!interaction.command) return;
 
@@ -22,7 +40,7 @@ export default {
       if (interaction.user.id !== client.config.ownerId) {
         return interaction.reply({
           content: "Este comando es privado",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
     }

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,0 +1,28 @@
+// Manifest estático de event handlers de Discord.
+//
+// Este array es la única fuente de verdad para qué events registra el bot.
+// Si agregás un event nuevo:
+//   1. Crealo en `src/events/<categoria>/<nombre>.ts` con `export default`
+//   2. Importalo arriba y agregalo al array
+//
+// No usamos `readdirSync` + `import()` dinámico — ver
+// `src/slashCommands/index.ts` para el por qué.
+
+import { IBotEvent } from "../shared/types";
+
+import interactionCreate from "./client/interactionCreate";
+import ready from "./client/ready";
+
+import messageDelete from "./message/messageDelete";
+import messageUpdate from "./message/messageUpdate";
+
+const events: IBotEvent[] = [
+  // client
+  interactionCreate,
+  ready,
+  // message
+  messageDelete,
+  messageUpdate,
+];
+
+export default events;

--- a/src/events/message/messageDelete.test.ts
+++ b/src/events/message/messageDelete.test.ts
@@ -28,9 +28,7 @@ const ownerMock = (overrides: Record<string, any> = {}) => {
   return {
     client: createMockClient({
       users: {
-        fetch: vi
-          .fn()
-          .mockResolvedValue({ send, ...overrides }),
+        fetch: vi.fn().mockResolvedValue({ send, ...overrides }),
       },
     }),
     send,
@@ -55,7 +53,10 @@ describe("messageDelete", () => {
 
   it("ignores messages with no content and no attachment", async () => {
     const { client, send } = ownerMock();
-    const message = createMessage({ content: "", attachments: { at: () => undefined } });
+    const message = createMessage({
+      content: "",
+      attachments: { at: () => undefined },
+    });
 
     await messageDelete.execute(message as any, client);
 
@@ -71,7 +72,7 @@ describe("messageDelete", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("DMs the owner with a content embed for a regular text message", async () => {
+  it("DMs the owner with a branded embed for a regular text message", async () => {
     const { client, send } = ownerMock();
     const message = createMessage({ content: "test message" });
 
@@ -80,9 +81,35 @@ describe("messageDelete", () => {
     expect(send).toHaveBeenCalledOnce();
     const payload = send.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    const embed = payload.embeds[0].data;
+    expect(embed.title).toBeUndefined();
+    expect(embed.description).toBe("test message");
+    expect(embed.color).toBe(0xed4245); // mod red
+    expect(embed.author.name).toBe("Diego");
+    expect(embed.footer.text).toBe("🗑️ Eliminado");
   });
 
-  it("DMs the owner with the file attached when the deleted message had an image", async () => {
+  it("DMs the owner with the file attached AND the same branded embed when the deleted message had an image", async () => {
+    const { client, send } = ownerMock();
+    const message = createMessage({
+      content: "look at this",
+      attachments: { at: () => ({ url: "https://example.com/img.png" }) },
+    });
+
+    await messageDelete.execute(message as any, client);
+
+    expect(send).toHaveBeenCalledOnce();
+    const payload = send.mock.calls[0][0];
+    // Re-uploads the URL as a fresh file so it survives the source delete
+    expect(payload.files).toEqual(["https://example.com/img.png"]);
+    // Embed shape consistent with the text-only case
+    const embed = payload.embeds[0].data;
+    expect(embed.title).toBeUndefined();
+    expect(embed.description).toBe("look at this");
+    expect(embed.color).toBe(0xed4245);
+  });
+
+  it("when the deleted message had ONLY an image (no text), the embed has no description", async () => {
     const { client, send } = ownerMock();
     const message = createMessage({
       content: "",
@@ -91,8 +118,20 @@ describe("messageDelete", () => {
 
     await messageDelete.execute(message as any, client);
 
-    expect(send).toHaveBeenCalledOnce();
     const payload = send.mock.calls[0][0];
     expect(payload.files).toEqual(["https://example.com/img.png"]);
+    expect(payload.embeds[0].data.description).toBeUndefined();
+  });
+
+  it("truncates very long messages to fit the embed description budget", async () => {
+    const { client, send } = ownerMock();
+    const longContent = "x".repeat(5000);
+    const message = createMessage({ content: longContent });
+
+    await messageDelete.execute(message as any, client);
+
+    const desc = send.mock.calls[0][0].embeds[0].data.description;
+    expect(desc.length).toBeLessThanOrEqual(4001);
+    expect(desc.endsWith("…")).toBe(true);
   });
 });

--- a/src/events/message/messageDelete.ts
+++ b/src/events/message/messageDelete.ts
@@ -1,67 +1,57 @@
 import { EmbedBuilder, Message } from "discord.js";
+
 import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
+const DELETE_COLOR = 0xed4245; // mod red — signal of removal
+const MAX_DESCRIPTION = 4000;
 
 export default {
   name: "messageDelete",
   type: "message",
-  // just work on the first message update, and just in gmi2 channel
+  /**
+   * Fires for individual message deletions. discord.js emits this event for
+   * every cached message in a bulkDelete too, so /clear's recap code skips
+   * the single-text-only case to avoid duplicating what this listener already
+   * sends.
+   */
   async execute(message: Message, client: ClientDiscord) {
-    if (message?.author?.bot) {
-      console.log("is bot");
+    if (message?.author?.bot) return;
 
-      return;
-    }
+    const attachmentUrl = message?.attachments?.at(0)?.url;
+    if (!message?.content && !attachmentUrl) return;
+    if (message?.channel?.id !== config.gmi2Channel) return;
 
-    if (!message?.content && !message?.attachments?.at(0)?.url) {
-      console.log("no content");
+    const trimmedContent = message.content
+      ? message.content.slice(0, MAX_DESCRIPTION) +
+        (message.content.length > MAX_DESCRIPTION ? "…" : "")
+      : "";
 
-      return;
-    }
+    const owner = await client.users.fetch(config.ownerId, { cache: false });
 
-    if (message?.channel?.id !== config.gmi2Channel) {
-      console.log("not gmi2 channel");
-
-      return;
-    }
-
-    const count = 4096;
-
-    const deletedMesaage =
-      message.content?.slice(0, count) +
-      (message.content?.length > count ? "..." : "") +
-      (message.attachments?.at(0)?.url
-        ? `\n${message.attachments?.at(0)?.url}`
-        : "");
-
-    const image = message.attachments?.at(0)?.url;
-
-    const user = await client.users.fetch(config.ownerId, {
-      cache: false,
-    });
-
-    if (image) {
-      await user.send({
-        content: `**${message.author.username}** ha borrado un mensaje con un imagen.`,
-        files: [image],
-      });
-
-      return;
-    }
-
-    const attachmentUrl = message.attachments?.at(0)?.url;
-    const log = new EmbedBuilder({
-      author: {
+    // Layout choice: no title up top so the embed reads like the original
+    // message preserved (avatar + name + content + timestamp). The 'deleted'
+    // hint goes in the footer alongside the brand, so the visual illusion of
+    // 'this is the message' isn't broken at first glance.
+    const embed = new EmbedBuilder()
+      .setAuthor({
         name: message.author.username || message.author.tag,
         iconURL: message.author.displayAvatarURL(),
-      },
-      description: deletedMesaage,
-      timestamp: new Date().toISOString(),
-      ...(attachmentUrl && {
-        image: { url: attachmentUrl },
-      }),
-    }).setColor("Red");
+      })
+      .setColor(DELETE_COLOR)
+      .setTimestamp(message.createdTimestamp ?? new Date())
+      // Footer-only hint (no brand) so the embed reads as the message itself,
+      // not as a Xiza-Bot announcement of a deletion.
+      .setFooter({ text: "🗑️ Eliminado" });
 
-    await user.send({ embeds: [log] });
+    if (trimmedContent) embed.setDescription(trimmedContent);
+
+    // Re-upload the attachment as a fresh file (not just the URL) so it
+    // survives Discord dropping the deleted-message CDN URL.
+    if (attachmentUrl) {
+      await owner.send({ embeds: [embed], files: [attachmentUrl] });
+      return;
+    }
+
+    await owner.send({ embeds: [embed] });
   },
 };

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -8,10 +8,13 @@ import { logger } from "../shared/utils/helpers";
 
 // Match the runtime's source file extension: .ts when running via tsx
 // (npm run dev), .js when running compiled output (npm start). Skip
-// .d.ts declaration files in either case.
+// .d.ts declaration files and co-located *.test.* files (Vitest is
+// ESM-only and breaks when required from CJS at runtime).
 const sourceExt = __filename.endsWith(".ts") ? ".ts" : ".js";
 const isLoadable = (file: string) =>
-  file.endsWith(sourceExt) && !file.endsWith(".d.ts");
+  file.endsWith(sourceExt) &&
+  !file.endsWith(".d.ts") &&
+  !file.endsWith(`.test${sourceExt}`);
 
 const checkHandler = (
   type: "Event" | "SlashCommand",

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,114 +1,55 @@
-import { readdirSync } from "fs";
+import { ApplicationCommandDataResolvable, ClientEvents } from "discord.js";
+import chalk from "chalk";
 
 import ClientDiscord from "../shared/classes/ClientDiscord";
-import { ApplicationCommandDataResolvable } from "discord.js";
-import path from "path";
-import chalk from "chalk";
+import events from "../events";
+import slashCommands from "../slashCommands";
 import { logger } from "../shared/utils/helpers";
 
-// Match the runtime's source file extension: .ts when running via tsx
-// (npm run dev), .js when running compiled output (npm start). Skip
-// .d.ts declaration files and co-located *.test.* files (Vitest is
-// ESM-only and breaks when required from CJS at runtime).
-const sourceExt = __filename.endsWith(".ts") ? ".ts" : ".js";
-const isLoadable = (file: string) =>
-  file.endsWith(sourceExt) &&
-  !file.endsWith(".d.ts") &&
-  !file.endsWith(`.test${sourceExt}`);
+const ok = (type: "Event" | "SlashCommand", name: string) =>
+  ` ✔️  => ${type} '${name}' is ready `;
 
-const checkHandler = (
-  type: "Event" | "SlashCommand",
-  file: string,
-  status: 0 | 1
-) => {
-  if (status === 1)
-    return ` ✔️  => ${type} '${file.substring(0, file.length - 3)}' is ready `;
-  return ` ❌  => ${type} '${file.substring(
-    0,
-    file.length - 3
-  )}' missing a help.name or help.name is not in string `;
-};
+const missing = (type: "Event" | "SlashCommand") =>
+  ` ❌  => ${type} missing a 'name' field or 'name' is not a string `;
 
-export const loadEvents = async (client: ClientDiscord) => {
-  const eventFolders = readdirSync(path.resolve(__dirname, "./../events"));
-  for (const folder of eventFolders) {
-    const eventFiles = readdirSync(
-      path.resolve(__dirname, `./../events/${folder}`)
-    ).filter(isLoadable);
+export const loadEvents = (client: ClientDiscord) => {
+  for (const event of events) {
+    if (!event.name) {
+      logger(chalk.bgRedBright.black(missing("Event")));
+      continue;
+    }
 
-    for (const file of eventFiles) {
-      let event;
-      try {
-        const mod = await import(`../events/${folder}/${file}`);
-        event = mod.default ?? mod;
-      } catch (err) {
-        logger(
-          chalk.bgRedBright.black(
-            ` ❌  => Event '${file.substring(0, file.length - 3)}' failed to load: ${err}`
-          )
-        );
-        continue;
-      }
+    logger(chalk.bgGreen.black(ok("Event", event.name)));
 
-      if (event.name) {
-        logger(chalk.bgGreen.black(checkHandler("Event", file, 1)));
-      } else {
-        logger(chalk.bgRedBright.black(checkHandler("Event", file, 0)));
-        continue;
-      }
+    if (!event.type) continue;
 
-      if (event.type) {
-        if (event.once) {
-          client.once(
-            event.name,
-            async (...args) => await event.execute(...args, client)
-          );
-        } else {
-          client.on(
-            event.name,
-            async (...args) => await event.execute(...args, client)
-          );
-        }
-      }
+    const handler = async (...args: unknown[]) =>
+      await event.execute(...args, client);
+
+    if (event.once) {
+      client.once(event.name as keyof ClientEvents, handler);
+    } else {
+      client.on(event.name as keyof ClientEvents, handler);
     }
   }
 };
 
-export const loadSlashCommands = async (client: ClientDiscord) => {
+export const loadSlashCommands = (client: ClientDiscord) => {
   const slash: ApplicationCommandDataResolvable[] = [];
 
-  const commandFolders = readdirSync(
-    path.resolve(__dirname, "./../slashCommands")
-  );
-  for (const folder of commandFolders) {
-    const commandFiles = readdirSync(
-      path.resolve(__dirname, `./../slashCommands/${folder}`)
-    ).filter(isLoadable);
-
-    for (const file of commandFiles) {
-      let command;
-      try {
-        command = (await import(`../slashCommands/${folder}/${file}`)).default;
-      } catch (err) {
-        logger(
-          chalk.bgRedBright.black(
-            ` ❌  => SlashCommand '${file.substring(0, file.length - 3)}' failed to load: ${err}`
-          )
-        );
-        continue;
-      }
-
-      if (command.name) {
-        client.slashCommands.set(command.name, command);
-        slash.push(command);
-        logger(
-          chalk.bgGreenBright.black(checkHandler("SlashCommand", file, 1))
-        );
-      } else {
-        logger(chalk.bgRedBright.black(checkHandler("SlashCommand", file, 0)));
-        continue;
-      }
+  for (const command of slashCommands) {
+    if (!command.name) {
+      logger(chalk.bgRedBright.black(missing("SlashCommand")));
+      continue;
     }
+
+    client.slashCommands.set(command.name, command);
+    // Cast: ISlashCommand y ApplicationCommandDataResolvable son compatibles en
+    // runtime, pero TS no puede inferir la unión discriminada porque
+    // SlashCommandsOptions.type es opcional. Deuda preexistente que el manifest
+    // estático reveló (antes el `import()` dinámico hacía `command: any`).
+    slash.push(command as unknown as ApplicationCommandDataResolvable);
+    logger(chalk.bgGreenBright.black(ok("SlashCommand", command.name)));
   }
 
   client.on("clientReady", async () => {

--- a/src/shared/constants/branding.ts
+++ b/src/shared/constants/branding.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../../../package.json"), "utf-8")
+) as { version: string };
+
+export const BOT_BRAND_NAME = "Xiza Bot";
+export const BOT_VERSION = `v${packageJson.version}`;
+
+export type CategoryName = "fun" | "info" | "mod";
+
+const CATEGORY_COLOR: Record<CategoryName, number> = {
+  info: 0x5865f2, // Discord blurple
+  fun: 0xfee75c, // Discord yellow
+  mod: 0xed4245, // Discord red
+};
+
+const CATEGORY_EMOJI: Record<CategoryName, string> = {
+  info: "ℹ️",
+  fun: "🎉",
+  mod: "🛡️",
+};
+
+export const DEFAULT_BRAND_COLOR = CATEGORY_COLOR.info;
+
+const isCategoryName = (s: string | null | undefined): s is CategoryName =>
+  s === "fun" || s === "info" || s === "mod";
+
+export const colorForCategory = (cat: string | null | undefined): number =>
+  isCategoryName(cat) ? CATEGORY_COLOR[cat] : DEFAULT_BRAND_COLOR;
+
+export const emojiForCategory = (cat: string | null | undefined): string =>
+  isCategoryName(cat) ? CATEGORY_EMOJI[cat] : "";
+
+export const capitalize = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1);

--- a/src/shared/constants/changelog.ts
+++ b/src/shared/constants/changelog.ts
@@ -1,0 +1,46 @@
+/**
+ * Hardcoded changelog source for the /changelog slash command.
+ *
+ * Curatorial — not a literal mapping of git history. Bump a new entry at
+ * the top of the array when a release ships something the server cares
+ * about. Older entries can stay or get trimmed; the command shows them
+ * newest-first.
+ */
+
+export type ChangelogEntry = {
+  version: string;
+  date: string; // ISO YYYY-MM-DD
+  highlights: string[];
+};
+
+export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: "0.4.0",
+    date: "2026-05-08",
+    highlights: [
+      "Facelift completo de los 18 slash commands con branding consistente (info azul, fun amarillo, mod rojo).",
+      "/help con autocomplete, dropdown y botón ‘volver al listado’.",
+      "/love con persistencia en Mongo y subcomandos owner para curar overrides.",
+      "/clear ahora DMea al moderador un recap con texto y archivos de lo eliminado.",
+      "Nuevos comandos: /about, /changelog, /uptime, /feedback, /team, /cum.",
+    ],
+  },
+  {
+    version: "0.3.2",
+    date: "2026-05-06",
+    highlights: [
+      "Migración completa a discord.js v14, Node 22, Mongoose 8, pnpm 10.",
+      "Loaders estáticos en lugar de readdir dinámico (compatible con tsx watch).",
+      "143 tests cubriendo el bot end-to-end, CI con GitHub Actions.",
+      "Strings del bot pasados a español neutral (tuteo).",
+    ],
+  },
+  {
+    version: "0.3.0",
+    date: "2026-04-22",
+    highlights: [
+      "Refactor del code base: dead code purge, DAO directo, separación de responsabilidades.",
+      "Tests co-locados al lado del código (*.test.ts).",
+    ],
+  },
+];

--- a/src/shared/services/love.service.ts
+++ b/src/shared/services/love.service.ts
@@ -1,0 +1,42 @@
+import * as loveDao from "../../api/dao/love.dao";
+import { ResponseData } from "../../handlers/ResponseData";
+import { ILove } from "../../api/models/Love";
+
+export const getOrCreatePair = async (
+  id1: string,
+  id2: string
+): Promise<ILove | null> => {
+  const response = await loveDao.getOrCreatePair(id1, id2);
+  if (response.statusCode !== 200) return null;
+  return (response as ResponseData).data as ILove;
+};
+
+export const setOverride = async (
+  id1: string,
+  id2: string,
+  percentage: number,
+  verdict: string | null,
+  setBy: string
+): Promise<ILove | null> => {
+  const response = await loveDao.setOverride(
+    id1,
+    id2,
+    percentage,
+    verdict,
+    setBy
+  );
+  if (response.statusCode !== 200) return null;
+  return (response as ResponseData).data as ILove;
+};
+
+export const resetPair = async (
+  id1: string,
+  id2: string
+): Promise<{ ok: boolean; statusCode: number; message: string }> => {
+  const response = await loveDao.resetPair(id1, id2);
+  return {
+    ok: response.statusCode === 200,
+    statusCode: response.statusCode,
+    message: response.message,
+  };
+};

--- a/src/shared/types/main.ts
+++ b/src/shared/types/main.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationCommandOptionType,
+  AutocompleteInteraction,
   ChatInputApplicationCommandData,
   ChatInputCommandInteraction,
   Message,
@@ -31,6 +32,7 @@ export type SlashCommandsOptions = {
   options?: SlashCommandsOptions[];
   type?: TypeCommandOption;
   required?: boolean;
+  autocomplete?: boolean;
 };
 
 /* UserApplicationCommandData
@@ -46,10 +48,15 @@ export type ISlashCommand = {
   options?: SlashCommandsOptions[];
   ownerOnly: boolean;
   defaultMemberPermissions?: PermissionResolvable;
+  examples?: string[];
   run: (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[],
+  ) => Promise<unknown>;
+  autocomplete?: (
+    client: ClientDiscord,
+    interaction: AutocompleteInteraction,
   ) => Promise<unknown>;
 };
 

--- a/src/shared/types/main.ts
+++ b/src/shared/types/main.ts
@@ -60,6 +60,13 @@ export type ISlashCommand = {
   ) => Promise<unknown>;
 };
 
+export interface IBotEvent {
+  name: string;
+  type: string;
+  once?: boolean;
+  execute: (...args: any[]) => unknown;
+}
+
 export type Week = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export type Month = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 

--- a/src/shared/utils/birthdayReminder.ts
+++ b/src/shared/utils/birthdayReminder.ts
@@ -1,41 +1,57 @@
+import { EmbedBuilder, User } from "discord.js";
+
 import _config from "../../config";
-import ClientDiscord from "../classes/ClientDiscord";
 import * as userDao from "../../api/dao/user.dao";
 import { ResponseData } from "../../handlers/ResponseData";
+import ClientDiscord from "../classes/ClientDiscord";
 import { channelSender, dateToUTC5 } from "./helpers";
-import { EmbedBuilder } from "discord.js";
 
-export const reminder = async (client: ClientDiscord) => {
+/**
+ * Builds the birthday-greeting embed used by both the daily cron and the
+ * /cum slash command. Single source of truth so the two paths can never
+ * drift visually.
+ */
+export const buildBirthdayGreetingEmbed = (user: User): EmbedBuilder =>
+  new EmbedBuilder()
+    .setColor("Random")
+    .setTitle("GangBang al CUMpleañero! 🥳🎂🎉")
+    .setDescription(`👑 Felicitaciones **<@${user.id}>**`)
+    .setThumbnail(user.avatarURL({ size: 64 }) ?? null)
+    .setImage(
+      "https://i.pinimg.com/736x/f8/28/57/f82857d4da012fba311ea8040e163d5e.jpg"
+    )
+    .setTimestamp(new Date());
+
+/**
+ * Walks the registered users, fires the greeting for everyone whose birthday
+ * matches today's date in UTC-5. Returns the number of greetings sent so the
+ * caller (the cron, or the /cum slash command) can report it.
+ */
+export const reminder = async (
+  client: ClientDiscord
+): Promise<{ count: number }> => {
+  let count = 0;
   try {
     const today = dateToUTC5(new Date());
 
     const res = await userDao.readUsers();
-    if (res.statusCode !== 200) return;
+    if (res.statusCode !== 200) return { count: 0 };
 
     const users: any = (res as ResponseData).data;
 
-    users.forEach(async (e: any) => {
-      if (today.day === e.birthdayDay && today.month === e.birthdayMonth) {
-        const user = await client.users.fetch(e.discordId);
-        const embed = new EmbedBuilder()
-          .setColor("Random")
-          .setTitle("GangBang al CUMpleañero! 🥳🎂🎉")
-          .setDescription(`👑 Felicitaciones **<@${user.id}>**`)
-          .setThumbnail(
-            user.avatarURL({
-              size: 64,
-            })!
-          )
-          .setImage(
-            "https://i.pinimg.com/736x/f8/28/57/f82857d4da012fba311ea8040e163d5e.jpg"
-          )
-          .setTimestamp(new Date());
-
-        channelSender(client, _config.gmi2Channel, {
-          embeds: [embed],
-          allowedMentions: { repliedUser: true },
-        });
+    for (const e of users) {
+      if (today.day !== e.birthdayDay || today.month !== e.birthdayMonth) {
+        continue;
       }
-    });
-  } catch (error) {}
+      const user = await client.users.fetch(e.discordId);
+      channelSender(client, _config.gmi2Channel, {
+        embeds: [buildBirthdayGreetingEmbed(user)],
+        allowedMentions: { repliedUser: true },
+      });
+      count++;
+    }
+  } catch {
+    // best-effort cron — don't blow up the daily run
+  }
+  return { count };
 };

--- a/src/shared/utils/helpers.test.ts
+++ b/src/shared/utils/helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   capitalize,
   dateToUTC5,
+  formatUptime,
   mentionUser,
   random,
   rangeHandler,
@@ -95,6 +96,43 @@ describe("helpers — pure functions", () => {
   describe("mentionUser(id)", () => {
     it("wraps the id in the bold-mention markdown format", () => {
       expect(mentionUser("123456789")).toBe("**<@123456789>**");
+    });
+  });
+
+  describe("formatUptime(seconds)", () => {
+    it("returns just seconds when below a minute", () => {
+      expect(formatUptime(0)).toBe("0s");
+      expect(formatUptime(45)).toBe("45s");
+      expect(formatUptime(59)).toBe("59s");
+    });
+
+    it("returns minutes + seconds when below an hour", () => {
+      expect(formatUptime(60)).toBe("1m 0s");
+      expect(formatUptime(125)).toBe("2m 5s");
+      expect(formatUptime(3599)).toBe("59m 59s");
+    });
+
+    it("returns hours + minutes when below a day", () => {
+      expect(formatUptime(3600)).toBe("1h 0m");
+      expect(formatUptime(3660)).toBe("1h 1m");
+      expect(formatUptime(86399)).toBe("23h 59m");
+    });
+
+    it("returns days + hours + minutes for >= 1 day", () => {
+      expect(formatUptime(86400)).toBe("1d 0h 0m");
+      expect(formatUptime(86400 + 3600 + 60)).toBe("1d 1h 1m");
+      expect(formatUptime(2 * 86400 + 5 * 3600 + 30 * 60)).toBe("2d 5h 30m");
+    });
+
+    it("guards against invalid input", () => {
+      expect(formatUptime(-5)).toBe("0s");
+      expect(formatUptime(NaN)).toBe("0s");
+      expect(formatUptime(Infinity)).toBe("0s");
+    });
+
+    it("floors fractional seconds", () => {
+      expect(formatUptime(45.7)).toBe("45s");
+      expect(formatUptime(125.99)).toBe("2m 5s");
     });
   });
 

--- a/src/shared/utils/helpers.test.ts
+++ b/src/shared/utils/helpers.test.ts
@@ -91,6 +91,18 @@ describe("helpers — pure functions", () => {
     it("handles empty input", () => {
       expect(shuffle([])).toEqual([]);
     });
+
+    it("does NOT mutate the input array", () => {
+      const input = [1, 2, 3, 4, 5];
+      const snapshot = [...input];
+      shuffle(input);
+      expect(input).toEqual(snapshot);
+    });
+
+    it("returns a new array reference", () => {
+      const input = [1, 2, 3];
+      expect(shuffle(input)).not.toBe(input);
+    });
   });
 
   describe("mentionUser(id)", () => {

--- a/src/shared/utils/helpers.ts
+++ b/src/shared/utils/helpers.ts
@@ -75,24 +75,17 @@ export const channelSender = (
   channel.send(msg);
 };
 
+/**
+ * Returns a shuffled COPY of the input array — the original is untouched.
+ * Uses Fisher-Yates so the distribution is uniform.
+ */
 export const shuffle = <T>(array: T[]): T[] => {
-  let currentIndex = array.length;
-  let randomIndex;
-
-  // While there remain elements to shuffle.
-  while (currentIndex !== 0) {
-    // Pick a remaining element.
-    randomIndex = Math.floor(Math.random() * currentIndex);
-    currentIndex--;
-
-    // And swap it with the current element.
-    [array[currentIndex], array[randomIndex]] = [
-      array[randomIndex],
-      array[currentIndex],
-    ];
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
   }
-
-  return array;
+  return result;
 };
 
 export const ownerSender = async (

--- a/src/shared/utils/helpers.ts
+++ b/src/shared/utils/helpers.ts
@@ -144,6 +144,24 @@ export const rangeHandler = (
 };
 
 /**
+ * Returns the next occurrence of (day/month) starting from `from`. If the
+ * birthday already happened this year, jumps to next year. Doesn't try to
+ * be clever about Feb 29 in non-leap years — JS Date will roll over (Feb 30
+ * → Mar 2), which is acceptable for a friend-server bot.
+ */
+export const nextBirthdayDate = (
+  day: number,
+  month: number,
+  from: Date = new Date()
+): Date => {
+  const candidate = new Date(from.getFullYear(), month - 1, day);
+  if (candidate.getTime() < from.getTime()) {
+    return new Date(from.getFullYear() + 1, month - 1, day);
+  }
+  return candidate;
+};
+
+/**
  * Formats a duration in seconds into a compact human-readable string.
  * Examples: 45s, 5m 30s, 2h 15m, 3d 4h 0m
  */

--- a/src/shared/utils/helpers.ts
+++ b/src/shared/utils/helpers.ts
@@ -149,3 +149,21 @@ export const rangeHandler = (
   if (value < min) return min;
   return value;
 };
+
+/**
+ * Formats a duration in seconds into a compact human-readable string.
+ * Examples: 45s, 5m 30s, 2h 15m, 3d 4h 0m
+ */
+export const formatUptime = (seconds: number): string => {
+  if (!isFinite(seconds) || seconds < 0) return "0s";
+  const totalSec = Math.floor(seconds);
+  const days = Math.floor(totalSec / 86400);
+  const hours = Math.floor((totalSec % 86400) / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  const secs = totalSec % 60;
+
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${secs}s`;
+  return `${secs}s`;
+};

--- a/src/slashCommands/fun/ahorcado.test.ts
+++ b/src/slashCommands/fun/ahorcado.test.ts
@@ -5,7 +5,14 @@ vi.mock("death-games", () => ({
   __esModule: true,
   default: {
     Hangman: class {
-      game = { ascii: ["_", "_"], turno: "user-1", ended: false, vidas: 7 };
+      game = {
+        ascii: ["_", "_"],
+        turno: "user-1",
+        ended: false,
+        vidas: 7,
+        letrasUsadas: [] as string[],
+        letrasIncorrectas: [] as string[],
+      };
       on = vi.fn();
       find = vi.fn().mockReturnValue(true);
     },
@@ -39,10 +46,9 @@ beforeEach(() => {
 });
 
 describe("/ahorcado", () => {
-  it("when bot_picks_word is true, replies and starts the game without DMing the user", async () => {
+  it("happy path with bot_picks_word=true: replies, sends kickoff embed, registers idle-timed collector", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();
-    // override the user fetched (player2) to be non-bot
     vi.mocked(client.users.fetch).mockResolvedValue({
       id: "player-2",
       bot: false,
@@ -56,8 +62,49 @@ describe("/ahorcado", () => {
     ]);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
-    expect(interaction.channel.send).toHaveBeenCalled(); // initial board
+    expect(interaction.channel.send).toHaveBeenCalled();
+    const sentEmbed = interaction.channel.send.mock.calls[0][0].embeds[0].data;
+    expect(sentEmbed.title).toBe("🎯 Ahorcado");
+    expect(sentEmbed.color).toBe(0xfee75c); // fun yellow
+    expect(sentEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(sentEmbed.author).toBeUndefined();
+
     expect(interaction.channel.createMessageCollector).toHaveBeenCalled();
+    const collectorOpts =
+      interaction.channel.createMessageCollector.mock.calls[0][0];
+    expect(collectorOpts.idle).toBe(5 * 60 * 1000);
+  });
+
+  it("solo play: works with no args (bot_picks_word defaults to true)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ahorcado.run(client, interaction, []);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.channel.send).toHaveBeenCalled();
+    const desc = interaction.channel.send.mock.calls[0][0].embeds[0].data
+      .description;
+    expect(desc).toContain("jugando solo");
+  });
+
+  it("rejects solo + bot_picks_word=false explicit (would be guessing your own word)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ahorcado.run(createMockClient(), interaction, [
+      arg("bot_picks_word", false),
+    ]);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("bot_picks_word");
   });
 
   it("rejects ephemerally when the channel is not sendable", async () => {
@@ -82,8 +129,6 @@ describe("/ahorcado", () => {
   it("rejects when any chosen player is a bot", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();
-
-    // Override fetch so the second call returns a bot user.
     vi.mocked(client.users.fetch).mockImplementation((async (id: string) => {
       if (id === "player-2-bot") {
         return { id, bot: true, username: "BotUser" };
@@ -100,5 +145,61 @@ describe("/ahorcado", () => {
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("bots");
+  });
+
+  it("rejects duplicate players (same user listed twice)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ahorcado.run(createMockClient(), interaction, [
+      arg("player2", "duplicate"),
+      arg("player3", "duplicate"),
+      arg("bot_picks_word", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
+    expect(interaction.channel.createMessageCollector).not.toHaveBeenCalled();
+  });
+
+  it("rejects when initiator lists themself as player2", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ahorcado.run(createMockClient(), interaction, [
+      arg("player2", "user-1"), // discord-mocks default initiator id
+      arg("bot_picks_word", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
+  });
+
+  it("collector filter matches the CURRENT turn's player (no pre-rotation bug)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ahorcado.run(client, interaction, [
+      arg("player2", "player-2"),
+      arg("bot_picks_word", true),
+    ]);
+
+    const collectorCall =
+      interaction.channel.createMessageCollector.mock.calls[0][0];
+    const filter = collectorCall.filter;
+
+    // turn = 0 → initiator (user-1) plays first, kickoff embed says
+    // 'Empieza user-1', so the filter must match user-1 (not the pre-rotated
+    // player-2 — that was the bug the rewrite fixes).
+    expect(filter({ author: { id: "user-1" }, content: "b" })).toBe(true);
+    expect(filter({ author: { id: "player-2" }, content: "b" })).toBe(false);
+    expect(filter({ author: { id: "user-1" }, content: "123" })).toBe(false); // not a letter
+    expect(filter({ author: { id: "intruder" }, content: "b" })).toBe(false);
   });
 });

--- a/src/slashCommands/fun/ahorcado.test.ts
+++ b/src/slashCommands/fun/ahorcado.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("death-games", () => ({
@@ -75,7 +76,7 @@ describe("/ahorcado", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("rejects when any chosen player is a bot", async () => {
@@ -97,7 +98,7 @@ describe("/ahorcado", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("bots");
   });
 });

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -2,6 +2,7 @@ import {
   ActionRowBuilder,
   ChatInputCommandInteraction,
   ComponentType,
+  MessageFlags,
   StringSelectMenuBuilder,
 } from "discord.js";
 import Death from "death-games";
@@ -71,7 +72,7 @@ const pull: ISlashCommand = {
       if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
       const channel = interaction.channel;
@@ -94,7 +95,7 @@ const pull: ISlashCommand = {
       if (users.some((u) => u.bot)) {
         return interaction.reply({
           content: "No puedes agregar bots.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
       const usernames = users.map((u) => u.username);
@@ -126,7 +127,7 @@ const pull: ISlashCommand = {
           return interaction.reply({
             content:
               "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word: true`.",
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
 

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -28,7 +28,7 @@ const pull: ISlashCommand = {
   name: "ahorcado",
   category: "fun",
   description:
-    "Ahorcado. Vos elegís palabra (DM con menú) o el bot la elige (con bot_picks_word).",
+    "Ahorcado. Tú eliges la palabra (DM con menú) o el bot la elige (con bot_picks_word).",
   ownerOnly: false,
   options: [
     {
@@ -93,7 +93,7 @@ const pull: ISlashCommand = {
       );
       if (users.some((u) => u.bot)) {
         return interaction.reply({
-          content: "No podés meter bots.",
+          content: "No puedes agregar bots.",
           ephemeral: true,
         });
       }
@@ -125,13 +125,13 @@ const pull: ISlashCommand = {
         } catch {
           return interaction.reply({
             content:
-              "No te pude mandar DM. Activá los DMs del servidor o usá `bot_picks_word: true`.",
+              "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word: true`.",
             ephemeral: true,
           });
         }
 
         await interaction.reply({
-          content: `Te mandé un DM para elegir la palabra. Tenés 20s.`,
+          content: `Te envié un DM para elegir la palabra. Tienes 20s.`,
         });
 
         try {

--- a/src/slashCommands/fun/ahorcado.ts
+++ b/src/slashCommands/fun/ahorcado.ts
@@ -1,22 +1,37 @@
 import {
   ActionRowBuilder,
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   ComponentType,
+  EmbedBuilder,
   MessageFlags,
   StringSelectMenuBuilder,
 } from "discord.js";
 import Death from "death-games";
+
 import _config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import words from "../../shared/data/words";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random, shuffle } from "../../shared/utils/helpers";
 
 const { photoRoot } = _config;
+
 const LIVES = 7;
 const IMG_BASE =
   "https://res.cloudinary.com/dnbgxu47a/image/upload/v1612912935/ahorcado";
+
+const WORD_PICK_TIMEOUT_MS = 20_000;
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+// Signal-carrying colors for end-state, same convention exception as /imc and /ruleta.
+const WIN_COLOR = 0x57f287; // discord green
+const LOSE_COLOR = 0xed4245; // mod red
 
 const rotate = (turn: number, last: number, step: number) => {
   let next = turn + step;
@@ -25,18 +40,122 @@ const rotate = (turn: number, last: number, step: number) => {
   return next;
 };
 
+const fmtBoard = (asciiTokens: string[]) =>
+  "```\n" + asciiTokens.join(" ") + "\n```";
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildKickoffEmbed = (
+  hangmanAscii: string[],
+  startingUsername: string,
+  isSolo: boolean,
+  botPicked: boolean
+) =>
+  baseEmbed()
+    .setTitle("🎯 Ahorcado")
+    .setDescription(
+      `${fmtBoard(hangmanAscii)}**Empieza ${startingUsername}**${
+        botPicked ? "\n_(palabra elegida por el bot)_" : ""
+      }${isSolo ? "\n_(jugando solo)_" : ""}`
+    );
+
+const buildTurnEmbed = (
+  hangmanAscii: string[],
+  nextUsername: string,
+  livesLeft: number,
+  wrongLetters: string[],
+  detail: string,
+  imageUrl: string
+) => {
+  const lines: string[] = [];
+  if (detail) lines.push(detail);
+  lines.push(fmtBoard(hangmanAscii));
+  lines.push(`**Turno de ${nextUsername}**`);
+  lines.push(`Intentos restantes: **${livesLeft}**`);
+  lines.push(
+    `Letras incorrectas: **[${wrongLetters.join(", ")}]**`
+  );
+
+  return baseEmbed()
+    .setTitle("🎯 Ahorcado")
+    .setDescription(lines.join("\n"))
+    .setImage(imageUrl);
+};
+
+const buildEndEmbed = (
+  won: boolean,
+  word: string,
+  finisherUsername: string,
+  finalAscii: string[]
+) => {
+  const text = won
+    ? `**¡Ganaron!** La palabra era: **${word}**\nDescubierto por: **${finisherUsername}**\n${fmtBoard(finalAscii)}`
+    : `**¡Perdieron!** La palabra era: **${word}**\nÚltimo error: **${finisherUsername}**\n${fmtBoard(finalAscii)}`;
+
+  const imageUrl = won
+    ? `${IMG_BASE}/${LIVES}.png`
+    : `${photoRoot}/hangman/${random(0, 2)}.gif`;
+
+  return new EmbedBuilder()
+    .setTitle(won ? "🏆 Ahorcado — Victoria" : "💀 Ahorcado — Derrota")
+    .setDescription(text)
+    .setColor(won ? WIN_COLOR : LOSE_COLOR)
+    .setImage(imageUrl)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildAbandonedEmbed = () =>
+  baseEmbed()
+    .setTitle("⌛ Ahorcado abandonado")
+    .setDescription("La partida se quedó sin movimientos por 5 minutos.");
+
+const buildSkipEmbed = (
+  playerMention: string,
+  letter: string,
+  asciiTokens: string[]
+) =>
+  baseEmbed()
+    .setTitle("🎯 Ahorcado")
+    .setDescription(
+      `${playerMention} ya probó la letra **${letter}** — sigue su turno.\n${fmtBoard(asciiTokens)}`
+    );
+
+const buildEliminationEmbed = (
+  playerMention: string,
+  attempt: string,
+  asciiTokens: string[]
+) =>
+  baseEmbed()
+    .setColor(LOSE_COLOR)
+    .setTitle("☠️ Jugador eliminado")
+    .setDescription(
+      `${playerMention} intentó adivinar **${attempt}** — palabra incorrecta.\nQueda fuera de la partida.\n${fmtBoard(asciiTokens)}`
+    );
+
+const buildAllEliminatedEmbed = (word: string, finalAscii: string[]) =>
+  new EmbedBuilder()
+    .setTitle("💀 Ahorcado — Todos eliminados")
+    .setDescription(
+      `Todos quedaron fuera tras intentos fallidos de adivinar la palabra.\nLa palabra era: **${word}**\n${fmtBoard(finalAscii)}`
+    )
+    .setColor(LOSE_COLOR)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
 const pull: ISlashCommand = {
   name: "ahorcado",
   category: "fun",
   description:
-    "Ahorcado. Tú eliges la palabra (DM con menú) o el bot la elige (con bot_picks_word).",
+    "Ahorcado. El bot elige la palabra; pasa bot_picks_word:false para elegirla por DM.",
   ownerOnly: false,
   options: [
     {
       name: "player2",
-      description: "Segundo jugador (obligatorio)",
+      description: "Segundo jugador (opcional — sin esto juegas solo)",
       type: ApplicationCommandOptionType.User,
-      required: true,
+      required: false,
     },
     {
       name: "player3",
@@ -58,10 +177,15 @@ const pull: ISlashCommand = {
     },
     {
       name: "bot_picks_word",
-      description: "Si está en true, el bot elige la palabra",
+      description: "El bot elige la palabra (default: true). Pon false para elegirla por DM.",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
+  ],
+  examples: [
+    "/ahorcado",
+    "/ahorcado player2:@bob",
+    "/ahorcado player2:@bob bot_picks_word:false",
   ],
   run: async (
     client: ClientDiscord,
@@ -69,7 +193,10 @@ const pull: ISlashCommand = {
     args: Argument[]
   ) => {
     try {
-      if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
+      if (
+        !interaction.channel?.isTextBased() ||
+        !interaction.channel.isSendable()
+      ) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
           flags: MessageFlags.Ephemeral,
@@ -84,10 +211,31 @@ const pull: ISlashCommand = {
           | undefined;
         if (id) playerIds.push(id);
       }
+      // Default true: most plays just want to start a game without the DM
+      // dance. Pass bot_picks_word:false to opt into picking the word yourself.
       const botPicks =
         (args.find((a) => a.name === "bot_picks_word")?.value as
           | boolean
-          | undefined) ?? false;
+          | undefined) ?? true;
+      const isSolo = playerIds.length === 1;
+
+      // Solo play only makes sense if the bot picks the word — otherwise the
+      // single player would be guessing their own choice.
+      if (isSolo && !botPicks) {
+        return interaction.reply({
+          content:
+            "Para jugar solo necesitas que el bot elija la palabra. No pongas `bot_picks_word:false`.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      // No duplicate players (catches both 'player2 == player3' and 'player2 == self').
+      if (new Set(playerIds).size !== playerIds.length) {
+        return interaction.reply({
+          content: "No puedes agregar al mismo jugador dos veces.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
       const users = await Promise.all(
         playerIds.map((id) => client.users.fetch(id))
@@ -98,13 +246,21 @@ const pull: ISlashCommand = {
           flags: MessageFlags.Ephemeral,
         });
       }
-      const usernames = users.map((u) => u.username);
+
+      // death-games' Hangman requires >= 2 player IDs. For solo play we
+      // duplicate the lone ID so the library is happy; the bot's collector
+      // filter (msg.author.id === game.turno) keeps matching the same user
+      // every round, so it plays as a real solo game.
+      const libPlayerIds = isSolo ? [playerIds[0], playerIds[0]] : playerIds;
+      const libUsernames = libPlayerIds.map(
+        (id) => users.find((u) => u.id === id)?.username ?? "?"
+      );
 
       let word = "hola";
       if (botPicks) {
         word = words[random(0, words.length - 1)].nombre.toLowerCase();
         await interaction.reply({
-          content: `Arrancando ahorcado — el bot eligió la palabra.`,
+          content: "Arrancando ahorcado — el bot eligió la palabra.",
         });
       } else {
         const actionRow =
@@ -126,20 +282,20 @@ const pull: ISlashCommand = {
         } catch {
           return interaction.reply({
             content:
-              "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word: true`.",
+              "No te pude enviar un DM. Activa los DMs del servidor o usa `bot_picks_word:true`.",
             flags: MessageFlags.Ephemeral,
           });
         }
 
         await interaction.reply({
-          content: `Te envié un DM para elegir la palabra. Tienes 20s.`,
+          content: "Te envié un DM para elegir la palabra. Tienes 20s.",
         });
 
         try {
           const select = await dm.awaitMessageComponent({
             componentType: ComponentType.StringSelect,
-            time: 20000,
-            idle: 20000,
+            time: WORD_PICK_TIMEOUT_MS,
+            idle: WORD_PICK_TIMEOUT_MS,
             dispose: true,
             filter: (i) => i.user.id === interaction.user.id,
           });
@@ -157,124 +313,167 @@ const pull: ISlashCommand = {
       }
 
       const hangman = new Death.Hangman(word, {
-        jugadores: playerIds,
+        jugadores: libPlayerIds,
         lowerCase: true,
         vidas: LIVES,
       });
 
+      // Semantics: `turn` is the index of the player whose turn it is RIGHT
+      // NOW (the one we're waiting on). After a guess we advance to the next
+      // alive player. Decoupled from the library's internal turn tracker so
+      // we can skip eliminated players that the library doesn't know about.
       let turn = 0;
 
+      // Players knocked out by guessing the wrong full word. Their messages
+      // are ignored by the filter and turn rotation skips them.
+      const eliminated = new Set<string>();
+
+      const peekNextTurn = (from: number) => {
+        let idx = from;
+        do {
+          idx = rotate(idx, libUsernames.length - 1, 1);
+        } while (eliminated.has(libPlayerIds[idx]));
+        return idx;
+      };
+
       hangman.on("end", (game: any) => {
-        turn = rotate(turn, usernames.length - 1, -1);
-        let text = "";
-        let lives = 0;
-        if (game.winned) {
-          text =
-            "El juego ha finalizado! La palabra era: **" +
-            game.palabra +
-            "**\nDescubierto por: **" +
-            usernames[turn] +
-            "**```" +
-            game.ascii.join(" ") +
-            "```";
-          lives = LIVES;
-        } else {
-          text =
-            "Han perdido! La palabra era: **" +
-            game.palabra +
-            "**\nÚltimo error: **" +
-            usernames[turn] +
-            "**```\n" +
-            game.ascii.join(" ") +
-            "```";
-        }
         channel.send({
           embeds: [
-            {
-              color: 0x0099ff,
-              title: "Ahorcado",
-              description: text,
-              image: {
-                url: lives
-                  ? `${IMG_BASE}/${lives}.png`
-                  : `${photoRoot}/hangman/${random(0, 2)}.gif`,
-              },
-            },
+            buildEndEmbed(
+              game.winned,
+              game.palabra,
+              libUsernames[turn], // the player who just moved
+              game.ascii
+            ),
           ],
         });
       });
 
       await channel.send({
         embeds: [
-          {
-            color: 0x0099ff,
-            title: "Ahorcado",
-            description:
-              "```\n" +
-              hangman.game.ascii.join(" ") +
-              "```**Empieza " +
-              usernames[turn] +
-              "**",
-          },
+          buildKickoffEmbed(
+            hangman.game.ascii,
+            libUsernames[turn],
+            isSolo,
+            botPicks
+          ),
         ],
       });
-      turn = rotate(turn, usernames.length - 1, 1);
 
       const collector = channel.createMessageCollector({
         filter: (msg) =>
-          msg.author.id === hangman.game.turno &&
+          msg.author.id === libPlayerIds[turn] &&
+          !eliminated.has(msg.author.id) &&
           /[A-Za-záéíóúñ]/.test(msg.content),
+        idle: IDLE_TIMEOUT_MS,
       });
 
       collector.on("collect", (msg) => {
-        let found = false;
-        if (msg.content.length > 1 && word === msg.content.toLowerCase()) {
-          for (let i = 0; i < word.length; i++) {
-            if (!hangman.game.ascii.includes(word[i])) hangman.find(word[i]);
+        const text = msg.content.toLowerCase();
+        const isFullWord = text.length > 1;
+
+        // === Dedup: single-letter guesses already tried ===
+        // The library decrements vidas every time `find()` sees a letter that's
+        // already in letrasUsadas (covers both correct and incorrect repeats),
+        // so we have to short-circuit BEFORE calling find().
+        if (!isFullWord && hangman.game.letrasUsadas.includes(text)) {
+          channel.send({
+            embeds: [
+              buildSkipEmbed(msg.author.toString(), text, hangman.game.ascii),
+            ],
+          });
+          return; // No life lost, no turn rotation — same player keeps the turn.
+        }
+
+        // === Full-word guess ===
+        if (isFullWord) {
+          if (text === word) {
+            // Correct! Reveal every still-hidden letter.
+            for (let i = 0; i < word.length; i++) {
+              if (!hangman.game.ascii.includes(word[i])) hangman.find(word[i]);
+            }
+            // The win triggers 'end' inside find() via the embed handler.
+            if (hangman.game.ended) return collector.stop("end");
+          } else {
+            // Wrong full-word → eliminate this player (no life consumed; the
+            // word was wrong, but it's also a one-shot: they get knocked out).
+            eliminated.add(msg.author.id);
+            channel.send({
+              embeds: [
+                buildEliminationEmbed(
+                  msg.author.toString(),
+                  msg.content,
+                  hangman.game.ascii
+                ),
+              ],
+            });
+
+            const aliveUnique = new Set(
+              libPlayerIds.filter((id) => !eliminated.has(id))
+            );
+            if (aliveUnique.size === 0) {
+              channel.send({
+                embeds: [
+                  buildAllEliminatedEmbed(word, hangman.game.ascii),
+                ],
+              });
+              return collector.stop("everyone-eliminated");
+            }
+
+            // Someone still alive — rotate the turn (skipping eliminated)
+            // and prompt the next player.
+            const nextTurnIdx = peekNextTurn(turn);
+            channel.send({
+              embeds: [
+                buildTurnEmbed(
+                  hangman.game.ascii,
+                  libUsernames[nextTurnIdx],
+                  hangman.game.vidas,
+                  hangman.game.letrasIncorrectas,
+                  "",
+                  `${IMG_BASE}/${hangman.game.vidas}.png`
+                ),
+              ],
+            });
+            turn = nextTurnIdx;
+            return;
           }
         } else {
-          found = !!hangman.find(msg.content);
+          // === Single-letter guess ===
+          hangman.find(text);
+          if (hangman.game.ended) return collector.stop("end");
         }
 
-        if (hangman.game.ended) return collector.stop();
-
-        let details = "";
-        if (!found) {
-          if (hangman.game.ascii.includes(msg.content)) {
-            details +=
-              '- La letra "' + msg.content + '" ya se encuentra en la palabra!';
-          } else {
-            details += "- Vaya! Parece que la ";
-            details +=
-              msg.content.length > 1
-                ? "palabra **" + msg.content + "** no es correcta!"
-                : "letra **" +
-                  msg.content +
-                  "** no se encontraba en la palabra!";
-          }
+        // Build the detail line for the next-turn embed.
+        let detail = "";
+        if (!isFullWord) {
+          detail = hangman.game.letrasIncorrectas.includes(text)
+            ? `- Vaya, la letra **${text}** no se encontraba en la palabra.`
+            : `- ¡La letra **${text}** está en la palabra!`;
         }
-        details +=
-          "```\n" +
-          hangman.game.ascii.join(" ") +
-          "\n```**Turno de " +
-          usernames[turn] +
-          "**\nIntentos restantes: **" +
-          hangman.game.vidas +
-          "**\nLetras incorrectas: **[" +
-          hangman.game.letrasIncorrectas.join(", ") +
-          "]**";
 
-        turn = rotate(turn, usernames.length - 1, 1);
+        const nextTurnIdx = peekNextTurn(turn);
         channel.send({
           embeds: [
-            {
-              color: 0x0099ff,
-              title: "Ahorcado",
-              description: details,
-              image: { url: `${IMG_BASE}/${hangman.game.vidas}.png` },
-            },
+            buildTurnEmbed(
+              hangman.game.ascii,
+              libUsernames[nextTurnIdx],
+              hangman.game.vidas,
+              hangman.game.letrasIncorrectas,
+              detail,
+              `${IMG_BASE}/${hangman.game.vidas}.png`
+            ),
           ],
         });
+        turn = nextTurnIdx;
+      });
+
+      collector.on("end", async (_, reason) => {
+        // 'end' is our explicit stop in the win/lose branch; 'idle' is the
+        // 5-min silence guard.
+        if (reason === "idle") {
+          await channel.send({ embeds: [buildAbandonedEmbed()] });
+        }
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/fun/flip.test.ts
+++ b/src/slashCommands/fun/flip.test.ts
@@ -1,32 +1,107 @@
-import { describe, expect, it, vi } from "vitest";
+import { MessageFlags } from "discord.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import flip from "./flip";
 
-describe("/flip", () => {
-  it("replies with a single Heads-or-Tails by default", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.1); // < 0.5 → Heads
+const stubRandom = (value: number) =>
+  vi.spyOn(Math, "random").mockReturnValue(value);
 
+describe("/flip", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("flips a single coin by default and replies publicly", async () => {
+    stubRandom(0.1); // < 0.5 → Cara
     const interaction = createMockInteraction();
     await flip.run(createMockClient(), interaction, []);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(payload.flags).toBeUndefined(); // public default
+    expect(payload.embeds[0].data.description).toContain("Cara");
   });
 
-  it("flips N coins when the option is provided", async () => {
+  it("renders Cruz when Math.random returns >= 0.5", async () => {
+    stubRandom(0.9);
     const interaction = createMockInteraction();
-    await flip.run(createMockClient(), interaction, [arg("coins", 5)]);
+    await flip.run(createMockClient(), interaction, []);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.embeds[0].data.description).toContain("Cruz");
+    expect(payload.embeds[0].data.description).not.toContain("Cara");
   });
 
-  it("clamps coin counts above 10 down to 10", async () => {
+  it("flips N coins and adds a totals line when N > 1", async () => {
+    stubRandom(0.1); // all heads
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("coins", 3)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    // 3 cara lines
+    expect(desc.split("Cara").length - 1).toBe(3);
+    expect(desc).toContain("**Total:**");
+    expect(desc).toContain("3 caras");
+    expect(desc).toContain("0 cruces");
+  });
+
+  it("clamps coins above 10 down to 10", async () => {
+    stubRandom(0.1);
     const interaction = createMockInteraction();
     await flip.run(createMockClient(), interaction, [arg("coins", 999)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    // The function uses ?.value && clamp internally; we just verify it doesn't blow up
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    expect(desc.split("Cara").length - 1).toBe(10);
+  });
+
+  it("rejects ephemerally when coins < 1", async () => {
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("coins", 0)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 1");
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    stubRandom(0.1);
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("private", true)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
+    stubRandom(0.1);
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.color).toBe(0xfee75c); // fun yellow
+    expect(embed.data.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.data.author).toBeUndefined();
+  });
+
+  it("singular Spanish: '1 cara · 0 cruces' (and inverse) for N === 2 with mixed result", async () => {
+    // Two flips: first random ≥ 0.5 → Cruz, second < 0.5 → Cara
+    const seq = [0.9, 0.1];
+    let i = 0;
+    vi.spyOn(Math, "random").mockImplementation(() => seq[i++]);
+
+    const interaction = createMockInteraction();
+    await flip.run(createMockClient(), interaction, [arg("coins", 2)]);
+
+    const desc = interaction.reply.mock.calls[0][0].embeds[0].data.description;
+    expect(desc).toContain("1 cara");
+    expect(desc).toContain("1 cruz"); // singular for tails as well
   });
 });

--- a/src/slashCommands/fun/flip.ts
+++ b/src/slashCommands/fun/flip.ts
@@ -59,7 +59,7 @@ const pull: ISlashCommand = {
     },
     {
       name: "private",
-      description: "Mostrar la respuesta solo a vos (default: público)",
+      description: "Mostrar la respuesta solo a ti (default: público)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/fun/flip.ts
+++ b/src/slashCommands/fun/flip.ts
@@ -1,44 +1,101 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const MIN_COINS = 1;
+const MAX_COINS = 10;
+
+const HEADS_LABEL = "👑 Cara";
+const TAILS_LABEL = "🛡 Cruz";
+
+type FlipResult = "heads" | "tails";
+
+const flipOnce = (): FlipResult => (Math.random() < 0.5 ? "heads" : "tails");
+
+const labelFor = (r: FlipResult) => (r === "heads" ? HEADS_LABEL : TAILS_LABEL);
+
+const buildEmbed = (results: FlipResult[]) => {
+  const heads = results.filter((r) => r === "heads").length;
+  const tails = results.length - heads;
+
+  const lines = results.map(labelFor);
+
+  const description =
+    results.length === 1
+      ? lines[0]
+      : `${lines.join("\n")}\n\n**Total:** ${heads} ${
+          heads === 1 ? "cara" : "caras"
+        } · ${tails} ${tails === 1 ? "cruz" : "cruces"}`;
+
+  return new EmbedBuilder()
+    .setTitle("🪙 Moneda al aire")
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
 
 const pull: ISlashCommand = {
   name: "flip",
   category: "fun",
-  description: "Flip a coin!",
+  description: "Tira una moneda al aire (cara o cruz)",
   ownerOnly: false,
   options: [
     {
       name: "coins",
-      description: "The number of coins to flip",
-      type: ApplicationCommandOptionType.Number,
+      description: `Cantidad de monedas a tirar (${MIN_COINS}–${MAX_COINS}, default: 1)`,
+      type: ApplicationCommandOptionType.Integer,
+      required: false,
+    },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a vos (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
   ],
+  examples: ["/flip", "/flip coins:5", "/flip coins:3 private:true"],
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const value: number = parseInt(args[0]?.value?.toString() || "1");
-      const number =
-        (args[0]?.value && (value > 10 ? 10 : value < 1 ? 1 : value)) || 1;
-      const result = [];
-      for (let i = 0; i < number; i++) {
-        result.push(Math.random() < 0.5 ? "🧑 Heads" : "🛡️ Tails");
-      }
-      const embed = new Discord.EmbedBuilder()
-        .setColor("Random")
-        .setTitle("Coin Flip")
-        .setDescription(result.join("\n"))
-        .setFooter({
-          text: `Requested by ${interaction.user.tag}`,
-          iconURL: interaction.user.displayAvatarURL(),
+      const rawCoins = args.find((a) => a.name === "coins")?.value as
+        | number
+        | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as boolean | undefined) ??
+        false;
+
+      // Reject 0/negative explicitly instead of silently clamping — the user
+      // probably mistyped. Big positive values still clamp to MAX_COINS.
+      if (rawCoins !== undefined && rawCoins < MIN_COINS) {
+        return interaction.reply({
+          content: `La cantidad de monedas debe ser al menos ${MIN_COINS}.`,
+          flags: MessageFlags.Ephemeral,
         });
-      interaction.reply({ embeds: [embed] });
+      }
+
+      const coins = Math.min(rawCoins ?? 1, MAX_COINS);
+
+      const results: FlipResult[] = [];
+      for (let i = 0; i < coins; i++) results.push(flipOnce());
+
+      return interaction.reply({
+        embeds: [buildEmbed(results)],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/fun/imc.test.ts
+++ b/src/slashCommands/fun/imc.test.ts
@@ -1,8 +1,15 @@
 import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import imc from "./imc";
+
+const findField = (embed: any, name: string) =>
+  embed.data.fields.find((f: any) => f.name === name);
 
 describe("/imc", () => {
   it("calculates IMC for a normal-weight input", async () => {
@@ -15,17 +22,27 @@ describe("/imc", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    const imcField = findField(payload.embeds[0], "IMC");
+    expect(imcField.value).toContain("22.86");
+    const stateField = findField(payload.embeds[0], "Estado");
+    expect(stateField.value).toContain("Peso normal");
   });
 
-  it("treats height > 3 as centimeters and divides by 100", async () => {
-    const interaction = createMockInteraction();
-    await imc.run(createMockClient(), interaction, [
+  it("treats height > 3 as centimeters and divides by 100 (same IMC as meters)", async () => {
+    const cmInteraction = createMockInteraction();
+    const mInteraction = createMockInteraction();
+    await imc.run(createMockClient(), cmInteraction, [
       arg("peso", 70),
-      arg("altura", 175), // cm
+      arg("altura", 175),
+    ]);
+    await imc.run(createMockClient(), mInteraction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
     ]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    // The embed should reflect the same IMC as the meters version (~22.86)
+    const cmIMC = findField(cmInteraction.reply.mock.calls[0][0].embeds[0], "IMC").value;
+    const mIMC = findField(mInteraction.reply.mock.calls[0][0].embeds[0], "IMC").value;
+    expect(cmIMC).toBe(mIMC);
   });
 
   it("rejects ephemerally on zero or negative input", async () => {
@@ -38,5 +55,71 @@ describe("/imc", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("includes the 'Peso ideal' range field derived from the height", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+    ]);
+
+    const idealField = findField(
+      interaction.reply.mock.calls[0][0].embeds[0],
+      "Peso ideal"
+    );
+    expect(idealField).toBeDefined();
+    // 18.5 * 1.75^2 = 56.65625 → 56.7
+    // 24.9 * 1.75^2 = 76.25625 → 76.3
+    expect(idealField.value).toBe("`56.7–76.3 kg`");
+  });
+
+  it("uses the data-driven status color and the brand footer (no setAuthor)", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+    ]);
+
+    const data = interaction.reply.mock.calls[0][0].embeds[0].data;
+    // 22.86 IMC → "Peso normal" → green #00ff00 = 0x00ff00
+    expect(data.color).toBe(0x00ff00);
+    expect(data.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(data.author).toBeUndefined();
+  });
+
+  it("uses the underweight color (red) for IMC below 18.5", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 45),
+      arg("altura", 1.75),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.color).toBe(0xff0000);
+    expect(findField(embed, "Estado").value).toContain("Bajo peso");
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("public by default", async () => {
+    const interaction = createMockInteraction();
+    await imc.run(createMockClient(), interaction, [
+      arg("peso", 70),
+      arg("altura", 1.75),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBeUndefined();
   });
 });

--- a/src/slashCommands/fun/imc.test.ts
+++ b/src/slashCommands/fun/imc.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
 import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -36,6 +37,6 @@ describe("/imc", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/fun/imc.ts
+++ b/src/slashCommands/fun/imc.ts
@@ -69,13 +69,13 @@ const pull: ISlashCommand = {
     },
     {
       name: "altura",
-      description: "Altura en metros (o cm si pasás un valor mayor a 3)",
+      description: "Altura en metros (o cm si pasas un valor mayor a 3)",
       type: ApplicationCommandOptionType.Number,
       required: true,
     },
     {
       name: "private",
-      description: "Mostrar la respuesta solo a vos (default: público)",
+      description: "Mostrar la respuesta solo a ti (default: público)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/fun/imc.ts
+++ b/src/slashCommands/fun/imc.ts
@@ -2,6 +2,7 @@ import {
   ChatInputCommandInteraction,
   ColorResolvable,
   EmbedBuilder,
+  MessageFlags,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
@@ -58,7 +59,7 @@ const pull: ISlashCommand = {
       if (!weight || !rawHeight || weight <= 0 || rawHeight <= 0) {
         return interaction.reply({
           content: "No seas pendejo, peso y altura tienen que ser > 0.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/fun/imc.ts
+++ b/src/slashCommands/fun/imc.ts
@@ -1,11 +1,16 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   ColorResolvable,
   EmbedBuilder,
   MessageFlags,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
@@ -15,6 +20,12 @@ type ImcRange = {
   color: string;
 };
 
+/**
+ * Data-driven color: red/yellow/green according to the BMI bucket. We INTENTIONALLY
+ * deviate from the fun-category yellow here — the status color encodes real meaning
+ * (healthy / overweight / underweight), not just branding. The convention of
+ * "color matches the category" bends when the color is a signal.
+ */
 const imcData: { [threshold: string]: ImcRange } = {
   "18.5": { message: "Bajo peso", icon: "🙀", color: "#ff0000" },
   "24.9": { message: "Peso normal", icon: "😺", color: "#00ff00" },
@@ -28,10 +39,26 @@ const thresholds = Object.keys(imcData)
   .map((k) => parseFloat(k))
   .sort((a, b) => a - b);
 
+const findRange = (imc: number): ImcRange => {
+  for (const t of thresholds) {
+    if (imc < t) return imcData[t.toString()]!;
+  }
+  return imcData[thresholds[thresholds.length - 1].toString()]!;
+};
+
+/**
+ * Healthy weight range derived from BMI 18.5–24.9 for the given height in meters.
+ * Returns kg with one decimal place.
+ */
+const idealWeightRange = (heightM: number): { min: number; max: number } => ({
+  min: Math.round(18.5 * heightM * heightM * 10) / 10,
+  max: Math.round(24.9 * heightM * heightM * 10) / 10,
+});
+
 const pull: ISlashCommand = {
   name: "imc",
   category: "fun",
-  description: "Calcula tu IMC",
+  description: "Calcula tu Índice de Masa Corporal",
   ownerOnly: false,
   options: [
     {
@@ -46,6 +73,17 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Number,
       required: true,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a vos (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/imc peso:70 altura:1.75",
+    "/imc peso:70 altura:175",
+    "/imc peso:70 altura:1.75 private:true",
   ],
   run: async (
     _: ClientDiscord,
@@ -53,51 +91,50 @@ const pull: ISlashCommand = {
     args: Argument[]
   ) => {
     try {
-      const weight = Number(args.find((a) => a.name === "peso")?.value);
-      const rawHeight = Number(args.find((a) => a.name === "altura")?.value);
+      const peso = Number(args.find((a) => a.name === "peso")?.value);
+      const rawAltura = Number(args.find((a) => a.name === "altura")?.value);
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
 
-      if (!weight || !rawHeight || weight <= 0 || rawHeight <= 0) {
+      if (!peso || !rawAltura || peso <= 0 || rawAltura <= 0) {
         return interaction.reply({
           content: "No seas pendejo, peso y altura tienen que ser > 0.",
           flags: MessageFlags.Ephemeral,
         });
       }
 
-      const height = rawHeight > 3 ? rawHeight / 100 : rawHeight;
-      const imcNumber = weight / (height * height);
+      const altura = rawAltura > 3 ? rawAltura / 100 : rawAltura;
+      const imc = peso / (altura * altura);
+      const range = findRange(imc);
+      const ideal = idealWeightRange(altura);
 
-      let imc: ImcRange = {
-        message: "No se pudo calcular",
-        icon: "🤔",
-        color: "#000000",
-      };
-      for (const threshold of thresholds) {
-        if (imcNumber < threshold) {
-          imc = imcData[threshold.toString()]!;
-          break;
-        }
-      }
-
-      const embed = new EmbedBuilder({
-        title: "Índice de Masa Corporal  🩺",
-        fields: [
-          {
-            name: "IMC",
-            value: `\`${imcNumber.toFixed(2)}\``,
-            inline: true,
-          },
+      const embed = new EmbedBuilder()
+        .setTitle("🩺 Índice de Masa Corporal")
+        .addFields(
+          { name: "IMC", value: `\`${imc.toFixed(2)}\``, inline: true },
           {
             name: "Estado",
-            value: `\`${imc.message}\` ${imc.icon}`,
+            value: `\`${range.message}\` ${range.icon}`,
             inline: true,
           },
-        ],
-        thumbnail: {
-          url: "https://es.calcuworld.com/wp-content/uploads/sites/2/2013/02/imc.png",
-        },
-      }).setColor(imc.color as ColorResolvable);
+          {
+            name: "Peso ideal",
+            value: `\`${ideal.min}–${ideal.max} kg\``,
+            inline: true,
+          }
+        )
+        .setColor(range.color as ColorResolvable)
+        .setThumbnail(
+          "https://es.calcuworld.com/wp-content/uploads/sites/2/2013/02/imc.png"
+        )
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
-      return interaction.reply({ embeds: [embed] });
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/fun/love.test.ts
+++ b/src/slashCommands/fun/love.test.ts
@@ -1,20 +1,275 @@
-import { describe, expect, it } from "vitest";
+import { MessageFlags } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+vi.mock("../../shared/services/love.service");
+
+import * as loveService from "../../shared/services/love.service";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+  subCommandArg,
+} from "../../test-utils/discord-mocks";
 import love from "./love";
 
-describe("/love", () => {
-  it("replies with the cheesy ship line and suppresses pings", async () => {
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const findField = (embed: any, name: string) =>
+  embed.data.fields.find((f: any) => f.name === name);
+
+describe("/love ship", () => {
+  it("queries the service, replies with embed, suppresses pings", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      pairKey: "111-222",
+      user1: "111",
+      user2: "222",
+      percentage: 73,
+      verdict: null,
+      isOverride: false,
+    } as any);
+
     const interaction = createMockInteraction();
     await love.run(createMockClient(), interaction, [
-      arg("user1", "111"),
-      arg("user2", "222"),
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
     ]);
 
+    expect(loveService.getOrCreatePair).toHaveBeenCalledWith("111", "222");
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.content).toContain("<@111>");
-    expect(payload.content).toContain("<@222>");
     expect(payload.allowedMentions).toEqual({ users: [] });
+    const embed = payload.embeds[0];
+    expect(embed.data.title).toBe("💘 Shipping");
+    expect(findField(embed, "💯 Compatibilidad").value).toContain("73%");
+  });
+
+  it("uses the stored verdict when it's an override", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 100,
+      verdict: "Tortolitos del server 💞",
+      isOverride: true,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(findField(embed, "💌 Veredicto").value).toBe(
+      "Tortolitos del server 💞"
+    );
+  });
+
+  it("self-ship: 100% with the self-love phrase, doesn't hit the service", async () => {
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "solo-user" },
+        { name: "user2", value: "solo-user" },
+      ]),
+    ]);
+
+    expect(loveService.getOrCreatePair).not.toHaveBeenCalled();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(findField(embed, "💯 Compatibilidad").value).toContain("100%");
+    expect(findField(embed, "💌 Veredicto").value).toContain("amor propio");
+  });
+
+  it("ephemeral when private:true", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+    } as any);
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "private", value: true },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("public by default", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+    } as any);
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBeUndefined();
+  });
+});
+
+describe("/love set (owner-only)", () => {
+  it("rejects non-owner with an ephemeral notice", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "intruder" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 95 },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("owner");
+    expect(loveService.setOverride).not.toHaveBeenCalled();
+  });
+
+  it("calls the service and replies ephemeral by default for owner", async () => {
+    vi.mocked(loveService.setOverride).mockResolvedValue({
+      percentage: 95,
+      verdict: "Custom",
+      isOverride: true,
+    } as any);
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 95 },
+        { name: "verdict", value: "Tortolitos" },
+      ]),
+    ]);
+
+    expect(loveService.setOverride).toHaveBeenCalledWith(
+      "111",
+      "222",
+      95,
+      "Tortolitos",
+      "owner-1"
+    );
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral); // owner default ephemeral
+    expect(payload.embeds[0].data.title).toBe("✏️ Override guardado");
+  });
+
+  it("becomes public when owner explicitly passes private:false", async () => {
+    vi.mocked(loveService.setOverride).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+      isOverride: true,
+    } as any);
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 50 },
+        { name: "private", value: false },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBeUndefined();
+  });
+
+  it("rejects out-of-range percentages with an ephemeral notice", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("set", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+        { name: "percentage", value: 200 },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("entre 0 y 100");
+    expect(loveService.setOverride).not.toHaveBeenCalled();
+  });
+});
+
+describe("/love reset (owner-only)", () => {
+  it("rejects non-owner with an ephemeral notice", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "intruder" } });
+    await love.run(client, interaction, [
+      subCommandArg("reset", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    expect(loveService.resetPair).not.toHaveBeenCalled();
+  });
+
+  it("calls the service for owner and replies ephemeral by default", async () => {
+    vi.mocked(loveService.resetPair).mockResolvedValue({
+      ok: true,
+      statusCode: 200,
+      message: "ok",
+    });
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("reset", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+
+    expect(loveService.resetPair).toHaveBeenCalledWith("111", "222");
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.embeds[0].data.title).toBe("🔄 Pareja reseteada");
+  });
+
+  it("returns a friendly notice when the pair didn't exist", async () => {
+    vi.mocked(loveService.resetPair).mockResolvedValue({
+      ok: false,
+      statusCode: 404,
+      message: "not found",
+    });
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await love.run(client, interaction, [
+      subCommandArg("reset", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("no estaba registrada");
+  });
+});
+
+describe("branding", () => {
+  it("ship embed uses fun color and brand footer (no setAuthor)", async () => {
+    vi.mocked(loveService.getOrCreatePair).mockResolvedValue({
+      percentage: 50,
+      verdict: null,
+    } as any);
+    const interaction = createMockInteraction();
+    await love.run(createMockClient(), interaction, [
+      subCommandArg("ship", [
+        { name: "user1", value: "111" },
+        { name: "user2", value: "222" },
+      ]),
+    ]);
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.color).toBe(0xfee75c);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
   });
 });

--- a/src/slashCommands/fun/love.ts
+++ b/src/slashCommands/fun/love.ts
@@ -130,7 +130,7 @@ const handleShip = async (
   const pair = await loveService.getOrCreatePair(user1, user2);
   if (!pair) {
     return interaction.reply({
-      content: "No pude calcular la compatibilidad. Probá de nuevo en un rato.",
+      content: "No pude calcular la compatibilidad. Prueba de nuevo en un rato.",
       flags: MessageFlags.Ephemeral,
     });
   }
@@ -255,7 +255,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -292,7 +292,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: sí)",
+          description: "Mostrar la respuesta solo a ti (default: sí)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -317,7 +317,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: sí)",
+          description: "Mostrar la respuesta solo a ti (default: sí)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },

--- a/src/slashCommands/fun/love.ts
+++ b/src/slashCommands/fun/love.ts
@@ -1,41 +1,354 @@
-import { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import * as loveService from "../../shared/services/love.service";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const SUB = {
+  ship: "ship",
+  set: "set",
+  reset: "reset",
+} as const;
+
+const OPT = {
+  user1: "user1",
+  user2: "user2",
+  percentage: "percentage",
+  verdict: "verdict",
+  private: "private",
+} as const;
+
+const VERDICTS: { max: number; phrase: string }[] = [
+  { max: 10, phrase: "Mejor sigan siendo conocidos. 🙅" },
+  { max: 25, phrase: "No, gracias. La química explota… al revés. 🧪" },
+  { max: 40, phrase: "Hay potencial, pero falta chispa. 🤏" },
+  { max: 55, phrase: "Buena onda, amistad sólida. 🤝" },
+  { max: 70, phrase: "Mira mira mira… algo pasa acá. 👀" },
+  { max: 85, phrase: "¡Tortolitos confirmados! 💞" },
+  { max: 99, phrase: "Almas gemelas, hagan los planes ya. 💞" },
+  { max: 100, phrase: "💍 Casamiento ya. Compre los anillos. ⛪" },
+];
+
+const SELF_LOVE_PHRASE = "El amor propio es el mejor amor. 💖";
+
+const verdictFor = (pct: number): string => {
+  for (const v of VERDICTS) {
+    if (pct <= v.max) return v.phrase;
+  }
+  return VERDICTS[VERDICTS.length - 1].phrase;
+};
+
+const HEART_FILLED = "❤️";
+const HEART_EMPTY = "🤍";
+const HEART_BAR_LENGTH = 10;
+
+const heartBar = (pct: number): string => {
+  const filled = Math.round((pct / 100) * HEART_BAR_LENGTH);
+  return (
+    HEART_FILLED.repeat(filled) + HEART_EMPTY.repeat(HEART_BAR_LENGTH - filled)
+  );
+};
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildShipEmbed = (
+  id1: string,
+  id2: string,
+  percentage: number,
+  customVerdict: string | null
+) => {
+  const isSelfShip = id1 === id2;
+  const description = isSelfShip
+    ? `<@${id1}> consigo mismo`
+    : `<@${id1}>  +  <@${id2}>`;
+
+  const verdictText = isSelfShip
+    ? SELF_LOVE_PHRASE
+    : customVerdict ?? verdictFor(percentage);
+
+  return baseEmbed()
+    .setTitle("💘 Shipping")
+    .setDescription(description)
+    .addFields(
+      {
+        name: "💯 Compatibilidad",
+        value: `${heartBar(percentage)}\n**${percentage}%**`,
+      },
+      {
+        name: "💌 Veredicto",
+        value: verdictText,
+      }
+    );
+};
+
+type SubArg = NonNullable<Argument["args"]>[number];
+
+const findArg = (args: SubArg[] | undefined, name: string) =>
+  args?.find((a) => a.name === name)?.value;
+
+const isOwner = (interaction: ChatInputCommandInteraction, client: ClientDiscord) =>
+  interaction.user.id === client.config.ownerId;
+
+const replyOwnerOnly = (interaction: ChatInputCommandInteraction) =>
+  interaction.reply({
+    content: "Solo el owner puede usar este subcomando.",
+    flags: MessageFlags.Ephemeral,
+  });
+
+const handleShip = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  const user1 = findArg(subArgs, OPT.user1) as string;
+  const user2 = findArg(subArgs, OPT.user2) as string;
+  const isPrivate = (findArg(subArgs, OPT.private) as boolean | undefined) ?? false;
+
+  // Self-ship: skip the DB roundtrip — always 100% with the self-love phrase.
+  if (user1 === user2) {
+    return interaction.reply({
+      embeds: [buildShipEmbed(user1, user2, 100, null)],
+      flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      allowedMentions: { users: [] },
+    });
+  }
+
+  const pair = await loveService.getOrCreatePair(user1, user2);
+  if (!pair) {
+    return interaction.reply({
+      content: "No pude calcular la compatibilidad. Probá de nuevo en un rato.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  return interaction.reply({
+    embeds: [buildShipEmbed(user1, user2, pair.percentage, pair.verdict)],
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+    allowedMentions: { users: [] },
+  });
+};
+
+const handleSet = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  if (!isOwner(interaction, client)) return replyOwnerOnly(interaction);
+
+  const user1 = findArg(subArgs, OPT.user1) as string;
+  const user2 = findArg(subArgs, OPT.user2) as string;
+  const percentage = findArg(subArgs, OPT.percentage) as number;
+  const verdict = (findArg(subArgs, OPT.verdict) as string | undefined) ?? null;
+  // Owner subcommands default to ephemeral. Add `private:false` to make it public.
+  const explicitPrivate = findArg(subArgs, OPT.private) as boolean | undefined;
+  const isPrivate = explicitPrivate ?? true;
+
+  if (percentage < 0 || percentage > 100) {
+    return interaction.reply({
+      content: "El porcentaje debe estar entre 0 y 100.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const updated = await loveService.setOverride(
+    user1,
+    user2,
+    percentage,
+    verdict,
+    interaction.user.id
+  );
+  if (!updated) {
+    return interaction.reply({
+      content: "No pude guardar el override.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const embed = baseEmbed()
+    .setTitle("✏️ Override guardado")
+    .setDescription(`<@${user1}> + <@${user2}> → **${percentage}%**`)
+    .addFields({
+      name: "💌 Veredicto",
+      value: verdict ?? "_(usa el bucket automático)_",
+    });
+
+  return interaction.reply({
+    embeds: [embed],
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+    allowedMentions: { users: [] },
+  });
+};
+
+const handleReset = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  if (!isOwner(interaction, client)) return replyOwnerOnly(interaction);
+
+  const user1 = findArg(subArgs, OPT.user1) as string;
+  const user2 = findArg(subArgs, OPT.user2) as string;
+  const explicitPrivate = findArg(subArgs, OPT.private) as boolean | undefined;
+  const isPrivate = explicitPrivate ?? true;
+
+  const result = await loveService.resetPair(user1, user2);
+
+  if (!result.ok) {
+    return interaction.reply({
+      content:
+        result.statusCode === 404
+          ? `Esa pareja no estaba registrada — no hay nada que resetear.`
+          : "No pude resetear la pareja.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const embed = baseEmbed()
+    .setTitle("🔄 Pareja reseteada")
+    .setDescription(
+      `<@${user1}> + <@${user2}> vuelve al cálculo automático en el próximo \`/love ship\`.`
+    );
+
+  return interaction.reply({
+    embeds: [embed],
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+    allowedMentions: { users: [] },
+  });
+};
 
 const pull: ISlashCommand = {
   name: "love",
   category: "fun",
-  description: "Shipea >w<!",
+  description: "Shippea a dos personas y calcula su compatibilidad",
   ownerOnly: false,
   options: [
     {
-      name: "user1",
-      description: "Primer shippeado",
-      type: ApplicationCommandOptionType.User,
-      required: true,
+      name: SUB.ship,
+      description: "Calcula la compatibilidad entre dos personas",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.user1,
+          description: "Primer shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.user2,
+          description: "Segundo shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
     {
-      name: "user2",
-      description: "Segundo shippeado",
-      type: ApplicationCommandOptionType.User,
-      required: true,
+      name: SUB.set,
+      description: "[Owner] Setea o edita la compatibilidad de una pareja",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.user1,
+          description: "Primer shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.user2,
+          description: "Segundo shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.percentage,
+          description: "Porcentaje de compatibilidad (0–100)",
+          type: ApplicationCommandOptionType.Integer,
+          required: true,
+        },
+        {
+          name: OPT.verdict,
+          description: "Veredicto custom (default: usa el bucket automático)",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: sí)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
+    },
+    {
+      name: SUB.reset,
+      description: "[Owner] Borra el override de una pareja (vuelve al cálculo automático)",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.user1,
+          description: "Primer shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.user2,
+          description: "Segundo shippeado",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: sí)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
   ],
+  examples: [
+    "/love ship user1:@ana user2:@bob",
+    "/love set user1:@ana user2:@bob percentage:95 verdict:\"Tortolitos del server\"",
+    "/love reset user1:@ana user2:@bob",
+  ],
   run: async (
-    _: ClientDiscord,
+    client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const user1Id = args.find((a) => a.name === "user1")?.value as string;
-      const user2Id = args.find((a) => a.name === "user2")?.value as string;
+      const sub = args[0];
+      if (!sub) return;
+      const subArgs = sub.args ?? [];
 
-      return interaction.reply({
-        content: `<@${user1Id}> y <@${user2Id}> se quieren, se besan :3 <3`,
-        allowedMentions: { users: [] },
-      });
+      switch (sub.name) {
+        case SUB.ship:
+          return handleShip(client, interaction, subArgs);
+        case SUB.set:
+          return handleSet(client, interaction, subArgs);
+        case SUB.reset:
+          return handleReset(client, interaction, subArgs);
+        default:
+          return;
+      }
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/fun/poke.test.ts
+++ b/src/slashCommands/fun/poke.test.ts
@@ -1,16 +1,20 @@
 import { MessageFlags } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createMockClient, createMockInteraction, subCommandArg } from "../../test-utils/discord-mocks";
+import {
+  createMockClient,
+  createMockInteraction,
+  subCommandArg,
+} from "../../test-utils/discord-mocks";
 import poke from "./poke";
 
 const fakePokemon = {
   name: "charmander",
   order: 4,
   sprites: {
-    front_default: "url-default",
+    front_default: "https://example.com/charmander.png",
     front_female: null,
-    front_shiny: "url-shiny",
+    front_shiny: "https://example.com/charmander-shiny.png",
     front_shiny_female: null,
   },
   types: [{ type: { name: "fire" } }],
@@ -28,15 +32,17 @@ const fakeTypeListing = {
   pokemon: [{ pokemon: { name: "charmander" } }],
 };
 
+const okFetch = (async (url: any) => {
+  const stringUrl = url.toString();
+  if (stringUrl.includes("/type/")) {
+    return new Response(JSON.stringify(fakeTypeListing), { status: 200 });
+  }
+  return new Response(JSON.stringify(fakePokemon), { status: 200 });
+}) as any;
+
 describe("/poke", () => {
   beforeEach(() => {
-    vi.spyOn(global, "fetch").mockImplementation((async (url: any) => {
-      const stringUrl = url.toString();
-      if (stringUrl.includes("/type/")) {
-        return new Response(JSON.stringify(fakeTypeListing), { status: 200 });
-      }
-      return new Response(JSON.stringify(fakePokemon), { status: 200 });
-    }) as any);
+    vi.spyOn(global, "fetch").mockImplementation(okFetch);
   });
 
   afterEach(() => {
@@ -46,23 +52,60 @@ describe("/poke", () => {
   describe("types subcommand", () => {
     it("replies with the static list of types — no fetch needed", async () => {
       const interaction = createMockInteraction();
-      await poke.run(createMockClient(), interaction, [subCommandArg("types")]);
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("types"),
+      ]);
 
       expect(interaction.reply).toHaveBeenCalledOnce();
       const payload = interaction.reply.mock.calls[0][0];
       expect(payload.embeds).toHaveLength(1);
       expect(global.fetch).not.toHaveBeenCalled();
     });
+
+    it("becomes ephemeral when private:true", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("types", [{ name: "private", value: true }]),
+      ]);
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    });
   });
 
   describe("random subcommand", () => {
     it("defers, fetches a pokemon, and replies via editReply", async () => {
       const interaction = createMockInteraction();
-      await poke.run(createMockClient(), interaction, [subCommandArg("random")]);
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
 
       expect(interaction.deferReply).toHaveBeenCalledOnce();
       expect(global.fetch).toHaveBeenCalledOnce();
       expect(interaction.editReply).toHaveBeenCalledOnce();
+    });
+
+    it("defers ephemerally when private:true", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random", [{ name: "private", value: true }]),
+      ]);
+      const deferPayload = interaction.deferReply.mock.calls[0][0];
+      expect(deferPayload.flags).toBe(MessageFlags.Ephemeral);
+    });
+
+    it("falls back to a friendly error message when fetch fails", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue(
+        new Response("oops", { status: 500 })
+      );
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
+
+      const payload = interaction.editReply.mock.calls[0][0];
+      expect(payload.content).toContain("PokéAPI");
+      // No flags here on purpose — editReply can't change ephemerality after defer
+      expect(payload.flags).toBeUndefined();
     });
   });
 
@@ -88,6 +131,78 @@ describe("/poke", () => {
       const payload = interaction.reply.mock.calls[0][0];
       expect(payload.flags).toBe(MessageFlags.Ephemeral);
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a friendly error when the type listing endpoint fails", async () => {
+      vi.spyOn(global, "fetch").mockImplementation((async (url: any) => {
+        if (url.toString().includes("/type/")) {
+          return new Response("oops", { status: 500 });
+        }
+        return new Response(JSON.stringify(fakePokemon), { status: 200 });
+      }) as any);
+
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("type", [{ name: "name", value: "fire" }]),
+      ]);
+
+      const payload = interaction.editReply.mock.calls[0][0];
+      expect(payload.content).toContain("PokéAPI");
+    });
+  });
+
+  describe("branding", () => {
+    it("fire-type Pokémon embed uses fire color and brand footer (no setAuthor)", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
+
+      const payload = interaction.editReply.mock.calls[0][0];
+      const embed = payload.embeds[0].data;
+      expect(embed.color).toBe(0xee8130); // fire color
+      expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+      expect(embed.author).toBeUndefined();
+    });
+
+    it("title is prefixed with 🔴", async () => {
+      const interaction = createMockInteraction();
+      await poke.run(createMockClient(), interaction, [
+        subCommandArg("random"),
+      ]);
+      const embed = interaction.editReply.mock.calls[0][0].embeds[0].data;
+      expect(embed.title).toMatch(/^🔴 /);
+    });
+  });
+
+  describe("autocomplete", () => {
+    const buildAutocompleteInteraction = (focusedValue: string) =>
+      ({
+        options: {
+          getFocused: vi
+            .fn()
+            .mockReturnValue({ name: "name", value: focusedValue }),
+        },
+        respond: vi.fn().mockResolvedValue(undefined),
+      }) as any;
+
+    it("returns matching types as choices (substring)", async () => {
+      const interaction = buildAutocompleteInteraction("fi");
+      await poke.autocomplete!(createMockClient(), interaction);
+
+      expect(interaction.respond).toHaveBeenCalledOnce();
+      const choices = interaction.respond.mock.calls[0][0];
+      const values = choices.map((c: any) => c.value);
+      expect(values).toContain("fire");
+      expect(values).toContain("fighting");
+      expect(values).not.toContain("water");
+    });
+
+    it("returns the full list when query is empty", async () => {
+      const interaction = buildAutocompleteInteraction("");
+      await poke.autocomplete!(createMockClient(), interaction);
+      const choices = interaction.respond.mock.calls[0][0];
+      expect(choices.length).toBe(18);
     });
   });
 });

--- a/src/slashCommands/fun/poke.test.ts
+++ b/src/slashCommands/fun/poke.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createMockClient, createMockInteraction, subCommandArg } from "../../test-utils/discord-mocks";
@@ -85,7 +86,7 @@ describe("/poke", () => {
 
       expect(interaction.reply).toHaveBeenCalledOnce();
       const payload = interaction.reply.mock.calls[0][0];
-      expect(payload.ephemeral).toBe(true);
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
       expect(global.fetch).not.toHaveBeenCalled();
     });
   });

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction } from "discord.js";
+import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
 import { Argument, ISlashCommand } from "../../shared/types";
@@ -84,7 +84,7 @@ const pull: ISlashCommand = {
         if (!POKE_TYPES.includes(typeName as (typeof POKE_TYPES)[number])) {
           return interaction.reply({
             content: `Tipo no encontrado. Prueba con: ${POKE_TYPES.join(", ")}`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
         await interaction.deferReply();

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -1,6 +1,16 @@
-import { ChatInputCommandInteraction, MessageFlags } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random } from "../../shared/utils/helpers";
 
@@ -25,11 +35,136 @@ const POKE_TYPES = [
   "water",
 ] as const;
 
+type PokeType = (typeof POKE_TYPES)[number];
+
+/**
+ * Canonical Pokémon type colors. Signal-carrying — convention bends as in /imc.
+ * Multi-type pokémon use the FIRST type's color (Bulbasaur is grass, not poison).
+ */
+const TYPE_COLOR: Record<PokeType, number> = {
+  bug: 0xa6b91a,
+  dark: 0x705746,
+  dragon: 0x6f35fc,
+  electric: 0xf7d02c,
+  fairy: 0xd685ad,
+  fighting: 0xc22e28,
+  fire: 0xee8130,
+  flying: 0xa98ff3,
+  ghost: 0x735797,
+  grass: 0x7ac74c,
+  ground: 0xe2bf65,
+  ice: 0x96d9d6,
+  normal: 0xa8a77a,
+  poison: 0xa33ea1,
+  psychic: 0xf95587,
+  rock: 0xb6a136,
+  steel: 0xb7b7ce,
+  water: 0x6390f0,
+};
+
+const DEFAULT_POKE_COLOR = 0xa8a77a; // normal-type fallback
+
 const SUB = {
   random: "random",
   types: "types",
   type: "type",
 } as const;
+
+const OPT = {
+  name: "name",
+  private: "private",
+} as const;
+
+const POKEAPI_BASE = "https://pokeapi.co/api/v2";
+const MAX_POKE_ID = 898; // Gen 1–8. Don't bump without verifying API coverage.
+
+const capitalizeFirst = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1);
+
+const isPokeType = (s: string): s is PokeType =>
+  (POKE_TYPES as readonly string[]).includes(s);
+
+const colorForFirstType = (data: any): number => {
+  const firstType = (data.types?.[0]?.type?.name as string | undefined) ?? "";
+  return isPokeType(firstType) ? TYPE_COLOR[firstType] : DEFAULT_POKE_COLOR;
+};
+
+const pickSprite = (data: any): { url: string; isShiny: boolean } => {
+  const sprites = [
+    data.sprites.front_default,
+    data.sprites.front_female,
+    data.sprites.front_shiny,
+    data.sprites.front_shiny_female,
+  ];
+  // 1-in-50 chance to pick from any of the four sprites (incl. shinies);
+  // otherwise default to one of the first two.
+  let img =
+    random(0, 49) === 1
+      ? sprites[random(0, sprites.length - 1)]
+      : sprites[random(0, 1)];
+  img ??= data.sprites.front_default;
+  return {
+    url: img,
+    isShiny: img === sprites[2] || img === sprites[3],
+  };
+};
+
+const buildPokemonEmbed = (data: any, idOrName: number | string) => {
+  const { url: img, isShiny } = pickSprite(data);
+  const types = (data.types as any[])
+    .map((t) => `\`${capitalizeFirst(t.type.name)}\``)
+    .join(" ");
+  const stats = data.stats as any[];
+  const order =
+    typeof idOrName === "number" || !data.order || data.order < 1
+      ? idOrName.toString()
+      : data.order;
+
+  return new EmbedBuilder()
+    .setTitle(
+      `🔴 ${capitalizeFirst(data.name)}${isShiny ? " ⭐️" : ""} #${order}`
+    )
+    .setDescription(types)
+    .setColor(colorForFirstType(data))
+    .addFields(
+      { name: "HP", value: `\`${stats[0].base_stat}\``, inline: true },
+      { name: "Attack", value: `\`${stats[1].base_stat}\``, inline: true },
+      { name: "Defense", value: `\`${stats[2].base_stat}\``, inline: true },
+      { name: "Speed", value: `\`${stats[5].base_stat}\``, inline: true },
+      { name: "Sp. Atk", value: `\`${stats[3].base_stat}\``, inline: true },
+      { name: "Sp. Def", value: `\`${stats[4].base_stat}\``, inline: true }
+    )
+    .setImage(img)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildTypesListEmbed = () =>
+  new EmbedBuilder()
+    .setTitle("🔴 Tipos disponibles")
+    .setDescription(POKE_TYPES.map((t) => `\`${t}\``).join(" "))
+    .setColor(DEFAULT_POKE_COLOR)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const fetchJson = async (url: string): Promise<any | null> => {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+};
+
+// Note: no `flags` field — editReply can't change ephemerality after defer.
+// The error inherits the visibility chosen at deferReply time.
+const apiErrorPayload = () => ({
+  content: "La PokéAPI no respondió bien. Intentá de nuevo en un rato.",
+});
+
+type SubArg = NonNullable<Argument["args"]>[number];
+
+const findArg = (args: SubArg[] | undefined, name: string) =>
+  args?.find((a) => a.name === name)?.value;
 
 const pull: ISlashCommand = {
   name: "poke",
@@ -41,11 +176,27 @@ const pull: ISlashCommand = {
       name: SUB.random,
       description: "Pokémon completamente random (1-898)",
       type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
     {
       name: SUB.types,
       description: "Lista los tipos disponibles",
       type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
+      ],
     },
     {
       name: SUB.type,
@@ -53,14 +204,42 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
-          name: "name",
+          name: OPT.name,
           description: "Tipo (fire, water, grass, etc.)",
           type: ApplicationCommandOptionType.String,
           required: true,
+          autocomplete: true,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
         },
       ],
     },
   ],
+  examples: [
+    "/poke random",
+    "/poke types",
+    "/poke type name:fire",
+    "/poke type name:water private:true",
+  ],
+  autocomplete: async (
+    _: ClientDiscord,
+    interaction: AutocompleteInteraction
+  ) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== OPT.name) {
+      await interaction.respond([]);
+      return;
+    }
+    const query = String(focused.value ?? "").toLowerCase();
+    const matches = POKE_TYPES.filter((t) => t.includes(query))
+      .slice(0, 25)
+      .map((t) => ({ name: capitalizeFirst(t), value: t }));
+    await interaction.respond(matches);
+  },
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
@@ -69,96 +248,53 @@ const pull: ISlashCommand = {
     try {
       const sub = args[0];
       if (!sub) return;
+      const subArgs = sub.args ?? [];
+      const isPrivate =
+        (findArg(subArgs, OPT.private) as boolean | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
 
       if (sub.name === SUB.types) {
-        const list = POKE_TYPES.map((t) => `\`${t}\``).join(" ");
         return interaction.reply({
-          embeds: [
-            { color: 0x0099ff, title: "Tipos disponibles", description: list },
-          ],
+          embeds: [buildTypesListEmbed()],
+          flags,
         });
       }
 
       if (sub.name === SUB.type) {
-        const typeName = sub.args?.[0].value as string;
-        if (!POKE_TYPES.includes(typeName as (typeof POKE_TYPES)[number])) {
+        const typeName = (findArg(subArgs, OPT.name) as string) ?? "";
+        if (!isPokeType(typeName)) {
           return interaction.reply({
             content: `Tipo no encontrado. Prueba con: ${POKE_TYPES.join(", ")}`,
             flags: MessageFlags.Ephemeral,
           });
         }
-        await interaction.deferReply();
-        const typeRes = await fetch(
-          `https://pokeapi.co/api/v2/type/${typeName}`
-        );
-        const typeData: any = await typeRes.json();
+
+        await interaction.deferReply({ flags });
+        const typeData = await fetchJson(`${POKEAPI_BASE}/type/${typeName}`);
+        if (!typeData?.pokemon?.length) {
+          return interaction.editReply(apiErrorPayload());
+        }
         const picked =
           typeData.pokemon[random(0, typeData.pokemon.length - 1)].pokemon.name;
-        const pokeRes = await fetch(
-          `https://pokeapi.co/api/v2/pokemon/${picked}`
-        );
-        const pokeData: any = await pokeRes.json();
-        return interaction.editReply(buildEmbed(pokeData, picked));
+        const pokeData = await fetchJson(`${POKEAPI_BASE}/pokemon/${picked}`);
+        if (!pokeData) return interaction.editReply(apiErrorPayload());
+        return interaction.editReply({
+          embeds: [buildPokemonEmbed(pokeData, picked)],
+        });
       }
 
-      // SUB.random (default)
-      await interaction.deferReply();
-      const id = random(1, 898);
-      const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`);
-      const data: any = await res.json();
-      return interaction.editReply(buildEmbed(data, id));
+      // SUB.random (default fallthrough)
+      await interaction.deferReply({ flags });
+      const id = random(1, MAX_POKE_ID);
+      const data = await fetchJson(`${POKEAPI_BASE}/pokemon/${id}`);
+      if (!data) return interaction.editReply(apiErrorPayload());
+      return interaction.editReply({
+        embeds: [buildPokemonEmbed(data, id)],
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }
   },
-};
-
-const capitalizeFirst = (s: string) =>
-  s.charAt(0).toUpperCase() + s.slice(1);
-
-const buildEmbed = (data: any, idOrName: number | string) => {
-  const sprites = [
-    data.sprites.front_default,
-    data.sprites.front_female,
-    data.sprites.front_shiny,
-    data.sprites.front_shiny_female,
-  ];
-
-  let img =
-    random(0, 49) === 1
-      ? sprites[random(0, sprites.length - 1)]
-      : sprites[random(0, 1)];
-  img ??= data.sprites.front_default;
-  const isShiny = img === sprites[2] || img === sprites[3];
-
-  const types = (data.types as any[])
-    .map((t) => `\`${capitalizeFirst(t.type.name)}\``)
-    .join(" ");
-
-  const stats = data.stats as any[];
-  const order =
-    typeof idOrName === "number" || !data.order || data.order < 1
-      ? idOrName.toString()
-      : data.order;
-
-  return {
-    embeds: [
-      {
-        color: 0x0099ff,
-        title: `${capitalizeFirst(data.name)}${isShiny ? " ⭐️" : ""} #${order}`,
-        description: types,
-        fields: [
-          { name: "HP", value: `\`${stats[0].base_stat}\``, inline: true },
-          { name: "Attack", value: `\`${stats[1].base_stat}\``, inline: true },
-          { name: "Defense", value: `\`${stats[2].base_stat}\``, inline: true },
-          { name: "Speed", value: `\`${stats[5].base_stat}\``, inline: true },
-          { name: "Sp. Atk", value: `\`${stats[3].base_stat}\``, inline: true },
-          { name: "Sp. Def", value: `\`${stats[4].base_stat}\``, inline: true },
-        ],
-        image: { url: img },
-      },
-    ],
-  };
 };
 
 export default pull;

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -83,7 +83,7 @@ const pull: ISlashCommand = {
         const typeName = sub.args?.[0].value as string;
         if (!POKE_TYPES.includes(typeName as (typeof POKE_TYPES)[number])) {
           return interaction.reply({
-            content: `Tipo no encontrado. Probá con: ${POKE_TYPES.join(", ")}`,
+            content: `Tipo no encontrado. Prueba con: ${POKE_TYPES.join(", ")}`,
             ephemeral: true,
           });
         }

--- a/src/slashCommands/fun/poke.ts
+++ b/src/slashCommands/fun/poke.ts
@@ -158,7 +158,7 @@ const fetchJson = async (url: string): Promise<any | null> => {
 // Note: no `flags` field — editReply can't change ephemerality after defer.
 // The error inherits the visibility chosen at deferReply time.
 const apiErrorPayload = () => ({
-  content: "La PokéAPI no respondió bien. Intentá de nuevo en un rato.",
+  content: "La PokéAPI no respondió bien. Intenta de nuevo en un rato.",
 });
 
 type SubArg = NonNullable<Argument["args"]>[number];
@@ -179,7 +179,7 @@ const pull: ISlashCommand = {
       options: [
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -192,7 +192,7 @@ const pull: ISlashCommand = {
       options: [
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -212,7 +212,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },

--- a/src/slashCommands/fun/roll.test.ts
+++ b/src/slashCommands/fun/roll.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("jimp", () => ({
@@ -9,7 +10,11 @@ vi.mock("jimp", () => ({
 }));
 
 import { Jimp } from "jimp";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import roll from "./roll";
 
 beforeEach(() => {
@@ -55,5 +60,69 @@ describe("/roll", () => {
 
     expect(Jimp.read).toHaveBeenCalledTimes(20);
     expect(interaction.reply).toHaveBeenCalledOnce();
+  });
+
+  it("includes a Total line when quantity > 1", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [
+      arg("quantity", 4),
+      arg("sides", 20),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    expect(desc).toContain("**4d20**");
+    expect(desc).toContain("**Total:**");
+  });
+
+  it("uses singular phrasing for a single roll", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("sides", 20)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const desc = payload.embeds[0].data.description;
+    expect(desc).toContain("Sacaste un");
+    expect(desc).toContain("d20");
+    expect(desc).not.toContain("Total");
+  });
+
+  it("rejects ephemerally when quantity < 1", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("quantity", 0)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 1");
+    expect(Jimp.read).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when sides < 2", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("sides", 1)]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 2");
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [
+      arg("sides", 20),
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
+    const interaction = createMockInteraction();
+    await roll.run(createMockClient(), interaction, [arg("sides", 20)]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.color).toBe(0xfee75c);
+    expect(embed.data.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.data.author).toBeUndefined();
   });
 });

--- a/src/slashCommands/fun/roll.ts
+++ b/src/slashCommands/fun/roll.ts
@@ -90,7 +90,7 @@ const pull: ISlashCommand = {
     },
     {
       name: OPTIONS.private,
-      description: "Mostrar la respuesta solo a vos (default: público)",
+      description: "Mostrar la respuesta solo a ti (default: público)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/fun/roll.ts
+++ b/src/slashCommands/fun/roll.ts
@@ -1,118 +1,154 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+import { Jimp } from "jimp";
+
 import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random } from "../../shared/utils/helpers";
-import { Jimp } from "jimp";
 
 const OPTIONS = {
   quantity: "quantity",
   sides: "sides",
+  private: "private",
 } as const;
 
-type OPTIONS_TYPES = (typeof OPTIONS)[keyof typeof OPTIONS];
+const MIN_QUANTITY = 1;
+const MAX_QUANTITY = 20;
+const MIN_SIDES = 2;
+const MAX_SIDES = 100;
+
+const IMAGE_AVAILABLE_SIDES = [4, 6, 12] as const;
+const TILES_PER_ROW = 6;
+
+const composeDiceImage = async (rolls: number[], sides: number) => {
+  const repo = config.oldRoot;
+  const images = await Promise.all(
+    rolls.map((r) => Jimp.read(`${repo}/d${sides}/d${r}.png`))
+  );
+
+  const tileWidth = images[0].width;
+  const tileHeight = images[0].height;
+  const cols = Math.min(images.length, TILES_PER_ROW);
+  const rows = Math.ceil(images.length / TILES_PER_ROW);
+  const finalImage = new Jimp({
+    width: cols * tileWidth,
+    height: rows * tileHeight,
+  });
+
+  for (let i = 0; i < images.length; i++) {
+    const col = i % TILES_PER_ROW;
+    const row = Math.floor(i / TILES_PER_ROW);
+    finalImage.composite(images[i], col * tileWidth, row * tileHeight);
+  }
+
+  return finalImage.getBuffer("image/png");
+};
+
+const buildEmbed = (rolls: number[], sides: number) => {
+  const total = rolls.reduce((a, b) => a + b, 0);
+  const dieLabel = `${rolls.length}d${sides}`;
+
+  const description =
+    rolls.length === 1
+      ? `Sacaste un **${rolls[0]}** (\`d${sides}\`)`
+      : `**${dieLabel}**: ${rolls.join(", ")}\n\n**Total:** ${total}`;
+
+  return new EmbedBuilder()
+    .setTitle("🎲 Dados")
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
 
 const pull: ISlashCommand = {
   name: "roll",
   category: "fun",
-  description: "roll dices",
+  description: "Tira dados (con imagen para d4, d6 y d12)",
   ownerOnly: false,
   options: [
     {
       name: OPTIONS.quantity,
-      description: "The number of dices to roll",
-      type: ApplicationCommandOptionType.Number,
+      description: `Cantidad de dados (${MIN_QUANTITY}–${MAX_QUANTITY}, default: 1)`,
+      type: ApplicationCommandOptionType.Integer,
       required: false,
     },
     {
       name: OPTIONS.sides,
-      description: "The number of sides of the dice",
-      type: ApplicationCommandOptionType.Number,
+      description: `Cantidad de lados (${MIN_SIDES}–${MAX_SIDES}, default: 6)`,
+      type: ApplicationCommandOptionType.Integer,
+      required: false,
+    },
+    {
+      name: OPTIONS.private,
+      description: "Mostrar la respuesta solo a vos (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
   ],
+  examples: ["/roll", "/roll quantity:3 sides:6", "/roll sides:20"],
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const { quantity, sides } = getArgs(args);
-      const result = [];
-      const existImages = [4, 6, 12];
-      const repo = config.oldRoot;
-      for (let i = 0; i < quantity; i++) {
-        result.push(random(1, sides));
-      }
-      const embed = new Discord.EmbedBuilder()
-        .setColor("Gold")
-        .setTitle("Dice Roll")
-        .setFooter({
-          text: `Requested by ${interaction.user.tag}`,
-          iconURL: interaction.user.displayAvatarURL(),
+      const rawQuantity = args.find((a) => a.name === OPTIONS.quantity)
+        ?.value as number | undefined;
+      const rawSides = args.find((a) => a.name === OPTIONS.sides)?.value as
+        | number
+        | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === OPTIONS.private)?.value as
+          | boolean
+          | undefined) ?? false;
+
+      if (rawQuantity !== undefined && rawQuantity < MIN_QUANTITY) {
+        return interaction.reply({
+          content: `La cantidad de dados debe ser al menos ${MIN_QUANTITY}.`,
+          flags: MessageFlags.Ephemeral,
         });
+      }
+      if (rawSides !== undefined && rawSides < MIN_SIDES) {
+        return interaction.reply({
+          content: `Un dado debe tener al menos ${MIN_SIDES} lados.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
-      if (existImages.includes(sides)) {
-        const images = await Promise.all(
-          result.map((r) => Jimp.read(`${repo}/d${sides}/d${r}.png`))
-        );
+      const quantity = Math.min(rawQuantity ?? 1, MAX_QUANTITY);
+      const sides = Math.min(rawSides ?? 6, MAX_SIDES);
 
-        const tileWidth = images[0].width;
-        const tileHeight = images[0].height;
-        const width = (images.length > 6 ? 6 : images.length) * tileWidth;
-        const height = Math.ceil(images.length / 6) * tileHeight;
-        const finalImage = new Jimp({ width, height });
-        let x = 0;
-        let col = 0;
-        let row = 0;
-        for (const image of images) {
-          finalImage.composite(image, x, row * tileHeight);
-          x += tileWidth;
-          col++;
-          if (col === 6) {
-            col = 0;
-            row++;
-            x = 0;
-          }
-        }
-        const buffer = await finalImage.getBuffer("image/png");
-        embed.setImage(`attachment://dice.png`);
-        interaction.reply({
+      const rolls: number[] = [];
+      for (let i = 0; i < quantity; i++) rolls.push(random(1, sides));
+
+      const embed = buildEmbed(rolls, sides);
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
+
+      if ((IMAGE_AVAILABLE_SIDES as readonly number[]).includes(sides)) {
+        const buffer = await composeDiceImage(rolls, sides);
+        embed.setImage("attachment://dice.png");
+        return interaction.reply({
           embeds: [embed],
           files: [{ attachment: buffer, name: "dice.png" }],
+          flags,
         });
-        return;
-      } else {
-        embed.setDescription(result.join("\n"));
       }
 
-      interaction.reply({ embeds: [embed] });
+      return interaction.reply({ embeds: [embed], flags });
     } catch (error) {
       errorHandler(interaction, error);
     }
   },
-};
-
-const maxQuantity = 20;
-
-const getArgs = (args: Argument[]) => {
-  let { quantity, sides } = args!.reduce<
-    Partial<Record<OPTIONS_TYPES, string | number | boolean>>
-  >(
-    (acc, cur) => {
-      acc[cur.name as OPTIONS_TYPES] = cur.value;
-      return acc;
-    },
-    { quantity: 1, sides: 6 }
-  );
-  quantity = Number(quantity);
-  sides = Number(sides);
-  if (!quantity) quantity = 1;
-  if (!sides) sides = 6;
-  quantity = quantity > maxQuantity ? maxQuantity : quantity < 1 ? 1 : quantity;
-  sides = sides > 100 ? 100 : sides < 1 ? 1 : sides;
-  return { quantity, sides };
 };
 
 export default pull;

--- a/src/slashCommands/fun/ruleta.test.ts
+++ b/src/slashCommands/fun/ruleta.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 });
 
 describe("/ruleta", () => {
-  it("happy path: replies and registers the collector", async () => {
+  it("happy path: replies with branded kickoff embed and registers an idle-timed collector", async () => {
     const interaction = createMockInteraction({ channel: sendableChannel() });
     const client = createMockClient();
     vi.mocked(client.users.fetch).mockResolvedValue({
@@ -48,7 +48,43 @@ describe("/ruleta", () => {
     await ruleta.run(client, interaction, [arg("player2", "player-2")]);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
-    expect(interaction.channel.createMessageCollector).toHaveBeenCalled();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.embeds).toHaveLength(1);
+    const embed = payload.embeds[0].data;
+    expect(embed.title).toBe("🔫 Ruleta rusa");
+    expect(embed.color).toBe(0xfee75c); // fun yellow
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+
+    // collector registered with idle timeout
+    expect(interaction.channel.createMessageCollector).toHaveBeenCalledOnce();
+    const collectorOpts = interaction.channel.createMessageCollector.mock.calls[0][0];
+    expect(collectorOpts.idle).toBe(5 * 60 * 1000);
+    expect(typeof collectorOpts.filter).toBe("function");
+  });
+
+  it("kickoff embed lists every player", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ruleta.run(client, interaction, [
+      arg("player2", "p2"),
+      arg("player3", "p3"),
+      arg("player4", "p4"),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const playersField = embed.fields.find((f: any) => f.name === "👥 Jugadores");
+    expect(playersField.value).toContain("<@user-1>");
+    expect(playersField.value).toContain("<@p2>");
+    expect(playersField.value).toContain("<@p3>");
+    expect(playersField.value).toContain("<@p4>");
   });
 
   it("rejects ephemerally when the channel is not sendable", async () => {
@@ -80,5 +116,110 @@ describe("/ruleta", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("bots");
+    // Doesn't even register a collector
+    expect(interaction.channel.createMessageCollector).not.toHaveBeenCalled();
+  });
+
+  it("solo play: works with no extra players (kickoff title shows 'Jugador' singular)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockImplementation((async (id: string) => ({
+      id,
+      bot: false,
+      username: `user-${id}`,
+      toString: () => `<@${id}>`,
+    })) as any);
+
+    await ruleta.run(client, interaction, []); // no player2
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.fields[0].name).toBe("👤 Jugador");
+    expect(embed.description).toContain("juega solo");
+    expect(interaction.channel.createMessageCollector).toHaveBeenCalled();
+  });
+
+  it("rejects when the same user appears more than once across player slots", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ruleta.run(createMockClient(), interaction, [
+      arg("player2", "duplicate"),
+      arg("player3", "duplicate"),
+    ]);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
+    // No collector since we bailed early
+    expect(interaction.channel.createMessageCollector).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the initiator lists themself as player2", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+
+    await ruleta.run(createMockClient(), interaction, [
+      // discord-mocks defaults the interaction.user.id to 'user-1'
+      arg("player2", "user-1"),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("dos veces");
+  });
+
+  it("alive update is sent as a branded embed (not plain text)", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockResolvedValue({
+      id: "player-2",
+      bot: false,
+      username: "Player2",
+      toString: () => "<@player-2>",
+    } as any);
+
+    await ruleta.run(client, interaction, [arg("player2", "player-2")]);
+
+    // Capture the collect handler that was registered on the collector
+    const collectorMock = interaction.channel.createMessageCollector.mock
+      .results[0].value;
+    const collectHandler = collectorMock.on.mock.calls.find(
+      (c: any) => c[0] === "collect"
+    )[1];
+
+    // Simulate a 'roll' message from the current-turn player
+    await collectHandler({
+      author: { id: "user-1", toString: () => "<@user-1>" },
+      content: "roll",
+    });
+
+    // channel.send should have been called with an embeds payload
+    const sendArg = interaction.channel.send.mock.calls[0][0];
+    expect(sendArg.embeds).toBeDefined();
+    expect(sendArg.embeds).toHaveLength(1);
+    const aliveEmbed = sendArg.embeds[0].data;
+    expect(aliveEmbed.color).toBe(0xfee75c);
+    expect(aliveEmbed.footer.text).toMatch(/Xiza Bot v\d+/);
+  });
+
+  it("collector filter only matches the current player typing 'roll'", async () => {
+    const interaction = createMockInteraction({ channel: sendableChannel() });
+    const client = createMockClient();
+    vi.mocked(client.users.fetch).mockResolvedValue({
+      id: "player-2",
+      bot: false,
+      username: "Player2",
+      toString: () => "<@player-2>",
+    } as any);
+
+    await ruleta.run(client, interaction, [arg("player2", "player-2")]);
+
+    const filter = interaction.channel.createMessageCollector.mock.calls[0][0].filter;
+    // Mock Roulette.game.turno is "user-1"
+    expect(filter({ author: { id: "user-1" }, content: "roll" })).toBe(true);
+    expect(filter({ author: { id: "user-1" }, content: "ROLL" })).toBe(true); // case-insensitive
+    expect(filter({ author: { id: "user-1" }, content: "fire" })).toBe(false);
+    expect(filter({ author: { id: "intruder" }, content: "roll" })).toBe(false);
   });
 });

--- a/src/slashCommands/fun/ruleta.test.ts
+++ b/src/slashCommands/fun/ruleta.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("death-games", () => ({
@@ -62,7 +63,7 @@ describe("/ruleta", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("rejects when any chosen player is a bot", async () => {
@@ -78,6 +79,6 @@ describe("/ruleta", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -1,11 +1,18 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
+  User,
 } from "discord.js";
 import Death from "death-games";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler, random as getRandom } from "../../shared/utils/helpers";
 
@@ -20,17 +27,80 @@ const ALIVE_MSGS = [
   " se ha salvado!",
 ];
 
+// Mod-red — signal of death/game-over, intentional deviation from fun yellow
+// (same logic as /imc keeping its data-driven status colors).
+const DEATH_COLOR = 0xed4245;
+
+// 5 min of silence → game gets cleaned up so a forgotten roulette doesn't hang
+// the channel with a dangling collector.
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+const buildKickoffEmbed = (users: User[]) => {
+  const isSolo = users.length === 1;
+  const playersList = users.map((u, i) => `${i + 1}. <@${u.id}>`).join("\n");
+  const description = isSolo
+    ? `<@${users[0].id}> juega solo — escribe \`roll\` cuando estés listo.`
+    : `Empieza <@${users[0].id}> — escribe \`roll\` en el chat cuando sea tu turno.`;
+
+  return new EmbedBuilder()
+    .setTitle("🔫 Ruleta rusa")
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .addFields({
+      name: isSolo ? "👤 Jugador" : "👥 Jugadores",
+      value: playersList,
+    })
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildAliveEmbed = (
+  rollerMention: string,
+  aliveMsg: string,
+  nextUserMention: string | null,
+  position: number
+) => {
+  const lines = [
+    `${rollerMention}${aliveMsg}`,
+    nextUserMention ? `Turno de ${nextUserMention}` : null,
+    `Escribe \`roll\` para probar suerte`,
+    `Posición actual: **${position}**`,
+  ].filter((s): s is string => Boolean(s));
+
+  return new EmbedBuilder()
+    .setDescription(lines.join("\n"))
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildDeathEmbed = (deadUserMention: string) =>
+  new EmbedBuilder()
+    .setTitle("💀 Los soplones, pum pum pum, al agua!")
+    .setDescription(`${deadUserMention} ha muerto! Se acabó la ronda!`)
+    .setColor(DEATH_COLOR)
+    .setImage(
+      `https://res.cloudinary.com/dnbgxu47a/image/upload/v1612981070/roulette/${getRandom(1, 5)}.gif`
+    )
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildAbandonedEmbed = () =>
+  new EmbedBuilder()
+    .setTitle("⌛ Juego abandonado")
+    .setDescription("La ruleta se quedó sin movimientos por 5 minutos.")
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
 const pull: ISlashCommand = {
   name: "ruleta",
   category: "fun",
-  description: "Ruleta rusa. Cada jugador escribe `roll` cuando es su turno.",
+  description:
+    "Ruleta rusa. Cada jugador escribe `roll` cuando es su turno. Podés jugar solo.",
   ownerOnly: false,
   options: [
     {
       name: "player2",
-      description: "Segundo jugador (obligatorio)",
+      description: "Segundo jugador (opcional — sin esto juegas solo)",
       type: ApplicationCommandOptionType.User,
-      required: true,
+      required: false,
     },
     {
       name: "player3",
@@ -51,13 +121,21 @@ const pull: ISlashCommand = {
       required: false,
     },
   ],
+  examples: [
+    "/ruleta",
+    "/ruleta player2:@bob",
+    "/ruleta player2:@bob player3:@carla player4:@diego",
+  ],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
+      if (
+        !interaction.channel?.isTextBased() ||
+        !interaction.channel.isSendable()
+      ) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
           flags: MessageFlags.Ephemeral,
@@ -73,6 +151,14 @@ const pull: ISlashCommand = {
         if (id) playerIds.push(id);
       }
 
+      // Reject duplicates — including someone listing themselves as player2.
+      if (new Set(playerIds).size !== playerIds.length) {
+        return interaction.reply({
+          content: "No puedes agregar al mismo jugador dos veces.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
       const users = await Promise.all(
         playerIds.map((id) => client.users.fetch(id))
       );
@@ -84,17 +170,15 @@ const pull: ISlashCommand = {
       }
 
       const ruleta = new Death.Roulette({ jugadores: playerIds });
+      const isSolo = playerIds.length === 1;
 
-      await interaction.reply({
-        content:
-          `Empieza ${interaction.user}\n` +
-          `Escribe \`roll\` en el chat para probar suerte`,
-      });
+      await interaction.reply({ embeds: [buildKickoffEmbed(users)] });
 
       const collector = channel.createMessageCollector({
         filter: (msg) =>
           ruleta.game.turno === msg.author.id &&
           msg.content.toLowerCase() === "roll",
+        idle: IDLE_TIMEOUT_MS,
       });
 
       collector.on("collect", async (msg) => {
@@ -102,30 +186,34 @@ const pull: ISlashCommand = {
         const dead = ruleta.elegir(roll);
 
         if (dead) {
-          const e = new EmbedBuilder()
-            .setColor("Random")
-            .setTitle("Los soplones, pum pum pum, al agua!")
-            .setDescription(
-              msg.author.toString() + " ha muerto! Se acabó la ronda!"
-            )
-            .setImage(
-              `https://res.cloudinary.com/dnbgxu47a/image/upload/v1612981070/roulette/${getRandom(1, 5)}.gif`
-            );
-          await channel.send({ embeds: [e] });
-          collector.stop();
+          await channel.send({
+            embeds: [buildDeathEmbed(msg.author.toString())],
+          });
+          collector.stop("dead");
           return;
         }
 
         const nextUser = users.find((u) => u.id === ruleta.game.turno);
-        await channel.send(
-          msg.author.toString() +
-            ALIVE_MSGS[getRandom(0, ALIVE_MSGS.length - 1)] +
-            "\nTurno de " +
-            (nextUser?.toString() ?? "?") +
-            "\nEscribe `roll` en el chat para probar suerte\n" +
-            "Posición actual: " +
-            ruleta.game.posicion
-        );
+        // In solo mode the next turn is always the same player — skip the
+        // 'Turno de' line so we don't repeat the player's name twice per roll.
+        const nextMention = isSolo ? null : (nextUser?.toString() ?? "?");
+
+        await channel.send({
+          embeds: [
+            buildAliveEmbed(
+              msg.author.toString(),
+              ALIVE_MSGS[getRandom(0, ALIVE_MSGS.length - 1)],
+              nextMention,
+              ruleta.game.posicion
+            ),
+          ],
+        });
+      });
+
+      collector.on("end", async (_, reason) => {
+        if (reason === "idle") {
+          await channel.send({ embeds: [buildAbandonedEmbed()] });
+        }
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -1,4 +1,8 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import Death from "death-games";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
@@ -56,7 +60,7 @@ const pull: ISlashCommand = {
       if (!interaction.channel?.isTextBased() || !interaction.channel.isSendable()) {
         return interaction.reply({
           content: "Este canal no soporta el juego.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
       const channel = interaction.channel;
@@ -75,7 +79,7 @@ const pull: ISlashCommand = {
       if (users.some((u) => u.bot)) {
         return interaction.reply({
           content: "No puedes agregar bots.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/fun/ruleta.ts
+++ b/src/slashCommands/fun/ruleta.ts
@@ -74,7 +74,7 @@ const pull: ISlashCommand = {
       );
       if (users.some((u) => u.bot)) {
         return interaction.reply({
-          content: "No podés meter bots.",
+          content: "No puedes agregar bots.",
           ephemeral: true,
         });
       }

--- a/src/slashCommands/fun/shuffle.test.ts
+++ b/src/slashCommands/fun/shuffle.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { MessageFlags } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction, subCommandArg } from "../../test-utils/discord-mocks";
+import {
+  createMockClient,
+  createMockInteraction,
+  subCommandArg,
+} from "../../test-utils/discord-mocks";
 import shuffle from "./shuffle";
 
 describe("/shuffle", () => {
-  describe("words subcommand", () => {
-    it("replies with the shuffled list", async () => {
+  describe("words subcommand — no winners (instant)", () => {
+    it("replies with the shuffled list and an original-list field", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
         subCommandArg("words", [{ name: "list", value: "ana bob carla david" }]),
@@ -14,18 +19,154 @@ describe("/shuffle", () => {
       expect(interaction.reply).toHaveBeenCalledOnce();
       const payload = interaction.reply.mock.calls[0][0];
       expect(payload.embeds).toHaveLength(1);
+      const embed = payload.embeds[0].data;
+      expect(embed.title).toBe("🔀 Lista aleatoria");
+      const original = embed.fields.find(
+        (f: any) => f.name === "Lista original"
+      );
+      expect(original.value).toBe("ana, bob, carla, david");
     });
 
-    it("respects the winners cap", async () => {
+    it("accepts comma-separated input", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [{ name: "list", value: "ana, bob, carla" }]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      const embed = payload.embeds[0].data;
+      const original = embed.fields.find(
+        (f: any) => f.name === "Lista original"
+      );
+      expect(original.value).toBe("ana, bob, carla");
+    });
+
+    it("rejects ephemerally when the list has fewer than 2 items", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [{ name: "list", value: "ana" }]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+      expect(payload.content).toContain("al menos 2");
+    });
+  });
+
+  describe("words subcommand — winners (animated raffle)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("defers, edits N teaser frames, then edits with the final winners embed", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
         subCommandArg("words", [
           { name: "list", value: "ana bob carla" },
           { name: "winners", value: 1 },
         ]),
       ]);
 
-      expect(interaction.reply).toHaveBeenCalledOnce();
+      // Drive the timers so all setTimeout-based sleeps resolve
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(interaction.deferReply).toHaveBeenCalledOnce();
+      // 3 teaser frames + 1 final reveal = 4 editReply calls
+      expect(interaction.editReply).toHaveBeenCalledTimes(4);
+      expect(interaction.reply).not.toHaveBeenCalled();
+
+      // The final edit should carry the winners embed
+      const finalCall = interaction.editReply.mock.calls.at(-1)![0];
+      expect(finalCall.embeds[0].data.title).toBe("🏆 Ganador");
+    });
+
+    it("uses 'Ganadores (N)' title for plural winners", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla david" },
+          { name: "winners", value: 3 },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const finalCall = interaction.editReply.mock.calls.at(-1)![0];
+      expect(finalCall.embeds[0].data.title).toBe("🏆 Ganadores (3)");
+    });
+
+    it("caps winners to the list length when winners > items", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob" },
+          { name: "winners", value: 99 },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const finalCall = interaction.editReply.mock.calls.at(-1)![0];
+      expect(finalCall.embeds[0].data.title).toBe("🏆 Ganadores (2)");
+    });
+
+    it("rejects ephemerally when winners < 1 (no defer, no animation)", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "winners", value: 0 },
+        ]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+      expect(payload.content).toContain("al menos 1");
+      expect(interaction.deferReply).not.toHaveBeenCalled();
+      expect(interaction.editReply).not.toHaveBeenCalled();
+    });
+
+    it("teaser frames use the '🎰 Sorteando...' title before the reveal", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "winners", value: 1 },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const calls = interaction.editReply.mock.calls;
+      // First three calls are teasers, last is the reveal
+      for (let i = 0; i < 3; i++) {
+        expect(calls[i][0].embeds[0].data.title).toBe("🎰 Sorteando...");
+      }
+    });
+
+    it("respects private:true on deferReply (animation runs ephemerally)", async () => {
+      const interaction = createMockInteraction();
+      const promise = shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "winners", value: 1 },
+          { name: "private", value: true },
+        ]),
+      ]);
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const deferPayload = interaction.deferReply.mock.calls[0][0];
+      expect(deferPayload.flags).toBe(MessageFlags.Ephemeral);
     });
   });
 
@@ -37,15 +178,68 @@ describe("/shuffle", () => {
       ]);
 
       expect(interaction.reply).toHaveBeenCalledOnce();
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.embeds[0].data.title).toBe("🔀 Números (1–5)");
     });
 
-    it("clamps quantity above 20 down to 20", async () => {
+    it("clamps quantity above 50 down to 50", async () => {
       const interaction = createMockInteraction();
       await shuffle.run(createMockClient(), interaction, [
-        subCommandArg("numbers", [{ name: "quantity", value: 99 }]),
+        subCommandArg("numbers", [{ name: "quantity", value: 999 }]),
       ]);
 
-      expect(interaction.reply).toHaveBeenCalledOnce();
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.embeds[0].data.title).toBe("🔀 Números (1–50)");
+    });
+
+    it("rejects ephemerally when quantity < 1", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("numbers", [{ name: "quantity", value: 0 }]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    });
+  });
+
+  describe("branding", () => {
+    it("uses the fun-category color and the brand footer (no setAuthor)", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [{ name: "list", value: "ana bob carla" }]),
+      ]);
+
+      const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+      expect(embed.color).toBe(0xfee75c);
+      expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+      expect(embed.author).toBeUndefined();
+    });
+
+    it("becomes ephemeral when private:true is passed (words, no winners)", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("words", [
+          { name: "list", value: "ana bob carla" },
+          { name: "private", value: true },
+        ]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    });
+
+    it("becomes ephemeral when private:true is passed (numbers)", async () => {
+      const interaction = createMockInteraction();
+      await shuffle.run(createMockClient(), interaction, [
+        subCommandArg("numbers", [
+          { name: "quantity", value: 5 },
+          { name: "private", value: true },
+        ]),
+      ]);
+
+      const payload = interaction.reply.mock.calls[0][0];
+      expect(payload.flags).toBe(MessageFlags.Ephemeral);
     });
   });
 });

--- a/src/slashCommands/fun/shuffle.ts
+++ b/src/slashCommands/fun/shuffle.ts
@@ -1,57 +1,170 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
-import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
-import { Argument, ISlashCommand } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 
-const OPTIONS = {
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler, shuffle } from "../../shared/utils/helpers";
+
+const SUB = {
   words: "words",
   numbers: "numbers",
+} as const;
+
+const OPT = {
   list: "list",
   winners: "winners",
   quantity: "quantity",
+  private: "private",
 } as const;
 
-type OPTIONS_TYPES = (typeof OPTIONS)[keyof typeof OPTIONS];
+const MIN_ITEMS = 2;
+const MIN_QUANTITY = 1;
+const MAX_QUANTITY = 50;
+
+// Animation only fires for /shuffle words winners:N — the dramatic reveal case.
+// Total wait: ANIMATION_FRAMES * FRAME_DELAY_MS = 1.8s with the defaults.
+const ANIMATION_FRAMES = 3;
+const FRAME_DELAY_MS = 600;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const parseWordList = (raw: string): string[] =>
+  raw
+    .split(/[,;\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+const enumerateLines = (items: (string | number)[]) =>
+  items.map((item, i) => `**${i + 1}.** ${item}`).join("\n");
+
+const teaserDescription = (list: string[]) =>
+  list.map((w, i) => `**${i + 1}.** ${w}`).join("\n");
+
+const baseEmbed = (title: string, description: string) =>
+  new EmbedBuilder()
+    .setTitle(title)
+    .setDescription(description)
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildTeaserEmbed = (list: string[]) =>
+  baseEmbed("🎰 Sorteando...", teaserDescription(shuffle(list)));
+
+const buildWinnersEmbed = (
+  shuffled: string[],
+  cap: number,
+  originalList: string[]
+) => {
+  const picked = shuffled.slice(0, cap);
+  const title = cap === 1 ? "🏆 Ganador" : `🏆 Ganadores (${cap})`;
+  return baseEmbed(title, enumerateLines(picked)).addFields({
+    name: "Lista original",
+    value: originalList.join(", "),
+  });
+};
+
+const buildShuffleEmbed = (list: string[]) =>
+  baseEmbed("🔀 Lista aleatoria", enumerateLines(shuffle(list))).addFields({
+    name: "Lista original",
+    value: list.join(", "),
+  });
+
+const buildNumbersEmbed = (quantity: number) =>
+  baseEmbed(
+    `🔀 Números (1–${quantity})`,
+    shuffle(Array.from({ length: quantity }, (_, i) => i + 1)).join(", ")
+  );
+
+/**
+ * Animated raffle reveal: defer → N teaser frames with re-shuffles → final winners.
+ * Runs purely on editReply so it works in both public and ephemeral mode.
+ */
+const animateWinnersReveal = async (
+  interaction: ChatInputCommandInteraction,
+  list: string[],
+  cap: number,
+  isPrivate: boolean
+) => {
+  await interaction.deferReply({
+    flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+  });
+
+  for (let i = 0; i < ANIMATION_FRAMES; i++) {
+    await interaction.editReply({ embeds: [buildTeaserEmbed(list)] });
+    await sleep(FRAME_DELAY_MS);
+  }
+
+  const finalShuffle = shuffle(list);
+  await interaction.editReply({
+    embeds: [buildWinnersEmbed(finalShuffle, cap, list)],
+  });
+};
 
 const pull: ISlashCommand = {
   name: "shuffle",
   category: "fun",
-  description: "Shuffle a list of words or numbers",
+  description: "Mezcla aleatoriamente una lista de palabras o números",
   ownerOnly: false,
   options: [
     {
-      name: OPTIONS.words,
-      description: "Shuffle a list of words",
+      name: SUB.words,
+      description: "Mezcla una lista de palabras",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
-          name: OPTIONS.list,
-          description: "example: name1 name2 name3",
+          name: OPT.list,
+          description: "Lista separada por espacios, comas o punto y coma",
           type: ApplicationCommandOptionType.String,
           required: true,
         },
         {
-          name: OPTIONS.winners,
-          description: "the number of winners",
+          name: OPT.winners,
+          description:
+            "Cantidad de ganadores a elegir (default: toda la lista, activa animación)",
           type: ApplicationCommandOptionType.Integer,
+          required: false,
+        },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
       ],
     },
     {
-      name: OPTIONS.numbers,
-      description: "Shuffle a list of numbers",
+      name: SUB.numbers,
+      description: "Genera y mezcla los números del 1 al N",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
-          name: OPTIONS.quantity,
-          description: "the number of numbers to sort",
+          name: OPT.quantity,
+          description: `Cantidad de números (${MIN_QUANTITY}–${MAX_QUANTITY})`,
           type: ApplicationCommandOptionType.Integer,
           required: true,
         },
+        {
+          name: OPT.private,
+          description: "Mostrar la respuesta solo a vos (default: público)",
+          type: ApplicationCommandOptionType.Boolean,
+          required: false,
+        },
       ],
     },
+  ],
+  examples: [
+    "/shuffle words list:ana,bob,carla",
+    "/shuffle words list:ana bob carla winners:1",
+    "/shuffle numbers quantity:10",
   ],
   run: async (
     _: ClientDiscord,
@@ -59,91 +172,71 @@ const pull: ISlashCommand = {
     args: Argument[]
   ) => {
     try {
-      const subCommand = args[0];
+      const sub = args[0];
+      if (!sub) return;
 
-      if (subCommand.name === OPTIONS.words) {
-        let { list: value, winners } = subCommand.args!.reduce<
-          Partial<Record<OPTIONS_TYPES, string | number | boolean>>
-        >(
-          (acc, cur) => {
-            acc[cur.name as OPTIONS_TYPES] = cur.value;
-            return acc;
-          },
-          { list: "" }
-        );
+      const subArgs = sub.args ?? [];
+      const findArg = (name: string) =>
+        subArgs.find((a) => a.name === name)?.value;
+      const isPrivate = (findArg(OPT.private) as boolean | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
 
-        const list = (value as string)?.split(" ").map((item) => item.trim());
-        const withWinners = Boolean(winners);
-        winners = parseInt(winners?.toString() || list.length.toString());
-        const title = withWinners
-          ? winners === 1
-            ? "Ganador"
-            : "Ganadores"
-          : "Lista aleatoria";
-        const shuffledList = shuffle(list);
+      if (sub.name === SUB.words) {
+        const rawList = (findArg(OPT.list) as string) ?? "";
+        const winners = findArg(OPT.winners) as number | undefined;
+        const list = parseWordList(rawList);
 
-        const embed = new Discord.EmbedBuilder()
-          .setColor("Random")
-          .setTitle(title)
-          .setDescription(enumerateArray(shuffledList, winners))
-          .setFields([
-            {
-              name: "Lista original",
-              value: list.join(", "),
-              inline: true,
-            },
-          ])
-          .setFooter({
-            text: `Requested by ${interaction.user.tag}`,
-            iconURL: interaction.user.displayAvatarURL(),
+        if (list.length < MIN_ITEMS) {
+          return interaction.reply({
+            content: `Necesito al menos ${MIN_ITEMS} elementos. Separá la lista con espacios, comas o punto y coma.`,
+            flags: MessageFlags.Ephemeral,
           });
-
-        interaction.reply({ embeds: [embed] });
-      } else if (subCommand.name === OPTIONS.numbers) {
-        let quantity = subCommand.args?.[0].value as number;
-        if (quantity > 20) quantity = 20;
-        if (quantity < 1) quantity = 1;
-        const list = [];
-        for (let i = 1; i <= quantity; i++) {
-          list.push(i);
         }
-        // const shuffledList = list.sort(() => Math.random() - 0.5);
-        const shuffledList = shuffle(list);
-
-        const embed = new Discord.EmbedBuilder()
-          .setColor("Random")
-          .setTitle("Shuffled List")
-          .setDescription(shuffledList.join(", "))
-          .setFooter({
-            text: `Requested by ${interaction.user.tag}`,
-            iconURL: interaction.user.displayAvatarURL(),
+        if (winners !== undefined && winners < 1) {
+          return interaction.reply({
+            content: "El número de ganadores debe ser al menos 1.",
+            flags: MessageFlags.Ephemeral,
           });
+        }
 
-        interaction.reply({ embeds: [embed] });
+        // Winners path → dramatic reveal with animation
+        if (winners !== undefined) {
+          const cap = Math.min(winners, list.length);
+          return animateWinnersReveal(interaction, list, cap, isPrivate);
+        }
+
+        // No winners → instant shuffle
+        return interaction.reply({
+          embeds: [buildShuffleEmbed(list)],
+          flags,
+        });
+      }
+
+      if (sub.name === SUB.numbers) {
+        const rawQuantity = findArg(OPT.quantity) as number | undefined;
+        if (rawQuantity === undefined) {
+          return interaction.reply({
+            content: "Tenés que pasar la cantidad.",
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        if (rawQuantity < MIN_QUANTITY) {
+          return interaction.reply({
+            content: `La cantidad debe ser al menos ${MIN_QUANTITY}.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+
+        const quantity = Math.min(rawQuantity, MAX_QUANTITY);
+        return interaction.reply({
+          embeds: [buildNumbersEmbed(quantity)],
+          flags,
+        });
       }
     } catch (error) {
       errorHandler(interaction, error);
     }
   },
 };
-
-const enumerateArray = (array: (string | number)[], winners: number) => {
-  const slicedArray = array.slice(0, winners);
-  let list = "";
-  for (let i = 0; i < slicedArray.length; i++) {
-    list += `${i + 1}. ${slicedArray[i]}\n`;
-  }
-  list = list.slice(0, -1);
-  return list;
-};
-
-function shuffle<T>(array: T[]): T[] {
-  const result = [...array]; // copiar para no mutar el original
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1)); // índice aleatorio 0..i
-    [result[i], result[j]] = [result[j], result[i]]; // swap
-  }
-  return result;
-}
 
 export default pull;

--- a/src/slashCommands/fun/shuffle.ts
+++ b/src/slashCommands/fun/shuffle.ts
@@ -135,7 +135,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },
@@ -154,7 +154,7 @@ const pull: ISlashCommand = {
         },
         {
           name: OPT.private,
-          description: "Mostrar la respuesta solo a vos (default: público)",
+          description: "Mostrar la respuesta solo a ti (default: público)",
           type: ApplicationCommandOptionType.Boolean,
           required: false,
         },

--- a/src/slashCommands/fun/team.test.ts
+++ b/src/slashCommands/fun/team.test.ts
@@ -1,0 +1,104 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import team from "./team";
+
+describe("/team", () => {
+  it("splits a list into N balanced teams (round-robin distribution)", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana bob carla diego eve frank"),
+      arg("teams", 2),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🧑‍🤝‍🧑 Equipos");
+    expect(embed.color).toBe(0xfee75c);
+    expect(embed.fields).toHaveLength(2);
+    // 6 items / 2 teams = 3 each
+    embed.fields.forEach((f: any) => {
+      expect(f.name).toMatch(/^🏳️ Equipo \d+ \(3\)$/);
+    });
+  });
+
+  it("balances unequal divisions (max diff of 1 between team sizes)", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "a b c d e"),
+      arg("teams", 3),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    // 5 items / 3 teams → sizes 2, 2, 1 (or 2, 1, 2 depending on shuffle)
+    const sizes = embed.fields.map((f: any) =>
+      parseInt(f.name.match(/\((\d+)\)/)![1])
+    );
+    expect(sizes.reduce((a: number, b: number) => a + b, 0)).toBe(5);
+    expect(Math.max(...sizes) - Math.min(...sizes)).toBeLessThanOrEqual(1);
+  });
+
+  it("accepts comma-separated lists", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana,bob,carla,diego"),
+      arg("teams", 2),
+    ]);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.fields).toHaveLength(2);
+  });
+
+  it("rejects ephemerally when teams is out of range", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "a b c d"),
+      arg("teams", 99),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("entre 2 y 10");
+  });
+
+  it("rejects ephemerally when the list has fewer items than teams", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana bob"),
+      arg("teams", 5),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("No hay suficientes");
+  });
+
+  it("rejects ephemerally when the list has fewer than 2 items", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "solo"),
+      arg("teams", 2),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("al menos 2");
+  });
+
+  it("ephemeral when private:true", async () => {
+    const interaction = createMockInteraction();
+    await team.run(createMockClient(), interaction, [
+      arg("list", "ana bob carla"),
+      arg("teams", 2),
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+});

--- a/src/slashCommands/fun/team.ts
+++ b/src/slashCommands/fun/team.ts
@@ -1,0 +1,128 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler, shuffle } from "../../shared/utils/helpers";
+
+const MIN_TEAMS = 2;
+const MAX_TEAMS = 10;
+const MIN_LIST_SIZE = 2;
+
+/**
+ * Splits a list into N teams via round-robin: shuffled list distributed one
+ * item at a time. Yields balanced sizes (max diff of 1) regardless of total.
+ */
+const splitIntoTeams = <T>(items: T[], teams: number): T[][] => {
+  const buckets: T[][] = Array.from({ length: teams }, () => []);
+  items.forEach((item, i) => buckets[i % teams].push(item));
+  return buckets;
+};
+
+const parseList = (raw: string): string[] =>
+  raw
+    .split(/[,;\s]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+const pull: ISlashCommand = {
+  name: "team",
+  category: "fun",
+  description: "Divide una lista en N equipos balanceados",
+  ownerOnly: false,
+  options: [
+    {
+      name: "list",
+      description: "Lista separada por espacios, comas o punto y coma",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+    },
+    {
+      name: "teams",
+      description: `Cantidad de equipos (${MIN_TEAMS}–${MAX_TEAMS})`,
+      type: ApplicationCommandOptionType.Integer,
+      required: true,
+    },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/team list:ana bob carla diego eve frank teams:2",
+    "/team list:ana,bob,carla,diego teams:2",
+  ],
+  run: async (
+    _: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const rawList = (args.find((a) => a.name === "list")?.value as string) ?? "";
+      const teams = args.find((a) => a.name === "teams")?.value as number;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      if (teams < MIN_TEAMS || teams > MAX_TEAMS) {
+        return interaction.reply({
+          content: `La cantidad de equipos debe estar entre ${MIN_TEAMS} y ${MAX_TEAMS}.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      const list = parseList(rawList);
+      if (list.length < MIN_LIST_SIZE) {
+        return interaction.reply({
+          content: `Necesito al menos ${MIN_LIST_SIZE} elementos. Separá la lista con espacios, comas o punto y coma.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+      if (list.length < teams) {
+        return interaction.reply({
+          content: `No hay suficientes elementos (${list.length}) para armar ${teams} equipos.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      const shuffled = shuffle(list);
+      const buckets = splitIntoTeams(shuffled, teams);
+
+      const fields = buckets.map((bucket, i) => ({
+        name: `🏳️ Equipo ${i + 1} (${bucket.length})`,
+        value: bucket.map((m, j) => `**${j + 1}.** ${m}`).join("\n"),
+        inline: true,
+      }));
+
+      const embed = new EmbedBuilder()
+        .setTitle("🧑‍🤝‍🧑 Equipos")
+        .setDescription(
+          `**${list.length}** ${list.length === 1 ? "persona" : "personas"} divididas en **${teams}** equipos.`
+        )
+        .setColor(colorForCategory("fun"))
+        .addFields(fields)
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/index.ts
+++ b/src/slashCommands/index.ts
@@ -1,0 +1,59 @@
+// Manifest estático de slash commands.
+//
+// Este array es la única fuente de verdad para qué slash commands carga el
+// bot. Si agregás un comando nuevo:
+//   1. Crealo en `src/slashCommands/<categoria>/<nombre>.ts` con `export default`
+//   2. Importalo arriba y agregalo al array en su sección de categoría
+//
+// No usamos `readdirSync` + `import()` dinámico porque los watchers
+// (tsx watch, node --watch, esbuild, etc.) no pueden inferir paths con
+// strings interpolados, y eso rompe el reload en dev.
+
+import { ISlashCommand } from "../shared/types";
+
+import ahorcado from "./fun/ahorcado";
+import flip from "./fun/flip";
+import imc from "./fun/imc";
+import love from "./fun/love";
+import poke from "./fun/poke";
+import roll from "./fun/roll";
+import ruleta from "./fun/ruleta";
+import shuffle from "./fun/shuffle";
+
+import channelId from "./info/channel-id";
+import gmi2 from "./info/gmi2";
+import help from "./info/help";
+import ping from "./info/ping";
+
+import clear from "./mod/clear";
+import cums from "./mod/cums";
+import nextcum from "./mod/nextcum";
+import register from "./mod/register";
+import say from "./mod/say";
+import who from "./mod/who";
+
+const slashCommands: ISlashCommand[] = [
+  // fun
+  ahorcado,
+  flip,
+  imc,
+  love,
+  poke,
+  roll,
+  ruleta,
+  shuffle,
+  // info
+  channelId,
+  gmi2,
+  help,
+  ping,
+  // mod
+  clear,
+  cums,
+  nextcum,
+  register,
+  say,
+  who,
+];
+
+export default slashCommands;

--- a/src/slashCommands/index.ts
+++ b/src/slashCommands/index.ts
@@ -19,13 +19,19 @@ import poke from "./fun/poke";
 import roll from "./fun/roll";
 import ruleta from "./fun/ruleta";
 import shuffle from "./fun/shuffle";
+import team from "./fun/team";
 
+import about from "./info/about";
+import changelog from "./info/changelog";
 import channelId from "./info/channel-id";
+import feedback from "./info/feedback";
 import gmi2 from "./info/gmi2";
 import help from "./info/help";
 import ping from "./info/ping";
+import uptime from "./info/uptime";
 
 import clear from "./mod/clear";
+import cum from "./mod/cum";
 import cums from "./mod/cums";
 import nextcum from "./mod/nextcum";
 import register from "./mod/register";
@@ -42,13 +48,19 @@ const slashCommands: ISlashCommand[] = [
   roll,
   ruleta,
   shuffle,
+  team,
   // info
+  about,
+  changelog,
   channelId,
+  feedback,
   gmi2,
   help,
   ping,
+  uptime,
   // mod
   clear,
+  cum,
   cums,
   nextcum,
   register,

--- a/src/slashCommands/info/about.test.ts
+++ b/src/slashCommands/info/about.test.ts
@@ -1,0 +1,37 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import about from "./about";
+
+describe("/about", () => {
+  it("renders an info-color embed with version, stack, and repo link", async () => {
+    const interaction = createMockInteraction();
+    await about.run(createMockClient(), interaction, []);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toMatch(/Xiza Bot/);
+    expect(embed.color).toBe(0x5865f2); // info blurple
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+
+    const fieldNames = embed.fields.map((f: any) => f.name);
+    expect(fieldNames).toContain("📦 Versión");
+    expect(fieldNames).toContain("⚙️ Stack");
+    expect(fieldNames).toContain("🔗 Código");
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    const i1 = createMockInteraction();
+    await about.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await about.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
+  });
+});

--- a/src/slashCommands/info/about.ts
+++ b/src/slashCommands/info/about.ts
@@ -1,0 +1,68 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const REPO_URL = "https://github.com/Xiza73/BotitoV2";
+
+const pull: ISlashCommand = {
+  name: "about",
+  category: "info",
+  description: "Información del bot",
+  ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/about", "/about private:true"],
+  run: async (
+    client: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      const embed = new EmbedBuilder()
+        .setTitle(`🤖 ${BOT_BRAND_NAME}`)
+        .setThumbnail(client.user?.avatarURL() ?? null)
+        .setDescription(
+          "Bot de Discord para el server de Gmi2. Cumpleaños, juegos, mod tools y un par de tonterías más."
+        )
+        .addFields(
+          { name: "📦 Versión", value: `\`${BOT_VERSION}\``, inline: true },
+          { name: "⚙️ Stack", value: "Node 22 · TS 5 · discord.js 14", inline: true },
+          { name: "🔗 Código", value: `[GitHub](${REPO_URL})`, inline: true }
+        )
+        .setColor(colorForCategory("info"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/info/changelog.test.ts
+++ b/src/slashCommands/info/changelog.test.ts
@@ -1,0 +1,82 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { CHANGELOG } from "../../shared/constants/changelog";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import changelog from "./changelog";
+
+describe("/changelog", () => {
+  it("by default, renders an embed listing all versions newest-first", async () => {
+    const interaction = createMockInteraction();
+    await changelog.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("📜 Changelog");
+    expect(embed.color).toBe(0x5865f2);
+    // The current top entry's version appears in the body
+    expect(embed.description).toContain(`v${CHANGELOG[0].version}`);
+  });
+
+  it("with a version arg, renders only that version", async () => {
+    const target = CHANGELOG[1] ?? CHANGELOG[0];
+    const interaction = createMockInteraction();
+    await changelog.run(createMockClient(), interaction, [
+      arg("version", target.version),
+    ]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe(`📜 Changelog — v${target.version}`);
+    expect(embed.description).toContain(target.date);
+  });
+
+  it("rejects ephemerally when the requested version doesn't exist", async () => {
+    const interaction = createMockInteraction();
+    await changelog.run(createMockClient(), interaction, [
+      arg("version", "99.99.99"),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("99.99.99");
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    const i1 = createMockInteraction();
+    await changelog.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await changelog.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  describe("autocomplete", () => {
+    const buildAutocomplete = (focusedValue: string) =>
+      ({
+        options: {
+          getFocused: vi
+            .fn()
+            .mockReturnValue({ name: "version", value: focusedValue }),
+        },
+        respond: vi.fn().mockResolvedValue(undefined),
+      }) as any;
+
+    it("returns matching versions as choices", async () => {
+      const interaction = buildAutocomplete("0.4");
+      await changelog.autocomplete!(createMockClient(), interaction);
+      const choices = interaction.respond.mock.calls[0][0];
+      expect(choices.some((c: any) => c.value.startsWith("0.4"))).toBe(true);
+    });
+
+    it("returns the full list when query is empty", async () => {
+      const interaction = buildAutocomplete("");
+      await changelog.autocomplete!(createMockClient(), interaction);
+      const choices = interaction.respond.mock.calls[0][0];
+      expect(choices.length).toBe(CHANGELOG.length);
+    });
+  });
+});

--- a/src/slashCommands/info/changelog.ts
+++ b/src/slashCommands/info/changelog.ts
@@ -1,0 +1,126 @@
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { CHANGELOG, ChangelogEntry } from "../../shared/constants/changelog";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+// Discord embed description maxes out at 4096; we leave a margin for the
+// field-style version headers we render inline.
+const MAX_DESCRIPTION = 3800;
+
+const buildAllVersionsEmbed = () => {
+  const lines: string[] = [];
+  for (const entry of CHANGELOG) {
+    const header = `### \`v${entry.version}\` — ${entry.date}`;
+    const body = entry.highlights.map((h) => `• ${h}`).join("\n");
+    const block = `${header}\n${body}\n`;
+
+    if (lines.join("\n").length + block.length > MAX_DESCRIPTION) {
+      lines.push("\n_(versiones más viejas truncadas)_");
+      break;
+    }
+    lines.push(block);
+  }
+
+  return new EmbedBuilder()
+    .setTitle("📜 Changelog")
+    .setDescription(lines.join("\n").trim() || "_(sin entradas)_")
+    .setColor(colorForCategory("info"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
+
+const buildSingleVersionEmbed = (entry: ChangelogEntry) =>
+  new EmbedBuilder()
+    .setTitle(`📜 Changelog — v${entry.version}`)
+    .setDescription(`**${entry.date}**\n\n${entry.highlights.map((h) => `• ${h}`).join("\n")}`)
+    .setColor(colorForCategory("info"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const pull: ISlashCommand = {
+  name: "changelog",
+  category: "info",
+  description: "Lista los cambios y novedades del bot",
+  ownerOnly: false,
+  options: [
+    {
+      name: "version",
+      description: "Versión específica a mostrar (default: todas)",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: true,
+    },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/changelog", "/changelog version:0.4.0"],
+  autocomplete: async (
+    _: ClientDiscord,
+    interaction: AutocompleteInteraction
+  ) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== "version") {
+      await interaction.respond([]);
+      return;
+    }
+    const query = String(focused.value ?? "").toLowerCase();
+    const matches = CHANGELOG.filter((e) => e.version.includes(query))
+      .slice(0, 25)
+      .map((e) => ({ name: `v${e.version} (${e.date})`, value: e.version }));
+    await interaction.respond(matches);
+  },
+  run: async (
+    _: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const versionArg = args.find((a) => a.name === "version")?.value as
+        | string
+        | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
+
+      if (versionArg) {
+        const entry = CHANGELOG.find((e) => e.version === versionArg);
+        if (!entry) {
+          return interaction.reply({
+            content: `No encontré la versión \`${versionArg}\`.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        return interaction.reply({
+          embeds: [buildSingleVersionEmbed(entry)],
+          flags,
+        });
+      }
+
+      return interaction.reply({
+        embeds: [buildAllVersionsEmbed()],
+        flags,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/info/channel-id.test.ts
+++ b/src/slashCommands/info/channel-id.test.ts
@@ -1,27 +1,143 @@
-import { describe, expect, it } from "vitest";
+import { ChannelType, MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import channelId from "./channel-id";
 
 describe("/channel-id", () => {
-  it("returns the current channel id when no option is provided", async () => {
+  it("uses the current channel id when no option is provided", async () => {
+    const client = createMockClient();
     const interaction = createMockInteraction({ channelId: "current-ch" });
-    await channelId.run(createMockClient(), interaction, []);
 
+    await channelId.run(client, interaction, []);
+
+    expect(client.channels.fetch).toHaveBeenCalledWith("current-ch");
     expect(interaction.reply).toHaveBeenCalledOnce();
-    const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.content).toContain("<#current-ch>");
-    expect(payload.content).toContain("current-ch");
   });
 
-  it("returns the provided channel id when the option is set", async () => {
+  it("fetches the provided channel id when the option is set", async () => {
+    const client = createMockClient();
     const interaction = createMockInteraction();
-    await channelId.run(createMockClient(), interaction, [
-      arg("channel", "specific-ch"),
-    ]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    await channelId.run(client, interaction, [arg("channel", "specific-ch")]);
+
+    expect(client.channels.fetch).toHaveBeenCalledWith("specific-ch");
+  });
+
+  it("is ephemeral by default and public when public:true is passed", async () => {
+    const interaction1 = createMockInteraction();
+    await channelId.run(createMockClient(), interaction1, []);
+    const ephemeralPayload = interaction1.reply.mock.calls[0][0];
+    expect(ephemeralPayload.flags).toBe(MessageFlags.Ephemeral);
+
+    const interaction2 = createMockInteraction();
+    await channelId.run(createMockClient(), interaction2, [arg("public", true)]);
+    const publicPayload = interaction2.reply.mock.calls[0][0];
+    expect(publicPayload.flags).toBeUndefined();
+  });
+
+  it("includes the core metadata fields in the embed", async () => {
+    const interaction = createMockInteraction({ channelId: "ch-42" });
+    await channelId.run(createMockClient(), interaction, []);
+
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.content).toContain("<#specific-ch>");
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+
+    expect(fieldNames).toContain("📁 Canal");
+    expect(fieldNames).toContain("🆔 ID");
+    expect(fieldNames).toContain("🏷 Tipo");
+  });
+
+  it("wraps the id in backticks for tap-to-copy", async () => {
+    const interaction = createMockInteraction({ channelId: "ch-99" });
+    await channelId.run(createMockClient(), interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const idField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "🆔 ID"
+    );
+    expect(idField.value).toBe("`ch-99`");
+  });
+
+  it("includes the parent category field when the channel has one", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockResolvedValueOnce({
+      id: "ch-with-parent",
+      name: "general",
+      type: ChannelType.GuildText,
+      guild: { id: "g", name: "G" },
+      parent: { name: "Charla" },
+      nsfw: false,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await channelId.run(client, interaction, [arg("channel", "ch-with-parent")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+    expect(fieldNames).toContain("📂 Categoría");
+    const parentField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "📂 Categoría"
+    );
+    expect(parentField.value).toBe("Charla");
+  });
+
+  it("only adds the NSFW field when the channel is flagged NSFW", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockResolvedValueOnce({
+      id: "spicy",
+      name: "spicy",
+      type: ChannelType.GuildText,
+      guild: { id: "g", name: "G" },
+      parent: null,
+      nsfw: true,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await channelId.run(client, interaction, [arg("channel", "spicy")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+    expect(fieldNames).toContain("🔞 NSFW");
+  });
+
+  it("formats common channel types with friendly labels", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockResolvedValueOnce({
+      id: "v",
+      type: ChannelType.GuildVoice,
+      guild: { id: "g" },
+      parent: null,
+      nsfw: false,
+    } as any);
+
+    const interaction = createMockInteraction();
+    await channelId.run(client, interaction, [arg("channel", "v")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const typeField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "🏷 Tipo"
+    );
+    expect(typeField.value).toContain("Voz");
+  });
+
+  it("returns an ephemeral notice when the channel can't be fetched and there's no fallback", async () => {
+    const client = createMockClient();
+    vi.mocked(client.channels.fetch).mockRejectedValueOnce(new Error("404"));
+
+    const interaction = createMockInteraction({
+      channelId: "ghost",
+      channel: null,
+    });
+
+    await channelId.run(client, interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.content).toContain("ghost");
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/info/channel-id.ts
+++ b/src/slashCommands/info/channel-id.ts
@@ -1,13 +1,85 @@
-import { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  Channel,
+  ChannelType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
+
+const TYPE_LABELS: Partial<Record<ChannelType, string>> = {
+  [ChannelType.GuildText]: "💬 Texto",
+  [ChannelType.GuildVoice]: "🔊 Voz",
+  [ChannelType.GuildCategory]: "📂 Categoría",
+  [ChannelType.GuildAnnouncement]: "📢 Anuncios",
+  [ChannelType.AnnouncementThread]: "🧵 Hilo (anuncios)",
+  [ChannelType.PublicThread]: "🧵 Hilo público",
+  [ChannelType.PrivateThread]: "🔒 Hilo privado",
+  [ChannelType.GuildStageVoice]: "🎤 Stage",
+  [ChannelType.GuildForum]: "💭 Foro",
+  [ChannelType.GuildMedia]: "🖼️ Media",
+  [ChannelType.DM]: "💌 DM",
+  [ChannelType.GroupDM]: "👥 Group DM",
+};
+
+const formatChannelType = (type: ChannelType): string =>
+  TYPE_LABELS[type] ?? `Tipo ${type}`;
+
+const buildEmbed = (client: ClientDiscord, channel: Channel) => {
+  const fields: { name: string; value: string; inline?: boolean }[] = [];
+
+  // For guild channels we can mention them; for DMs we just show "—"
+  const isGuildChannel = "guild" in channel;
+  const channelLabel = isGuildChannel
+    ? `<#${channel.id}>`
+    : (channel as any).name ?? "DM";
+
+  fields.push({ name: "📁 Canal", value: channelLabel, inline: true });
+  fields.push({ name: "🆔 ID", value: `\`${channel.id}\``, inline: true });
+  fields.push({
+    name: "🏷 Tipo",
+    value: formatChannelType(channel.type),
+    inline: true,
+  });
+
+  if (isGuildChannel) {
+    const parent = (channel as any).parent;
+    if (parent?.name) {
+      fields.push({
+        name: "📂 Categoría",
+        value: parent.name,
+        inline: true,
+      });
+    }
+
+    if ((channel as any).nsfw === true) {
+      fields.push({ name: "🔞 NSFW", value: "Sí", inline: true });
+    }
+  }
+
+  return new EmbedBuilder()
+    .setAuthor({
+      name: BOT_BRAND_NAME,
+      iconURL: client.user?.avatarURL() ?? undefined,
+    })
+    .setTitle("Información del canal")
+    .setColor(colorForCategory("info"))
+    .addFields(fields)
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+};
 
 const pull: ISlashCommand = {
   name: "channel-id",
   category: "info",
-  description: "Muestra el id del canal",
+  description: "Muestra la información y el ID de un canal",
   ownerOnly: false,
   options: [
     {
@@ -16,17 +88,52 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Channel,
       required: false,
     },
+    {
+      name: "public",
+      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/channel-id",
+    "/channel-id channel:#general",
+    "/channel-id public:true",
   ],
   run: async (
-    _: ClientDiscord,
+    client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const channelId = (args[0]?.value as string) ?? interaction.channelId;
+      const channelArg = args.find((a) => a.name === "channel")?.value as
+        | string
+        | undefined;
+      const publicArg =
+        (args.find((a) => a.name === "public")?.value as boolean | undefined) ??
+        false;
+
+      const channelId = channelArg ?? interaction.channelId;
+
+      let channel: Channel | null = null;
+      try {
+        channel = await client.channels.fetch(channelId);
+      } catch {
+        // Fallback: if fetch fails (eg. uncached DM), use interaction.channel
+        channel = interaction.channel ?? null;
+      }
+
+      if (!channel) {
+        return interaction.reply({
+          content: `No encontré el canal con id \`${channelId}\`.`,
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
       return interaction.reply({
-        content: `El canal es: <#${channelId}> con id ${channelId}`,
+        embeds: [buildEmbed(client, channel)],
+        flags: publicArg ? undefined : MessageFlags.Ephemeral,
+        allowedMentions: { repliedUser: false },
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/info/channel-id.ts
+++ b/src/slashCommands/info/channel-id.ts
@@ -33,7 +33,7 @@ const TYPE_LABELS: Partial<Record<ChannelType, string>> = {
 const formatChannelType = (type: ChannelType): string =>
   TYPE_LABELS[type] ?? `Tipo ${type}`;
 
-const buildEmbed = (client: ClientDiscord, channel: Channel) => {
+const buildEmbed = (channel: Channel) => {
   const fields: { name: string; value: string; inline?: boolean }[] = [];
 
   // For guild channels we can mention them; for DMs we just show "—"
@@ -66,10 +66,6 @@ const buildEmbed = (client: ClientDiscord, channel: Channel) => {
   }
 
   return new EmbedBuilder()
-    .setAuthor({
-      name: BOT_BRAND_NAME,
-      iconURL: client.user?.avatarURL() ?? undefined,
-    })
     .setTitle("Información del canal")
     .setColor(colorForCategory("info"))
     .addFields(fields)
@@ -131,7 +127,7 @@ const pull: ISlashCommand = {
       }
 
       return interaction.reply({
-        embeds: [buildEmbed(client, channel)],
+        embeds: [buildEmbed(channel)],
         flags: publicArg ? undefined : MessageFlags.Ephemeral,
         allowedMentions: { repliedUser: false },
       });

--- a/src/slashCommands/info/channel-id.ts
+++ b/src/slashCommands/info/channel-id.ts
@@ -86,7 +86,7 @@ const pull: ISlashCommand = {
     },
     {
       name: "public",
-      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      description: "Mostrar la respuesta a todo el canal (default: solo a ti)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/info/feedback.test.ts
+++ b/src/slashCommands/info/feedback.test.ts
@@ -1,0 +1,106 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import feedback from "./feedback";
+
+const setupClientWithOwner = () => {
+  const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
+  const ownerCreateDM = vi.fn().mockResolvedValue({ send: dmSend });
+  const client = createMockClient({
+    config: { ownerId: "owner-1" },
+    users: {
+      fetch: vi
+        .fn()
+        .mockResolvedValue({ id: "owner-1", createDM: ownerCreateDM }),
+    },
+  });
+  return { client, dmSend, ownerCreateDM };
+};
+
+describe("/feedback", () => {
+  it("DMs the owner with a branded embed and confirms ephemerally", async () => {
+    const { client, dmSend } = setupClientWithOwner();
+    const interaction = createMockInteraction({
+      user: {
+        id: "alice",
+        username: "alice",
+        tag: "alice#0001",
+        displayAvatarURL: () => "https://example.com/a.png",
+      },
+    });
+
+    await feedback.run(client, interaction, [
+      arg("message", "el bot está bárbaro"),
+    ]);
+
+    expect(dmSend).toHaveBeenCalledOnce();
+    const dmPayload = dmSend.mock.calls[0][0];
+    const embed = dmPayload.embeds[0].data;
+    expect(embed.title).toBe("📨 Feedback recibido");
+    expect(embed.description).toBe("el bot está bárbaro");
+    expect(embed.color).toBe(0x5865f2);
+
+    const fromField = embed.fields.find((f: any) => f.name === "👤 De");
+    expect(fromField.value).toContain("<@alice>");
+
+    const replyPayload = interaction.reply.mock.calls[0][0];
+    expect(replyPayload.flags).toBe(MessageFlags.Ephemeral);
+    expect(replyPayload.content).toContain("gracias");
+  });
+
+  it("hides the author when anonymous:true is passed", async () => {
+    const { client, dmSend } = setupClientWithOwner();
+    const interaction = createMockInteraction({
+      user: {
+        id: "alice",
+        username: "alice",
+        tag: "alice#0001",
+        displayAvatarURL: () => "https://example.com/a.png",
+      },
+    });
+
+    await feedback.run(client, interaction, [
+      arg("message", "queja anónima"),
+      arg("anonymous", true),
+    ]);
+
+    const embed = dmSend.mock.calls[0][0].embeds[0].data;
+    const fromField = embed.fields.find((f: any) => f.name === "👤 De");
+    expect(fromField.value).toContain("anónimo");
+    expect(fromField.value).not.toContain("alice");
+  });
+
+  it("rejects ephemerally on empty message", async () => {
+    const { client } = setupClientWithOwner();
+    const interaction = createMockInteraction();
+    await feedback.run(client, interaction, [arg("message", "   ")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("vacío");
+  });
+
+  it("returns a friendly error if the owner DM can't be delivered", async () => {
+    const ownerCreateDM = vi.fn().mockRejectedValue(new Error("blocked"));
+    const client = createMockClient({
+      config: { ownerId: "owner-1" },
+      users: {
+        fetch: vi
+          .fn()
+          .mockResolvedValue({ id: "owner-1", createDM: ownerCreateDM }),
+      },
+    });
+    const interaction = createMockInteraction();
+
+    await feedback.run(client, interaction, [arg("message", "hola")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("No pude entregar");
+  });
+});

--- a/src/slashCommands/info/feedback.ts
+++ b/src/slashCommands/info/feedback.ts
@@ -1,0 +1,100 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const MAX_FEEDBACK = 1500;
+
+const pull: ISlashCommand = {
+  name: "feedback",
+  category: "info",
+  description: "Envía feedback o sugerencias al owner del bot",
+  ownerOnly: false,
+  options: [
+    {
+      name: "message",
+      description: "Tu feedback o sugerencia",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+    },
+    {
+      name: "anonymous",
+      description: "Enviar sin tu nombre (default: false)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/feedback message:falta el comando X",
+    "/feedback message:gran trabajo anonymous:true",
+  ],
+  run: async (
+    client: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const text = args.find((a) => a.name === "message")?.value as string;
+      const anonymous =
+        (args.find((a) => a.name === "anonymous")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      if (!text || text.trim().length === 0) {
+        return interaction.reply({
+          content: "El mensaje no puede estar vacío.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      const trimmed =
+        text.length > MAX_FEEDBACK ? text.slice(0, MAX_FEEDBACK) + "…" : text;
+
+      const embed = new EmbedBuilder()
+        .setTitle("📨 Feedback recibido")
+        .setDescription(trimmed)
+        .setColor(colorForCategory("info"))
+        .addFields({
+          name: "👤 De",
+          value: anonymous
+            ? "_(anónimo)_"
+            : `<@${interaction.user.id}> (\`${interaction.user.tag ?? interaction.user.username}\`)`,
+          inline: false,
+        })
+        .setTimestamp(new Date())
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      try {
+        const owner = await client.users.fetch(client.config.ownerId);
+        const dm = await owner.createDM();
+        await dm.send({ embeds: [embed], allowedMentions: { parse: [] } });
+      } catch {
+        return interaction.reply({
+          content:
+            "No pude entregar tu feedback al owner. Intenta de nuevo en un rato.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+
+      return interaction.reply({
+        content: "✅ Listo, gracias por tu feedback.",
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/info/gmi2.test.ts
+++ b/src/slashCommands/info/gmi2.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
 import { createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -20,6 +21,6 @@ describe("/gmi2", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/info/gmi2.ts
+++ b/src/slashCommands/info/gmi2.ts
@@ -1,4 +1,8 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
@@ -17,7 +21,7 @@ const pull: ISlashCommand = {
       if (!interaction.guild) {
         return interaction.reply({
           content: "Este comando solo funciona en un servidor.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/info/help.test.ts
+++ b/src/slashCommands/info/help.test.ts
@@ -1,58 +1,221 @@
-import { Collection } from "discord.js";
-import { describe, expect, it } from "vitest";
+import { Collection, MessageFlags } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import help from "./help";
 
-const stubCommand = (name: string, category: string | null) => ({
+const stubCommand = (
+  name: string,
+  category: string | null,
+  overrides: Record<string, any> = {}
+) => ({
   name,
   category,
   description: `Test ${name}`,
   ownerOnly: false,
   run: () => Promise.resolve(),
+  ...overrides,
 });
 
-describe("/help", () => {
-  it("lists all categories when no command is given", async () => {
-    const slashCommands = new Collection<string, any>();
-    slashCommands.set("ping", stubCommand("ping", "info"));
-    slashCommands.set("flip", stubCommand("flip", "fun"));
-    slashCommands.set("clear", stubCommand("clear", "mod"));
+const buildClient = (commands: Record<string, any>, ownerId = "owner-1") => {
+  const slashCommands = new Collection<string, any>();
+  for (const [name, cmd] of Object.entries(commands)) slashCommands.set(name, cmd);
+  return createMockClient({
+    slashCommands,
+    config: { ownerId, gmi2Channel: "gmi2" },
+  });
+};
+
+describe("/help — listing", () => {
+  it("lists all categories with their commands by default", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      flip: stubCommand("flip", "fun"),
+      clear: stubCommand("clear", "mod"),
+    });
 
     const interaction = createMockInteraction();
-    await help.run(createMockClient({ slashCommands }), interaction, []);
+    await help.run(client, interaction, []);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral); // default
   });
 
-  it("returns the detail embed when given a known command name", async () => {
-    const slashCommands = new Collection<string, any>();
-    slashCommands.set("ping", stubCommand("ping", "info"));
+  it("becomes public when public:true is passed", async () => {
+    const client = buildClient({ ping: stubCommand("ping", "info") });
 
     const interaction = createMockInteraction();
-    await help.run(createMockClient({ slashCommands }), interaction, [
-      arg("command", "ping"),
-    ]);
+    await help.run(client, interaction, [arg("public", true)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.embeds).toHaveLength(1);
+    expect(payload.flags).toBeUndefined();
   });
 
-  it("replies ephemerally when given an unknown command name", async () => {
-    const slashCommands = new Collection<string, any>();
-    slashCommands.set("ping", stubCommand("ping", "info"));
+  it("filters by category when the option is passed", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      flip: stubCommand("flip", "fun"),
+    });
 
     const interaction = createMockInteraction();
-    await help.run(createMockClient({ slashCommands }), interaction, [
-      arg("command", "nope"),
-    ]);
+    await help.run(client, interaction, [arg("category", "fun")]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
-    expect(payload.content).toContain("nope");
+    expect(payload.embeds[0].data.title).toContain("Fun");
+  });
+
+  it("hides ownerOnly commands from non-owners", async () => {
+    const client = buildClient(
+      {
+        ping: stubCommand("ping", "info"),
+        secret: stubCommand("secret", "info", { ownerOnly: true }),
+      },
+      "owner-1"
+    );
+
+    const interaction = createMockInteraction({ user: { id: "non-owner" } });
+    await help.run(client, interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldsValues = payload.embeds[0].data.fields.map((f: any) => f.value).join(" ");
+    expect(fieldsValues).toContain("/ping");
+    expect(fieldsValues).not.toContain("/secret");
+  });
+
+  it("shows ownerOnly commands to the owner", async () => {
+    const client = buildClient(
+      {
+        ping: stubCommand("ping", "info"),
+        secret: stubCommand("secret", "info", { ownerOnly: true }),
+      },
+      "owner-1"
+    );
+
+    const interaction = createMockInteraction({ user: { id: "owner-1" } });
+    await help.run(client, interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fieldsValues = payload.embeds[0].data.fields.map((f: any) => f.value).join(" ");
+    expect(fieldsValues).toContain("/secret");
+  });
+});
+
+describe("/help — detail view", () => {
+  it("shows the command's options and examples when present", async () => {
+    const command = stubCommand("ahorcado", "fun", {
+      options: [
+        {
+          name: "player2",
+          description: "Segundo jugador",
+          required: true,
+        },
+        {
+          name: "bot_picks_word",
+          description: "Si true, el bot elige",
+          required: false,
+        },
+      ],
+      examples: ["/ahorcado player2:@bob", "/ahorcado player2:@bob bot_picks_word:true"],
+    });
+    const client = buildClient({ ahorcado: command });
+
+    const interaction = createMockInteraction();
+    await help.run(client, interaction, [arg("command", "ahorcado")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    const fields = payload.embeds[0].data.fields;
+    expect(fields.find((f: any) => f.name === "Opciones").value).toContain("player2");
+    expect(fields.find((f: any) => f.name === "Ejemplos").value).toContain("/ahorcado");
+  });
+
+  it("returns an ephemeral notice for unknown commands", async () => {
+    const client = buildClient({ ping: stubCommand("ping", "info") });
+
+    const interaction = createMockInteraction();
+    await help.run(client, interaction, [arg("command", "ghost")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("ghost");
+  });
+
+  it("hides ownerOnly commands from non-owners even in detail view", async () => {
+    const client = buildClient(
+      { secret: stubCommand("secret", "info", { ownerOnly: true }) },
+      "owner-1"
+    );
+
+    const interaction = createMockInteraction({ user: { id: "non-owner" } });
+    await help.run(client, interaction, [arg("command", "secret")]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("secret");
+  });
+});
+
+describe("/help — autocomplete", () => {
+  const buildAutocompleteInteraction = (
+    focusedName: string,
+    focusedValue: string,
+    userId = "user-1"
+  ) => ({
+    user: { id: userId },
+    options: {
+      getFocused: vi.fn().mockReturnValue({ name: focusedName, value: focusedValue }),
+    },
+    respond: vi.fn().mockResolvedValue(undefined),
+  }) as any;
+
+  it("suggests command names that contain the query (substring match)", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      poke: stubCommand("poke", "fun"),
+      flip: stubCommand("flip", "fun"),
+    });
+
+    const interaction = buildAutocompleteInteraction("command", "po");
+    await help.autocomplete!(client, interaction);
+
+    expect(interaction.respond).toHaveBeenCalledOnce();
+    const values = interaction.respond.mock.calls[0][0].map((c: any) => c.value);
+    expect(values).toEqual(["poke"]);
+  });
+
+  it("hides ownerOnly commands from non-owner autocomplete", async () => {
+    const client = buildClient(
+      {
+        ping: stubCommand("ping", "info"),
+        secret: stubCommand("secret", "info", { ownerOnly: true }),
+      },
+      "owner-1"
+    );
+
+    const interaction = buildAutocompleteInteraction("command", "", "non-owner");
+    await help.autocomplete!(client, interaction);
+
+    const values = interaction.respond.mock.calls[0][0].map((c: any) => c.value);
+    expect(values).toContain("ping");
+    expect(values).not.toContain("secret");
+  });
+
+  it("suggests categories for the 'category' option", async () => {
+    const client = buildClient({
+      ping: stubCommand("ping", "info"),
+      flip: stubCommand("flip", "fun"),
+    });
+
+    const interaction = buildAutocompleteInteraction("category", "");
+    await help.autocomplete!(client, interaction);
+
+    const values = interaction.respond.mock.calls[0][0].map((c: any) => c.value);
+    expect(values).toContain("info");
+    expect(values).toContain("fun");
   });
 });

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -77,7 +77,7 @@ const buildListEmbed = (
     .setTitle(filterCategory ? `Comandos de ${capitalize(filterCategory)}` : "Help")
     .setThumbnail(client.user?.avatarURL() ?? null)
     .setDescription(
-      `Hola **<@${userId}>** — elegí un comando del menú o usa \`/help command:<nombre>\` para ver el detalle.\n` +
+      `Hola **<@${userId}>** — elige un comando del menú o usa \`/help command:<nombre>\` para ver el detalle.\n` +
         `**Total:** ${filtered.length} ${filtered.length === 1 ? "comando" : "comandos"}`
     )
     .setColor(filterCategory ? colorForCategory(filterCategory) : colorForCategory("info"))
@@ -136,7 +136,7 @@ const buildSelectRow = (commands: ISlashCommand[]) => {
   return new ActionRowBuilder<StringSelectMenuBuilder>().setComponents(
     new StringSelectMenuBuilder()
       .setCustomId(SELECT_CUSTOM_ID)
-      .setPlaceholder("Elegí un comando para ver el detalle…")
+      .setPlaceholder("Elige un comando para ver el detalle…")
       .addOptions(options)
   );
 };
@@ -239,7 +239,7 @@ const pull: ISlashCommand = {
     },
     {
       name: "public",
-      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      description: "Mostrar la respuesta a todo el canal (default: solo a ti)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -42,11 +42,6 @@ const visibleCommandsFor = (
   return isOwner ? all : all.filter((c) => !c.ownerOnly);
 };
 
-const buildAuthor = (client: ClientDiscord) => ({
-  name: BOT_BRAND_NAME,
-  iconURL: client.user?.avatarURL() ?? undefined,
-});
-
 const buildFooter = (extra?: string) => ({
   text: `${BOT_BRAND_NAME} ${BOT_VERSION}${extra ? ` · ${extra}` : ""}`,
 });
@@ -79,7 +74,6 @@ const buildListEmbed = (
   }));
 
   return new EmbedBuilder()
-    .setAuthor(buildAuthor(client))
     .setTitle(filterCategory ? `Comandos de ${capitalize(filterCategory)}` : "Help")
     .setThumbnail(client.user?.avatarURL() ?? null)
     .setDescription(
@@ -93,7 +87,7 @@ const buildListEmbed = (
     );
 };
 
-const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
+const buildDetailEmbed = (command: ISlashCommand) => {
   const fields: { name: string; value: string; inline?: boolean }[] = [];
 
   fields.push({
@@ -123,7 +117,6 @@ const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
   }
 
   return new EmbedBuilder()
-    .setAuthor(buildAuthor(client))
     .setTitle(`/${command.name}`)
     .setDescription(command.description || "Sin descripción")
     .setColor(colorForCategory(command.category))
@@ -182,7 +175,7 @@ const attachComponentCollector = async (
             return;
           }
           await i.update({
-            embeds: [buildDetailEmbed(client, command)],
+            embeds: [buildDetailEmbed(command)],
             components: [buildBackRow()],
           });
           return;
@@ -318,7 +311,7 @@ const pull: ISlashCommand = {
           });
         }
         return interaction.reply({
-          embeds: [buildDetailEmbed(client, command)],
+          embeds: [buildDetailEmbed(command)],
           flags: publicArg ? undefined : MessageFlags.Ephemeral,
           allowedMentions: { repliedUser: false },
         });

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -1,15 +1,233 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ActionRowBuilder,
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonStyle,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+  StringSelectMenuBuilder,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
-import { Argument, ISlashCommand } from "../../shared/types";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  capitalize,
+  colorForCategory,
+  emojiForCategory,
+} from "../../shared/constants/branding";
+import {
+  Argument,
+  ISlashCommand,
+  SlashCommandsOptions,
+} from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
-const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+const SELECT_CUSTOM_ID = "help-pick-command";
+const BACK_BUTTON_ID = "help-back-to-list";
+const COLLECTOR_TIMEOUT_MS = 120_000;
+
+const formatOption = (opt: SlashCommandsOptions): string => {
+  const flag = opt.required ? "**" : "";
+  const star = opt.required ? "" : " *(opcional)*";
+  return `${flag}\`${opt.name}\`${flag}${star} — ${opt.description}`;
+};
+
+const visibleCommandsFor = (
+  client: ClientDiscord,
+  isOwner: boolean
+): ISlashCommand[] => {
+  const all = [...client.slashCommands.values()];
+  return isOwner ? all : all.filter((c) => !c.ownerOnly);
+};
+
+const buildAuthor = (client: ClientDiscord) => ({
+  name: BOT_BRAND_NAME,
+  iconURL: client.user?.avatarURL() ?? undefined,
+});
+
+const buildFooter = (extra?: string) => ({
+  text: `${BOT_BRAND_NAME} ${BOT_VERSION}${extra ? ` · ${extra}` : ""}`,
+});
+
+const buildListEmbed = (
+  client: ClientDiscord,
+  userId: string,
+  filterCategory: string | null,
+  isOwner: boolean
+) => {
+  const visible = visibleCommandsFor(client, isOwner);
+  const filtered = filterCategory
+    ? visible.filter((c) => c.category === filterCategory)
+    : visible;
+
+  const categories = [
+    ...new Set(
+      filtered.map((c) => c.category).filter((c): c is string => Boolean(c))
+    ),
+  ].sort();
+
+  const fields = categories.map((cat) => ({
+    name: `${emojiForCategory(cat)} ${capitalize(cat)}`,
+    value:
+      filtered
+        .filter((c) => c.category === cat)
+        .map((c) => `**\`/${c.name}\`**`)
+        .join(" · ") || "—",
+    inline: false,
+  }));
+
+  return new EmbedBuilder()
+    .setAuthor(buildAuthor(client))
+    .setTitle(filterCategory ? `Comandos de ${capitalize(filterCategory)}` : "Help")
+    .setThumbnail(client.user?.avatarURL() ?? null)
+    .setDescription(
+      `Hola **<@${userId}>** — elegí un comando del menú o usa \`/help command:<nombre>\` para ver el detalle.\n` +
+        `**Total:** ${filtered.length} ${filtered.length === 1 ? "comando" : "comandos"}`
+    )
+    .setColor(filterCategory ? colorForCategory(filterCategory) : colorForCategory("info"))
+    .addFields(fields)
+    .setFooter(
+      buildFooter(filterCategory ? "/help solo para ver todos" : undefined)
+    );
+};
+
+const buildDetailEmbed = (client: ClientDiscord, command: ISlashCommand) => {
+  const fields: { name: string; value: string; inline?: boolean }[] = [];
+
+  fields.push({
+    name: "Categoría",
+    value: command.category
+      ? `${emojiForCategory(command.category)} ${capitalize(command.category)}`
+      : "—",
+    inline: true,
+  });
+
+  if (command.ownerOnly) {
+    fields.push({ name: "Acceso", value: "🔒 Solo owner", inline: true });
+  }
+
+  if (command.options && command.options.length > 0) {
+    fields.push({
+      name: "Opciones",
+      value: command.options.map(formatOption).join("\n"),
+    });
+  }
+
+  if (command.examples && command.examples.length > 0) {
+    fields.push({
+      name: "Ejemplos",
+      value: command.examples.map((e) => `\`${e}\``).join("\n"),
+    });
+  }
+
+  return new EmbedBuilder()
+    .setAuthor(buildAuthor(client))
+    .setTitle(`/${command.name}`)
+    .setDescription(command.description || "Sin descripción")
+    .setColor(colorForCategory(command.category))
+    .addFields(fields)
+    .setFooter(buildFooter("/help para ver todos los comandos"));
+};
+
+const buildSelectRow = (commands: ISlashCommand[]) => {
+  const options = commands.slice(0, 25).map((c) => ({
+    label: `/${c.name}`,
+    description: c.description.slice(0, 100),
+    value: c.name,
+  }));
+
+  if (options.length === 0) return null;
+
+  return new ActionRowBuilder<StringSelectMenuBuilder>().setComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(SELECT_CUSTOM_ID)
+      .setPlaceholder("Elegí un comando para ver el detalle…")
+      .addOptions(options)
+  );
+};
+
+const buildBackRow = () =>
+  new ActionRowBuilder<ButtonBuilder>().setComponents(
+    new ButtonBuilder()
+      .setCustomId(BACK_BUTTON_ID)
+      .setLabel("← Volver al listado")
+      .setStyle(ButtonStyle.Secondary)
+  );
+
+const attachComponentCollector = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  state: { categoryArg: string | null; isOwner: boolean }
+) => {
+  try {
+    const message = await interaction.fetchReply();
+    const collector = message.createMessageComponentCollector({
+      time: COLLECTOR_TIMEOUT_MS,
+      filter: (i) => i.user.id === interaction.user.id,
+    });
+
+    collector.on("collect", async (i) => {
+      try {
+        if (i.isStringSelectMenu() && i.customId === SELECT_CUSTOM_ID) {
+          const command = client.slashCommands.get(i.values[0]);
+          if (!command || (command.ownerOnly && !state.isOwner)) {
+            await i.update({
+              content: `No existe un slash command llamado "${i.values[0]}".`,
+              embeds: [],
+              components: [],
+            });
+            collector.stop("invalid-selection");
+            return;
+          }
+          await i.update({
+            embeds: [buildDetailEmbed(client, command)],
+            components: [buildBackRow()],
+          });
+          return;
+        }
+
+        if (i.isButton() && i.customId === BACK_BUTTON_ID) {
+          const visible = visibleCommandsFor(client, state.isOwner);
+          const filtered = state.categoryArg
+            ? visible.filter((c) => c.category === state.categoryArg)
+            : visible;
+          const row = buildSelectRow(filtered);
+          await i.update({
+            embeds: [
+              buildListEmbed(
+                client,
+                interaction.user.id,
+                state.categoryArg,
+                state.isOwner
+              ),
+            ],
+            components: row ? [row] : [],
+          });
+        }
+      } catch {
+        // Component update failed (interaction expired, etc.) — keep the collector alive
+        // so other clicks can still try.
+      }
+    });
+
+    collector.on("end", async () => {
+      try {
+        await interaction.editReply({ components: [] });
+      } catch {
+        // best-effort; the message may already be gone
+      }
+    });
+  } catch {
+    // fetchReply failed — nothing to attach a collector to
+  }
+};
 
 const pull: ISlashCommand = {
   name: "help",
   category: "info",
-  description: "Muestra todos los slash commands o detalle de uno específico",
+  description: "Lista los slash commands o muestra el detalle de uno",
   ownerOnly: false,
   options: [
     {
@@ -17,83 +235,124 @@ const pull: ISlashCommand = {
       description: "Slash command a mostrar en detalle",
       type: ApplicationCommandOptionType.String,
       required: false,
+      autocomplete: true,
+    },
+    {
+      name: "category",
+      description: "Filtrar el listado por categoría",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: true,
+    },
+    {
+      name: "public",
+      description: "Mostrar la respuesta a todo el canal (default: solo a vos)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
     },
   ],
+  examples: [
+    "/help",
+    "/help command:ping",
+    "/help category:fun",
+    "/help public:true",
+  ],
+  autocomplete: async (
+    client: ClientDiscord,
+    interaction: AutocompleteInteraction
+  ) => {
+    const focused = interaction.options.getFocused(true);
+    const query = String(focused.value ?? "").toLowerCase();
+    const isOwner = interaction.user.id === client.config.ownerId;
+    const visible = visibleCommandsFor(client, isOwner);
+
+    if (focused.name === "command") {
+      const matches = visible
+        .filter((c) => c.name.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((c) => ({ name: `/${c.name}`, value: c.name }));
+      await interaction.respond(matches);
+      return;
+    }
+
+    if (focused.name === "category") {
+      const cats = [
+        ...new Set(
+          visible.map((c) => c.category).filter((c): c is string => Boolean(c))
+        ),
+      ];
+      const matches = cats
+        .filter((c) => c.toLowerCase().includes(query))
+        .slice(0, 25)
+        .map((c) => ({
+          name: `${emojiForCategory(c)} ${capitalize(c)}`,
+          value: c,
+        }));
+      await interaction.respond(matches);
+    }
+  },
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      const arg = (args[0]?.value as string | undefined)?.toLowerCase();
+      const commandArg = args.find((a) => a.name === "command")?.value as
+        | string
+        | undefined;
+      const categoryArg = args.find((a) => a.name === "category")?.value as
+        | string
+        | undefined;
+      const publicArg =
+        (args.find((a) => a.name === "public")?.value as boolean | undefined) ??
+        false;
+      const isOwner = interaction.user.id === client.config.ownerId;
 
-      if (!arg) {
-        const categories = [
-          ...new Set(
-            client.slashCommands
-              .map((cmd) => cmd.category)
-              .filter((c): c is string => Boolean(c))
+      // Detail view — no select, just the embed.
+      if (commandArg) {
+        const command = client.slashCommands.get(commandArg.toLowerCase());
+        if (!command || (command.ownerOnly && !isOwner)) {
+          return interaction.reply({
+            content: `No existe un slash command llamado "${commandArg}".`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+        return interaction.reply({
+          embeds: [buildDetailEmbed(client, command)],
+          flags: publicArg ? undefined : MessageFlags.Ephemeral,
+          allowedMentions: { repliedUser: false },
+        });
+      }
+
+      // Listing — embed + select menu so the user can drill in without
+      // re-typing /help.
+      const visible = visibleCommandsFor(client, isOwner);
+      const filtered = categoryArg
+        ? visible.filter((c) => c.category === categoryArg)
+        : visible;
+      const row = buildSelectRow(filtered);
+
+      await interaction.reply({
+        embeds: [
+          buildListEmbed(
+            client,
+            interaction.user.id,
+            categoryArg ?? null,
+            isOwner
           ),
-        ].sort();
-
-        const fields = categories.map((cat) => ({
-          name: `▫ ${capitalize(cat)}`,
-          value:
-            client.slashCommands
-              .filter((cmd) => cmd.category === cat)
-              .map((cmd) => `\`/${cmd.name}\``)
-              .join(", ") || "—",
-          inline: true,
-        }));
-
-        const helpEmbed = new Discord.EmbedBuilder()
-          .setTitle(`${client.user?.username} Help`)
-          .setDescription(
-            `Hola **<@${interaction.user.id}>** — usa ` +
-              "`/help command:<nombre>`" +
-              ` para ver el detalle de un slash command.\n` +
-              `**Total slash commands:** ${client.slashCommands.size}`
-          )
-          .setColor("Random")
-          .addFields(fields);
-
-        return interaction.reply({
-          embeds: [helpEmbed],
-          allowedMentions: { repliedUser: false },
-        });
-      }
-
-      const command = client.slashCommands.get(arg);
-      if (!command) {
-        return interaction.reply({
-          content: `No existe un slash command llamado "${args[0].value}".`,
-          allowedMentions: { repliedUser: false },
-          ephemeral: true,
-        });
-      }
-
-      const helpCmdEmbed = new Discord.EmbedBuilder()
-        .setTitle(`${client.user?.username} Help | /${command.name}`)
-        .addFields(
-          {
-            name: "Descripción",
-            value: command.description || "Sin descripción",
-          },
-          {
-            name: "Categoría",
-            value: command.category || "—",
-          },
-          {
-            name: "Owner only",
-            value: command.ownerOnly ? "Sí" : "No",
-          }
-        )
-        .setColor("Random");
-
-      return interaction.reply({
-        embeds: [helpCmdEmbed],
+        ],
+        components: row ? [row] : [],
+        flags: publicArg ? undefined : MessageFlags.Ephemeral,
         allowedMentions: { repliedUser: false },
       });
+
+      if (row) {
+        // Fire-and-forget: collector lives until select/back click or timeout.
+        attachComponentCollector(client, interaction, {
+          categoryArg: categoryArg ?? null,
+          isOwner,
+        });
+      }
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/info/help.ts
+++ b/src/slashCommands/info/help.ts
@@ -49,7 +49,7 @@ const pull: ISlashCommand = {
         const helpEmbed = new Discord.EmbedBuilder()
           .setTitle(`${client.user?.username} Help`)
           .setDescription(
-            `Hola **<@${interaction.user.id}>** — usá ` +
+            `Hola **<@${interaction.user.id}>** — usa ` +
               "`/help command:<nombre>`" +
               ` para ver el detalle de un slash command.\n` +
               `**Total slash commands:** ${client.slashCommands.size}`

--- a/src/slashCommands/info/ping.test.ts
+++ b/src/slashCommands/info/ping.test.ts
@@ -1,25 +1,73 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it } from "vitest";
 
-import { createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import ping from "./ping";
 
 describe("/ping", () => {
-  it("sends 'Pinging...' to the channel and replies with the ping embed", async () => {
+  it("defers publicly by default and replies via editReply with the embed", async () => {
     const interaction = createMockInteraction();
     await ping.run(createMockClient(), interaction, []);
 
-    expect(interaction.channel.send).toHaveBeenCalledWith("🏓 Pinging...");
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    const payload = interaction.reply.mock.calls[0][0];
+    expect(interaction.deferReply).toHaveBeenCalledOnce();
+    const deferPayload = interaction.deferReply.mock.calls[0][0];
+    // Public default → no Ephemeral flag set
+    expect(deferPayload?.flags).toBeUndefined();
+
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.channel.send).not.toHaveBeenCalled();
   });
 
-  it("returns early when the channel is not sendable", async () => {
-    const interaction = createMockInteraction({
-      channel: { isSendable: () => false },
-    });
+  it("defers ephemerally when private:true is passed", async () => {
+    const interaction = createMockInteraction();
+    await ping.run(createMockClient(), interaction, [arg("private", true)]);
+
+    expect(interaction.deferReply).toHaveBeenCalledOnce();
+    const deferPayload = interaction.deferReply.mock.calls[0][0];
+    expect(deferPayload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("includes the four expected metric fields in the embed", async () => {
+    const interaction = createMockInteraction();
     await ping.run(createMockClient(), interaction, []);
 
-    expect(interaction.reply).not.toHaveBeenCalled();
+    const payload = interaction.editReply.mock.calls[0][0];
+    const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
+
+    expect(fieldNames).toContain("🏓 Round-trip");
+    expect(fieldNames).toContain("📡 API");
+    expect(fieldNames).toContain("⏰ Uptime");
+    expect(fieldNames).toContain("📦 Versión");
+  });
+
+  it("reports the API ping from client.ws.ping", async () => {
+    const client = createMockClient({ ws: { ping: 123 } });
+    const interaction = createMockInteraction();
+    await ping.run(client, interaction, []);
+
+    const payload = interaction.editReply.mock.calls[0][0];
+    const apiField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "📡 API"
+    );
+    expect(apiField.value).toContain("123ms");
+  });
+
+  it("clamps a negative ws.ping to 0 (happens when the bot just connected)", async () => {
+    const client = createMockClient({ ws: { ping: -1 } });
+    const interaction = createMockInteraction();
+    await ping.run(client, interaction, []);
+
+    const payload = interaction.editReply.mock.calls[0][0];
+    const apiField = payload.embeds[0].data.fields.find(
+      (f: any) => f.name === "📡 API"
+    );
+    expect(apiField.value).toContain("0ms");
   });
 });

--- a/src/slashCommands/info/ping.test.ts
+++ b/src/slashCommands/info/ping.test.ts
@@ -41,7 +41,7 @@ describe("/ping", () => {
     const payload = interaction.editReply.mock.calls[0][0];
     const fieldNames = payload.embeds[0].data.fields.map((f: any) => f.name);
 
-    expect(fieldNames).toContain("🏓 Round-trip");
+    expect(fieldNames).toContain("📶 Round-trip");
     expect(fieldNames).toContain("📡 API");
     expect(fieldNames).toContain("⏰ Uptime");
     expect(fieldNames).toContain("📦 Versión");

--- a/src/slashCommands/info/ping.ts
+++ b/src/slashCommands/info/ping.ts
@@ -56,7 +56,7 @@ const pull: ISlashCommand = {
     {
       name: "private",
       description:
-        "Mostrar la respuesta solo a vos (default: false, lo ve todo el canal)",
+        "Mostrar la respuesta solo a ti (default: false, lo ve todo el canal)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },

--- a/src/slashCommands/info/ping.ts
+++ b/src/slashCommands/info/ping.ts
@@ -20,16 +20,12 @@ const buildEmbed = (
   uptimeSec: number
 ) =>
   new EmbedBuilder()
-    .setAuthor({
-      name: BOT_BRAND_NAME,
-      iconURL: client.user?.avatarURL() ?? undefined,
-    })
     .setTitle("🏓 Pong!")
     .setThumbnail(client.user?.avatarURL() ?? null)
     .setColor(colorForCategory("info"))
     .addFields(
       {
-        name: "🏓 Round-trip",
+        name: "📶 Round-trip",
         value: `\`${roundTripMs}ms\``,
         inline: true,
       },

--- a/src/slashCommands/info/ping.ts
+++ b/src/slashCommands/info/ping.ts
@@ -1,42 +1,92 @@
-import Discord, { ChatInputCommandInteraction } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
+import { errorHandler, formatUptime } from "../../shared/utils/helpers";
+
+const buildEmbed = (
+  client: ClientDiscord,
+  roundTripMs: number,
+  apiPingMs: number,
+  uptimeSec: number
+) =>
+  new EmbedBuilder()
+    .setAuthor({
+      name: BOT_BRAND_NAME,
+      iconURL: client.user?.avatarURL() ?? undefined,
+    })
+    .setTitle("🏓 Pong!")
+    .setThumbnail(client.user?.avatarURL() ?? null)
+    .setColor(colorForCategory("info"))
+    .addFields(
+      {
+        name: "🏓 Round-trip",
+        value: `\`${roundTripMs}ms\``,
+        inline: true,
+      },
+      {
+        name: "📡 API",
+        value: `\`${apiPingMs}ms\``,
+        inline: true,
+      },
+      {
+        name: "⏰ Uptime",
+        value: `\`${formatUptime(uptimeSec)}\``,
+        inline: true,
+      },
+      {
+        name: "📦 Versión",
+        value: `\`${BOT_VERSION}\``,
+        inline: true,
+      }
+    )
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
 const pull: ISlashCommand = {
   name: "ping",
   category: "info",
-  description: "Check the bot's ping!",
+  description: "Mide la latencia del bot",
   ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description:
+        "Mostrar la respuesta solo a vos (default: false, lo ve todo el canal)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/ping", "/ping private:true"],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
-    _: Argument[]
+    args: Argument[]
   ) => {
     try {
-      if (!interaction.channel?.isSendable()) return;
-      const msg = await interaction.channel.send(`🏓 Pinging...`);
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as boolean | undefined) ??
+        false;
 
-      const pingEmbed = new Discord.EmbedBuilder()
-        .setTitle(":signal_strength: Bot Ping")
-        .addFields([
-          {
-            name: "Time",
-            value: `${Math.floor(
-              msg!.createdAt.getTime() - interaction.createdAt.getTime()
-            )}ms`,
-            inline: true,
-          },
-          {
-            name: "API Ping",
-            value: `${client.ws.ping}ms`,
-            inline: true,
-          },
-        ])
-        .setColor("Random");
-      await interaction.reply({ embeds: [pingEmbed] });
+      await interaction.deferReply({
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
 
-      await msg?.delete();
+      const roundTrip = Date.now() - interaction.createdTimestamp;
+      const apiPing = Math.max(0, Math.round(client.ws.ping));
+      const uptime = process.uptime();
+
+      await interaction.editReply({
+        embeds: [buildEmbed(client, roundTrip, apiPing, uptime)],
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/info/uptime.test.ts
+++ b/src/slashCommands/info/uptime.test.ts
@@ -1,0 +1,37 @@
+import { MessageFlags } from "discord.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import uptime from "./uptime";
+
+describe("/uptime", () => {
+  it("renders a branded embed with formatted uptime and a relative-time start", async () => {
+    const interaction = createMockInteraction();
+    await uptime.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("⏰ Uptime");
+    expect(embed.color).toBe(0x5865f2);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.description).toMatch(/`[\dsmhd ]+`/);
+
+    const startedField = embed.fields.find(
+      (f: any) => f.name === "🚀 Activo desde"
+    );
+    expect(startedField.value).toMatch(/^<t:\d+:R>$/);
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    const i1 = createMockInteraction();
+    await uptime.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await uptime.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
+  });
+});

--- a/src/slashCommands/info/uptime.ts
+++ b/src/slashCommands/info/uptime.ts
@@ -1,0 +1,68 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler, formatUptime } from "../../shared/utils/helpers";
+
+const pull: ISlashCommand = {
+  name: "uptime",
+  category: "info",
+  description: "Tiempo activo del bot desde el último deploy",
+  ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/uptime", "/uptime private:true"],
+  run: async (
+    _: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      const uptimeSec = process.uptime();
+      const startedTimestamp = Math.floor(
+        (Date.now() - uptimeSec * 1000) / 1000
+      );
+
+      const embed = new EmbedBuilder()
+        .setTitle("⏰ Uptime")
+        .setDescription(`\`${formatUptime(uptimeSec)}\``)
+        .addFields({
+          name: "🚀 Activo desde",
+          value: `<t:${startedTimestamp}:R>`,
+          inline: true,
+        })
+        .setColor(colorForCategory("info"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -29,7 +30,7 @@ describe("/clear", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("permisos");
   });
 
@@ -39,6 +40,6 @@ describe("/clear", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/clear.test.ts
+++ b/src/slashCommands/mod/clear.test.ts
@@ -1,27 +1,308 @@
-import { MessageFlags } from "discord.js";
-import { describe, expect, it, vi } from "vitest";
+import { Collection, MessageFlags } from "discord.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import clear from "./clear";
 
+const fakeMessage = (overrides: Partial<any> = {}) => {
+  const id = overrides.id ?? `msg-${Math.random().toString(36).slice(2)}`;
+  return {
+    id,
+    content: "hola",
+    author: { username: "tester" },
+    createdTimestamp: Date.now(),
+    attachments: new Collection<string, any>(),
+    ...overrides,
+  } as any;
+};
+
+const fakeFetchResult = (messages: any[]) => {
+  // Discord returns newest-first; test fixtures pass them oldest-first for
+  // readability, so reverse to mimic real API order.
+  const col = new Collection<string, any>();
+  [...messages].reverse().forEach((m) => col.set(m.id, m));
+  return col;
+};
+
+const fakeBulkResult = (messages: any[]) => {
+  const col = new Collection<string, any>();
+  messages.forEach((m) => col.set(m.id, m));
+  return col;
+};
+
+const setupChannel = (messages: any[], opts: { send?: any } = {}) => {
+  const send = opts.send ?? vi.fn().mockResolvedValue({ delete: vi.fn() });
+  const fetch = vi.fn().mockResolvedValue(fakeFetchResult(messages));
+  const bulkDelete = vi.fn().mockResolvedValue(fakeBulkResult(messages));
+  return {
+    channel: {
+      isSendable: () => true,
+      send,
+      messages: { fetch },
+      bulkDelete,
+    },
+    send,
+    fetch,
+    bulkDelete,
+  };
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
 describe("/clear", () => {
-  it("bulk-deletes the requested amount and posts a public count notice", async () => {
-    const send = vi.fn().mockResolvedValue({ delete: vi.fn() });
-    const bulkDelete = vi.fn().mockResolvedValue({ size: 4 });
+  it("defers, downloads attachments BEFORE bulkDelete, then DMs the recap and posts the public count", async () => {
+    vi.useFakeTimers();
+    const messages = [
+      fakeMessage({
+        id: "m1",
+        content: "hola",
+        author: { username: "ana" },
+      }),
+      fakeMessage({
+        id: "m2",
+        content: "qué onda",
+        author: { username: "bob" },
+      }),
+      fakeMessage({
+        id: "m3",
+        content: "🥲",
+        author: { username: "carla" },
+      }),
+    ];
+    const { channel, send, fetch, bulkDelete } = setupChannel(messages);
+
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
     const interaction = createMockInteraction({
-      channel: {
-        isSendable: () => true,
-        send,
-        bulkDelete,
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
       },
     });
 
-    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
+    await clear.run(createMockClient(), interaction, [arg("amount", 3)]);
 
-    expect(bulkDelete).toHaveBeenCalledWith(4, true);
+    // 1. Defers immediately so we don't hit the 3s 'Unknown interaction' timeout
+    expect(interaction.deferReply).toHaveBeenCalledOnce();
+
+    // 2. Fetches messages BEFORE deleting (so CDN URLs are still valid)
+    expect(fetch).toHaveBeenCalledWith({ limit: 3 });
+
+    // 3. bulkDelete is called by ID array, in chronological order
+    const deleteCall = bulkDelete.mock.calls[0];
+    expect(deleteCall[0]).toEqual(["m1", "m2", "m3"]);
+    expect(deleteCall[1]).toBe(true);
+
+    // 4. Recap delivered via DM (with all 3 messages)
+    expect(dmSend).toHaveBeenCalledOnce();
+    const dmPayload = dmSend.mock.calls[0][0];
+    const recap = dmPayload.embeds[0].data;
+    expect(recap.title).toBe("📋 Eliminados (3)");
+    expect(recap.description).toContain("ana");
+    expect(recap.description).toContain("bob");
+    expect(recap.description).toContain("carla");
+    expect(dmPayload.allowedMentions).toEqual({ parse: [] });
+
+    // 5. Public count notice posted in channel
+    expect(send).toHaveBeenCalledOnce();
+    const noticeEmbed = send.mock.calls[0][0].embeds[0].data;
+    expect(noticeEmbed.title).toBe("🧹 Chat limpiado");
+    expect(noticeEmbed.description).toContain("3");
+
+    // 6. Happy-path: deleteReply removes the deferred ephemeral
+    expect(interaction.deleteReply).toHaveBeenCalledOnce();
+    // No editReply — the deferred reply was simply deleted, not filled
+    expect(interaction.editReply).not.toHaveBeenCalled();
   });
 
-  it("rejects ephemerally when the member lacks ManageMessages", async () => {
+  it("skips the DM recap entirely for /clear amount:1 with a text-only message (the messageDelete listener already covers it)", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "asf", author: { username: "ana" } }),
+    ];
+    const { channel } = setupChannel(messages);
+
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
+    const createDM = vi.fn().mockResolvedValue({ send: dmSend });
+    const interaction = createMockInteraction({
+      channel,
+      user: { id: "mod-1", createDM },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    // No DM at all — the listener already handles single text deletes
+    expect(createDM).not.toHaveBeenCalled();
+    expect(dmSend).not.toHaveBeenCalled();
+
+    // Public count notice still posts
+    expect(channel.send).toHaveBeenCalledOnce();
+    // Deferred ephemeral cleared
+    expect(interaction.deleteReply).toHaveBeenCalledOnce();
+  });
+
+  it("public count notice uses singular Spanish for a 1-message delete ('Se eliminó', not 'Se eliminaron')", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "asf", author: { username: "ana" } }),
+    ];
+    const { channel, send } = setupChannel(messages);
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    const description = send.mock.calls[0][0].embeds[0].data.description;
+    expect(description).toBe("Se eliminó **1** mensaje.");
+  });
+
+  it("public count notice uses plural Spanish for a multi-message delete", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "uno" }),
+      fakeMessage({ id: "m2", content: "dos" }),
+      fakeMessage({ id: "m3", content: "tres" }),
+    ];
+    const { channel, send } = setupChannel(messages);
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 3)]);
+
+    const description = send.mock.calls[0][0].embeds[0].data.description;
+    expect(description).toBe("Se eliminaron **3** mensajes.");
+  });
+
+  it("DOES DM the recap for /clear amount:1 when the single message has an attachment", async () => {
+    const att = new Collection<string, any>([
+      ["a1", { url: "https://cdn.discordapp.com/x.png", name: "x.png" }],
+    ]);
+    const messages = [
+      fakeMessage({ id: "m1", content: "look", attachments: att }),
+    ];
+    const { channel } = setupChannel(messages);
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
+      })
+    );
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    // DM with the recap and the re-uploaded file
+    expect(dmSend).toHaveBeenCalledOnce();
+    const dmPayload = dmSend.mock.calls[0][0];
+    expect(dmPayload.files).toHaveLength(1);
+    expect(dmPayload.embeds[0].data.title).toBe("📋 Eliminados (1)");
+    expect(dmPayload.embeds[0].data.description).toContain("look");
+  });
+
+  it("downloads attachments via fetch BEFORE bulkDelete and re-uploads them as files in the DM", async () => {
+    const att = new Collection<string, any>([
+      [
+        "a1",
+        {
+          url: "https://cdn.discordapp.com/example.png",
+          name: "example.png",
+        },
+      ],
+    ]);
+    const messages = [
+      fakeMessage({
+        id: "m1",
+        content: "look",
+        attachments: att,
+      }),
+    ];
+    const { channel, bulkDelete } = setupChannel(messages);
+
+    const dmSend = vi.fn().mockResolvedValue({ id: "dm-msg" });
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: dmSend }),
+      },
+    });
+
+    // Track call order: fetch must complete before bulkDelete is called.
+    const callOrder: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => {
+        callOrder.push("attachment-fetch");
+        return {
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3]).buffer),
+        };
+      })
+    );
+    bulkDelete.mockImplementation(async (ids: any) => {
+      callOrder.push("bulk-delete");
+      return fakeBulkResult(messages);
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 1)]);
+
+    expect(callOrder).toEqual(["attachment-fetch", "bulk-delete"]);
+
+    const dmPayload = dmSend.mock.calls[0][0];
+    expect(dmPayload.files).toHaveLength(1);
+    expect(dmPayload.files[0].name).toBe("example.png");
+    expect(Buffer.isBuffer(dmPayload.files[0].attachment)).toBe(true);
+  });
+
+  it("falls back to inline ephemeral when DMs are disabled (multi-message path so DM is actually attempted)", async () => {
+    const messages = [
+      fakeMessage({ id: "m1", content: "uno" }),
+      fakeMessage({ id: "m2", content: "dos" }),
+    ];
+    const { channel } = setupChannel(messages);
+
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockRejectedValue(new Error("DMs blocked")),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 2)]);
+
+    // The deferReply gets edited (not deleted) so the moderator still sees the recap
+    expect(interaction.deleteReply).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
+    expect(payload.content).toContain("DM");
+    expect(payload.embeds[0].data.title).toBe("📋 Eliminados (2)");
+  });
+
+  it("rejects ephemerally when the member lacks ManageMessages (no defer needed — fast path)", async () => {
     const interaction = createMockInteraction({
       member: { permissions: { has: vi.fn().mockReturnValue(false) } },
     });
@@ -32,14 +313,69 @@ describe("/clear", () => {
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("permisos");
+    expect(interaction.deferReply).not.toHaveBeenCalled();
   });
 
-  it("rejects ephemerally when amount is invalid (zero or negative)", async () => {
+  it("rejects ephemerally when amount <= 0", async () => {
     const interaction = createMockInteraction();
     await clear.run(createMockClient(), interaction, [arg("amount", 0)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("mayor a 0");
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+  });
+
+  it("editReplies a friendly empty embed when bulkDelete returns 0 messages (e.g. all >14d)", async () => {
+    const messages = [fakeMessage({ id: "m1" })];
+    const channel = {
+      isSendable: () => true,
+      send: vi.fn().mockResolvedValue({ delete: vi.fn() }),
+      messages: { fetch: vi.fn().mockResolvedValue(fakeFetchResult(messages)) },
+      bulkDelete: vi.fn().mockResolvedValue(fakeBulkResult([])), // 0 deleted
+    };
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
+
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
+    expect(payload.embeds[0].data.title).toBe("🧹 Nada para limpiar");
+    // Public notice not sent — nothing actually happened
+    expect(channel.send).not.toHaveBeenCalled();
+  });
+
+  it("editReplies an error embed when bulkDelete throws", async () => {
+    const messages = [fakeMessage({ id: "m1" })];
+    const channel = {
+      isSendable: () => true,
+      send: vi.fn().mockResolvedValue({ delete: vi.fn() }),
+      messages: { fetch: vi.fn().mockResolvedValue(fakeFetchResult(messages)) },
+      bulkDelete: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("You can only bulk delete messages younger than 14 days")
+        ),
+    };
+    const interaction = createMockInteraction({
+      channel,
+      user: {
+        id: "mod-1",
+        createDM: vi.fn().mockResolvedValue({ send: vi.fn() }),
+      },
+    });
+
+    await clear.run(createMockClient(), interaction, [arg("amount", 4)]);
+
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    const payload = interaction.editReply.mock.calls[0][0];
+    expect(payload.embeds[0].data.title).toBe("❌ No se pudo limpiar el chat");
+    expect(payload.embeds[0].data.description).toContain("14 days");
   });
 });

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -1,4 +1,4 @@
-import Discord, { ChatInputCommandInteraction, PermissionFlagsBits, PermissionsBitField } from "discord.js";
+import Discord, { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits, PermissionsBitField } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
 import { Argument, ISlashCommand } from "../../shared/types";
@@ -33,7 +33,7 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "No tienes permisos para eliminar mensajes...",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -44,7 +44,7 @@ const pull: ISlashCommand = {
         return interaction.reply({
           content:
             "Por favor selecciona una cantidad de mensajes a eliminar apropiada.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -56,7 +56,7 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "No cuento con permisos para eliminar mensajes.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -76,7 +76,7 @@ const pull: ISlashCommand = {
 
       await interaction.reply({
         content: "Limpiando chat...",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
 
       channel

--- a/src/slashCommands/mod/clear.ts
+++ b/src/slashCommands/mod/clear.ts
@@ -1,97 +1,275 @@
-import Discord, { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits, PermissionsBitField } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Message,
+  MessageFlags,
+  PermissionFlagsBits,
+  PermissionsBitField,
+  TextChannel,
+} from "discord.js";
+
+import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
-import config from "../../config";
+
+const NOTICE_TTL_MS = 5_000;
+const MAX_RECAP_ATTACHMENTS = 10;
+const MAX_RECAP_DESCRIPTION = 3800;
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("mod"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildPublicNoticeEmbed = (deletedCount: number) =>
+  baseEmbed()
+    .setTitle("🧹 Chat limpiado")
+    .setDescription(
+      deletedCount === 1
+        ? `Se eliminó **1** mensaje.`
+        : `Se eliminaron **${deletedCount}** mensajes.`
+    );
+
+const buildErrorEmbed = (reason: string) =>
+  baseEmbed()
+    .setTitle("❌ No se pudo limpiar el chat")
+    .setDescription(reason);
+
+const buildEmptyEmbed = () =>
+  baseEmbed()
+    .setTitle("🧹 Nada para limpiar")
+    .setDescription(
+      "No había mensajes recientes para eliminar (Discord no permite borrar mensajes de más de 14 días en bloque)."
+    );
+
+type DownloadedAttachment = {
+  msgId: string;
+  name: string;
+  buffer: Buffer;
+};
+
+/**
+ * Fetch every attachment binary in parallel BEFORE the messages get deleted.
+ * Discord's CDN URLs become invalid the moment the source message is deleted,
+ * so any download has to happen first or it fails silently.
+ */
+const downloadAttachments = async (
+  messages: Message[]
+): Promise<DownloadedAttachment[]> => {
+  const tasks = messages.flatMap((msg) =>
+    [...msg.attachments.values()].map(
+      async (att): Promise<DownloadedAttachment | null> => {
+        try {
+          const res = await fetch(att.url);
+          if (!res.ok) return null;
+          return {
+            msgId: msg.id,
+            name: att.name,
+            buffer: Buffer.from(await res.arrayBuffer()),
+          };
+        } catch {
+          return null;
+        }
+      }
+    )
+  );
+  const settled = await Promise.all(tasks);
+  return settled.filter((x): x is DownloadedAttachment => x !== null);
+};
+
+/**
+ * Build the moderator-only DM recap: embed listing every deleted message
+ * (chronological) plus the re-uploaded attachment Buffers Discord can serve
+ * as fresh files.
+ */
+const buildRecap = (
+  messages: Message[],
+  downloaded: DownloadedAttachment[]
+) => {
+  const lines: string[] = [];
+  let textTruncated = false;
+
+  for (const msg of messages) {
+    const ts = `<t:${Math.floor(msg.createdTimestamp / 1000)}:t>`;
+    const author = `**${msg.author.username}**`;
+    const body =
+      msg.content?.trim() ||
+      (msg.attachments.size > 0 ? "_(solo adjuntos)_" : "_(mensaje vacío)_");
+    const line = `${ts} ${author}: ${body}`;
+
+    if (lines.join("\n").length + line.length + 1 > MAX_RECAP_DESCRIPTION) {
+      textTruncated = true;
+      break;
+    }
+    lines.push(line);
+  }
+
+  // Cap attachments at Discord's per-message ceiling.
+  const filesTruncated = downloaded.length > MAX_RECAP_ATTACHMENTS;
+  const files = downloaded
+    .slice(0, MAX_RECAP_ATTACHMENTS)
+    .map((d) => ({ attachment: d.buffer, name: d.name }));
+
+  if (textTruncated || filesTruncated) {
+    lines.push("\n_(recap truncado por límites de Discord)_");
+  }
+
+  const embed = baseEmbed()
+    .setTitle(`📋 Eliminados (${messages.length})`)
+    .setDescription(lines.join("\n") || "_(sin contenido)_");
+
+  return { embed, files };
+};
 
 const pull: ISlashCommand = {
   name: "clear",
   category: "mod",
-  description: "Limpia el chat",
+  description: "Limpia mensajes del canal en bloque",
   ownerOnly: false,
   defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [
     {
       name: "amount",
-      description: "Cantidad de mensajes a borrar",
+      description: `Cantidad de mensajes a borrar (1–${config.maxDeleteMessages}, default: 1)`,
       type: ApplicationCommandOptionType.Integer,
       required: false,
     },
   ],
+  examples: ["/clear", "/clear amount:10"],
   run: async (
-    client: ClientDiscord,
+    _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
     args: Argument[]
   ) => {
     try {
-      // Member doesn't have permissions
       if (
-        !(interaction.member!.permissions as Readonly<PermissionsBitField>).has(
+        !(interaction.member?.permissions as Readonly<PermissionsBitField>)?.has(
           PermissionFlagsBits.ManageMessages
         )
       ) {
         return interaction.reply({
-          content: "No tienes permisos para eliminar mensajes...",
+          content: "No tienes permisos para eliminar mensajes.",
           flags: MessageFlags.Ephemeral,
         });
       }
 
-      const arg = args[0]?.value || 1;
-
-      // Check if args[0] is a number
-      if (isNaN(parseInt(arg.toString())) || parseInt(arg.toString()) <= 0) {
+      const requested =
+        (args.find((a) => a.name === "amount")?.value as number | undefined) ??
+        1;
+      if (requested <= 0) {
         return interaction.reply({
-          content:
-            "Por favor selecciona una cantidad de mensajes a eliminar apropiada.",
+          content: "La cantidad debe ser un número mayor a 0.",
           flags: MessageFlags.Ephemeral,
         });
       }
 
-      // Maybe the bot can't delete messages
-      if (
-        !(interaction.member?.permissions as Readonly<PermissionsBitField>).has(
-          PermissionFlagsBits.ManageMessages
-        )
-      ) {
-        return interaction.reply({
-          content: "No cuento con permisos para eliminar mensajes.",
-          flags: MessageFlags.Ephemeral,
-        });
-      }
+      const amountToDelete = Math.min(requested, config.maxDeleteMessages);
+      const channel = interaction.channel as TextChannel;
 
-      const amount = parseInt(arg.toString());
-      if (!amount) {
-        return interaction.reply({
-          content: "Por favor selecciona una cantidad de mensajes a borrar.",
-        });
-      }
+      // Defer immediately. The fetch + parallel attachment downloads can
+      // easily blow past Discord's 3s acknowledgement window — without this
+      // the user gets 'Unknown interaction' on anything non-trivial.
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-      const amountToDelete =
-        amount > config.maxDeleteMessages ? config.maxDeleteMessages : amount;
-
-      const channel: Discord.TextChannel = <Discord.TextChannel>(
-        interaction.channel
-      );
-
-      await interaction.reply({
-        content: "Limpiando chat...",
-        flags: MessageFlags.Ephemeral,
+      // Fetch the candidate messages BEFORE deleting them — the CDN URLs
+      // for their attachments are only valid while the source still exists.
+      const candidates = await channel.messages.fetch({
+        limit: amountToDelete,
       });
+      // fetch() returns newest-first; bulkDelete and the recap want chronological.
+      const messageArr = [...candidates.values()].reverse();
 
-      channel
-        .bulkDelete(amountToDelete, true)
-        .then(async (deleted) => {
-          const notice = await channel.send(
-            `\`${deleted.size}\` mensajes borrados.`
-          );
-          setTimeout(() => {
-            notice.delete().catch(() => {});
-          }, 5000);
-        })
-        .catch((err) =>
-          interaction.editReply(`Error: ${err}`).catch(() => {})
+      // Download every attachment binary in parallel, then bulk-delete by ID.
+      const downloaded = await downloadAttachments(messageArr);
+
+      let deletedCount: number;
+      try {
+        const result = await channel.bulkDelete(
+          messageArr.map((m) => m.id),
+          true
         );
+        deletedCount = result.size;
+      } catch (bulkErr: any) {
+        return interaction.editReply({
+          embeds: [
+            buildErrorEmbed(
+              bulkErr?.message ??
+                "Discord rechazó la operación. ¿Mensajes muy viejos (>14 días) o falta de permisos del bot?"
+            ),
+          ],
+        });
+      }
+
+      if (deletedCount === 0) {
+        return interaction.editReply({ embeds: [buildEmptyEmbed()] });
+      }
+
+      // Skip the DM recap when it would just duplicate what the messageDelete
+      // listener (events/message/messageDelete.ts) already DMs the owner.
+      // The listener handles single-message deletes one-by-one with full
+      // fidelity, so /clear only needs to add value when there's bulk context
+      // OR an attachment that the listener might miss.
+      const hasAttachments = downloaded.length > 0;
+      const skipRecap = messageArr.length === 1 && !hasAttachments;
+
+      // Recap is built from the messages we captured pre-delete (and their
+      // pre-downloaded attachments) — not from bulkDelete's return, which
+      // strips message bodies for messages older than 14 days.
+      const { embed: recapEmbed, files } = buildRecap(messageArr, downloaded);
+
+      // Recap goes by DM — internal log persisted in the moderator's DM
+      // history, invisible to the rest of the server regardless of who ran
+      // the command.
+      let dmDelivered = true;
+      if (!skipRecap) {
+        try {
+          const dm = await interaction.user.createDM();
+          await dm.send({
+            embeds: [recapEmbed],
+            files,
+            allowedMentions: { parse: [] },
+          });
+        } catch {
+          dmDelivered = false;
+        }
+      }
+
+      // Public auto-deleting notice in the channel: just the count, no detail.
+      const notice = await channel.send({
+        embeds: [buildPublicNoticeEmbed(deletedCount)],
+      });
+      setTimeout(() => {
+        (notice as Message).delete().catch(() => {});
+      }, NOTICE_TTL_MS);
+
+      // Happy path: drop the deferred ephemeral so the moderator gets no
+      // visible reply in the channel — the recap is in their DM, the count
+      // notice is in the channel for context. Both already cover the UX.
+      if (skipRecap || dmDelivered) {
+        try {
+          await interaction.deleteReply();
+        } catch {
+          // Token expired or already deleted — nothing left to do.
+        }
+        return;
+      }
+
+      // DM fallback: when the moderator has DMs disabled, surface the recap
+      // inline as the only place to see what got nuked.
+      return interaction.editReply({
+        content:
+          "No te pude enviar DM (¿los tienes desactivados?). Te dejo el detalle acá:",
+        embeds: [recapEmbed],
+        files,
+        allowedMentions: { parse: [] },
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/cum.test.ts
+++ b/src/slashCommands/mod/cum.test.ts
@@ -1,0 +1,59 @@
+import { MessageFlags } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../shared/utils/birthdayReminder");
+
+import * as birthdayReminder from "../../shared/utils/birthdayReminder";
+import {
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
+import cum from "./cum";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("/cum", () => {
+  it("calls reminder() and reports the count back to the moderator (ephemeral)", async () => {
+    vi.mocked(birthdayReminder.reminder).mockResolvedValue({ count: 2 });
+    const interaction = createMockInteraction();
+
+    await cum.run(createMockClient(), interaction, []);
+
+    expect(birthdayReminder.reminder).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("**2** saludos");
+  });
+
+  it("uses singular 'saludo' when only one greeting fired", async () => {
+    vi.mocked(birthdayReminder.reminder).mockResolvedValue({ count: 1 });
+    const interaction = createMockInteraction();
+
+    await cum.run(createMockClient(), interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.content).toContain("**1** saludo");
+    expect(payload.content).not.toContain("saludos");
+  });
+
+  it("returns a friendly notice when no birthday matches today", async () => {
+    vi.mocked(birthdayReminder.reminder).mockResolvedValue({ count: 0 });
+    const interaction = createMockInteraction();
+
+    await cum.run(createMockClient(), interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("nadie");
+  });
+
+  it("is marked owner-only at the schema level", () => {
+    expect(cum.ownerOnly).toBe(true);
+  });
+});

--- a/src/slashCommands/mod/cum.ts
+++ b/src/slashCommands/mod/cum.ts
@@ -1,0 +1,42 @@
+import {
+  ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { reminder } from "../../shared/utils/birthdayReminder";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const pull: ISlashCommand = {
+  name: "cum",
+  category: "mod",
+  description: "[Owner] Dispara manualmente el saludo de cumpleaños del día",
+  ownerOnly: true,
+  examples: ["/cum"],
+  run: async (
+    client: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    _: Argument[]
+  ) => {
+    try {
+      const { count } = await reminder(client);
+
+      const message =
+        count === 0
+          ? "Hoy no es cumple de nadie registrado."
+          : count === 1
+            ? "Disparé **1** saludo."
+            : `Disparé **${count}** saludos.`;
+
+      return interaction.reply({
+        content: message,
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/mod/cums.test.ts
+++ b/src/slashCommands/mod/cums.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/services/birthday.service");
@@ -42,7 +43,7 @@ describe("/cums", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
   it("returns the empty-state notice when the filter has no results", async () => {
@@ -53,7 +54,7 @@ describe("/cums", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(payload.content).toContain("No hay cumpleaños");
   });
 });

--- a/src/slashCommands/mod/cums.test.ts
+++ b/src/slashCommands/mod/cums.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../shared/services/birthday.service");
 
 import * as birthdayService from "../../shared/services/birthday.service";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import cums from "./cums";
 
 beforeEach(() => {
@@ -15,6 +19,7 @@ describe("/cums", () => {
   it("replies with all birthdays when no month option is given", async () => {
     vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
       Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+      Mayo: [{ name: "Ana", discordId: "222", birthdayDay: 5 }],
     });
 
     const interaction = createMockInteraction();
@@ -22,10 +27,12 @@ describe("/cums", () => {
 
     expect(birthdayService.getBirthdays).toHaveBeenCalledOnce();
     expect(birthdayService.getBirthdaysByMonth).not.toHaveBeenCalled();
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Cumpleaños del servidor");
+    expect(embed.description).toContain("**2** personas registradas");
   });
 
-  it("filters by month when the option is provided", async () => {
+  it("filters by month when the option is provided (passes 0-indexed month to the service)", async () => {
     vi.mocked(birthdayService.getBirthdaysByMonth).mockResolvedValue({
       Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
     });
@@ -33,28 +40,109 @@ describe("/cums", () => {
     const interaction = createMockInteraction();
     await cums.run(createMockClient(), interaction, [arg("month", 2)]);
 
-    expect(birthdayService.getBirthdaysByMonth).toHaveBeenCalledWith(1); // month - 1
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(birthdayService.getBirthdaysByMonth).toHaveBeenCalledWith(1); // Feb is 0-indexed 1
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Cumpleaños de Febrero");
   });
 
-  it("rejects ephemerally when the month option is out of range", async () => {
+  it("singular phrasing for a 1-person registration", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.description).toBe("**1** persona registrada");
+  });
+
+  it("rejects ephemerally when the month option is out of range (>12)", async () => {
     const interaction = createMockInteraction();
     await cums.run(createMockClient(), interaction, [arg("month", 13)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("entre 1 y 12");
+    expect(birthdayService.getBirthdaysByMonth).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when the month option is 0 or negative", async () => {
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, [arg("month", 0)]);
+
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 
-  it("returns the empty-state notice when the filter has no results", async () => {
+  it("returns a branded empty embed when the filter has no results", async () => {
     vi.mocked(birthdayService.getBirthdaysByMonth).mockResolvedValue({});
 
     const interaction = createMockInteraction();
     await cums.run(createMockClient(), interaction, [arg("month", 2)]);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Sin cumpleaños en Febrero");
+    expect(embed.description).toContain("No hay cumpleaños");
+  });
+
+  it("returns a friendly embed when there are no registrations at all", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({});
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Sin cumpleaños registrados");
+    expect(embed.description).toContain("/register");
+  });
+
+  it("uses mod-red color and the brand footer (no setAuthor)", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.color).toBe(0xed4245);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+  });
+
+  it("ephemeral when private:true", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, [arg("private", true)]);
+
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
-    expect(payload.content).toContain("No hay cumpleaños");
+  });
+
+  it("sorts by day within a month", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({
+      Febrero: [
+        { name: "Carla", discordId: "333", birthdayDay: "20" },
+        { name: "Diego", discordId: "111", birthdayDay: "5" },
+        { name: "Ana", discordId: "222", birthdayDay: "12" },
+      ],
+    });
+
+    const interaction = createMockInteraction();
+    await cums.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const febField = embed.fields.find((f: any) => f.name === "Febrero");
+    const value = febField.value;
+    // Order: 5, 12, 20
+    const indexOf5 = value.indexOf("`5`");
+    const indexOf12 = value.indexOf("`12`");
+    const indexOf20 = value.indexOf("`20`");
+    expect(indexOf5).toBeLessThan(indexOf12);
+    expect(indexOf12).toBeLessThan(indexOf20);
   });
 });

--- a/src/slashCommands/mod/cums.ts
+++ b/src/slashCommands/mod/cums.ts
@@ -1,18 +1,64 @@
 import {
   APIEmbedField,
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import calendar from "../../shared/constants/calendar";
-import { Argument, CumData, ISlashCommand, Month } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
 import {
   getBirthdays,
   getBirthdaysByMonth,
 } from "../../shared/services/birthday.service";
+import { Argument, CumData, ISlashCommand, Month } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const baseEmbed = (title: string) =>
+  new EmbedBuilder()
+    .setTitle(title)
+    .setColor(colorForCategory("mod"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const buildBirthdaysEmbed = (response: CumData, monthName: string | null) => {
+  const totalCount = Object.values(response).reduce(
+    (sum, list) => sum + list.length,
+    0
+  );
+
+  const fields: APIEmbedField[] = [];
+  for (const month in response) {
+    const users = response[month]
+      .map((b: any) => ({ day: b.birthdayDay, mention: `<@${b.discordId}>` }))
+      .sort((a, b) => parseInt(a.day) - parseInt(b.day));
+
+    fields.push({
+      name: month,
+      value: users.map((u) => `\`${u.day}\` ${u.mention}`).join("\n"),
+      inline: true,
+    });
+  }
+
+  const title = monthName
+    ? `🎂 Cumpleaños de ${monthName}`
+    : "🎂 Cumpleaños del servidor";
+  const description = `**${totalCount}** ${
+    totalCount === 1 ? "persona registrada" : "personas registradas"
+  }`;
+
+  return baseEmbed(title).setDescription(description).addFields(fields);
+};
+
+const buildEmptyMonthEmbed = (monthName: string) =>
+  baseEmbed(`🎂 Sin cumpleaños en ${monthName}`).setDescription(
+    "No hay cumpleaños registrados para este mes."
+  );
 
 const pull: ISlashCommand = {
   name: "cums",
@@ -26,7 +72,14 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Integer,
       required: false,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
   ],
+  examples: ["/cums", "/cums month:5", "/cums private:true"],
   run: async (
     _: ClientDiscord,
     interaction: ChatInputCommandInteraction,
@@ -36,49 +89,49 @@ const pull: ISlashCommand = {
       const monthInput = args.find((a) => a.name === "month")?.value as
         | number
         | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
 
       let response: CumData = {};
+      let monthName: string | null = null;
+
       if (monthInput !== undefined) {
-        const month = (monthInput - 1) as Month;
-        if (month < 0 || month > 11) {
+        if (monthInput < 1 || monthInput > 12) {
           return interaction.reply({
-            content: "El mes debe estar entre 1 y 12",
+            content: "El mes debe estar entre 1 y 12.",
             flags: MessageFlags.Ephemeral,
           });
         }
-        response = await getBirthdaysByMonth(month);
+        const monthIdx = (monthInput - 1) as Month;
+        monthName = calendar.months[monthIdx];
+        response = await getBirthdaysByMonth(monthIdx);
         if (Object.keys(response).length === 0) {
           return interaction.reply({
-            content: `No hay cumpleaños en ${calendar.months[month]}`,
-            flags: MessageFlags.Ephemeral,
+            embeds: [buildEmptyMonthEmbed(monthName)],
+            flags,
           });
         }
       } else {
         response = await getBirthdays();
+        if (Object.keys(response).length === 0) {
+          return interaction.reply({
+            embeds: [
+              baseEmbed("🎂 Sin cumpleaños registrados").setDescription(
+                "Todavía no hay nadie con cumpleaños registrado en el bot. Usa `/register` para empezar."
+              ),
+            ],
+            flags,
+          });
+        }
       }
-
-      const embed = new EmbedBuilder({
-        title: "Cumpleaños 🎂",
-        color: 0x00ff00,
-      });
-
-      const fields: APIEmbedField[] = [];
-      for (const monthName in response) {
-        const users = response[monthName].map(
-          (b: any) => ` \`${b.birthdayDay}\` <@${b.discordId}>`
-        );
-        users.sort((a, b) => {
-          const dayA = parseInt(a.split(" ")[1].replace("`", ""));
-          const dayB = parseInt(b.split(" ")[1].replace("`", ""));
-          return dayA - dayB;
-        });
-        fields.push({ name: monthName, value: users.join("\n"), inline: true });
-      }
-      embed.addFields(fields);
 
       return interaction.reply({
-        embeds: [embed],
-        allowedMentions: { repliedUser: false },
+        embeds: [buildBirthdaysEmbed(response, monthName)],
+        flags,
+        allowedMentions: { parse: [] },
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/mod/cums.ts
+++ b/src/slashCommands/mod/cums.ts
@@ -2,6 +2,7 @@ import {
   APIEmbedField,
   ChatInputCommandInteraction,
   EmbedBuilder,
+  MessageFlags,
 } from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import { ApplicationCommandOptionType } from "discord.js";
@@ -42,14 +43,14 @@ const pull: ISlashCommand = {
         if (month < 0 || month > 11) {
           return interaction.reply({
             content: "El mes debe estar entre 1 y 12",
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
         response = await getBirthdaysByMonth(month);
         if (Object.keys(response).length === 0) {
           return interaction.reply({
             content: `No hay cumpleaños en ${calendar.months[month]}`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           });
         }
       } else {

--- a/src/slashCommands/mod/nextcum.test.ts
+++ b/src/slashCommands/mod/nextcum.test.ts
@@ -4,21 +4,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../shared/services/birthday.service");
 
 import * as birthdayService from "../../shared/services/birthday.service";
-import { createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import nextcum from "./nextcum";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const sample = {
+  name: "Diego",
+  discordId: "111",
+  birthdayDay: 17,
+  birthdayMonth: 2,
+};
+
 describe("/nextcum", () => {
   it("fetches the user and replies with the upcoming-birthday embed", async () => {
-    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue({
-      name: "Diego",
-      discordId: "111",
-      birthdayDay: 17,
-      birthdayMonth: 2,
-    });
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
 
     const interaction = createMockInteraction();
     const client = createMockClient();
@@ -28,6 +34,7 @@ describe("/nextcum", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(payload.allowedMentions).toEqual({ parse: [] });
   });
 
   it("replies ephemerally when no birthday is registered", async () => {
@@ -39,5 +46,47 @@ describe("/nextcum", () => {
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  it("renders the canonical fields: real name, mention, fecha, faltan", async () => {
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+
+    const interaction = createMockInteraction();
+    await nextcum.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("🎂 Próximo cumple");
+    expect(embed.description).toContain("Diego");
+    expect(embed.description).toContain("<@111>");
+
+    const fechaField = embed.fields.find((f: any) => f.name === "📅 Fecha");
+    expect(fechaField.value).toContain("17 de Febrero");
+
+    const faltanField = embed.fields.find((f: any) => f.name === "⏳ Faltan");
+    expect(faltanField.value).toMatch(/^<t:\d+:R>$/);
+  });
+
+  it("uses mod-red color and the brand footer (no setAuthor)", async () => {
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+
+    const interaction = createMockInteraction();
+    await nextcum.run(createMockClient(), interaction, []);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.color).toBe(0xed4245);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+
+    const i1 = createMockInteraction();
+    await nextcum.run(createMockClient(), i1, []);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction();
+    await nextcum.run(createMockClient(), i2, [arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/nextcum.test.ts
+++ b/src/slashCommands/mod/nextcum.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/services/birthday.service");
@@ -37,6 +38,6 @@ describe("/nextcum", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/nextcum.ts
+++ b/src/slashCommands/mod/nextcum.ts
@@ -1,4 +1,8 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
 import calendar from "../../shared/constants/calendar";
 import {
@@ -25,7 +29,7 @@ const pull: ISlashCommand = {
       if (!response?.discordId) {
         return interaction.reply({
           content: "No hay cumpleaños próximos registrados.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/mod/nextcum.ts
+++ b/src/slashCommands/mod/nextcum.ts
@@ -1,30 +1,51 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import calendar from "../../shared/constants/calendar";
+import { getNextBirthday } from "../../shared/services/birthday.service";
 import {
   Argument,
   CumUser,
   ISlashCommand,
   Month,
 } from "../../shared/types";
-import { errorHandler, mentionUser } from "../../shared/utils/helpers";
-import { getNextBirthday } from "../../shared/services/birthday.service";
+import { errorHandler, nextBirthdayDate } from "../../shared/utils/helpers";
 
 const pull: ISlashCommand = {
   name: "nextcum",
   category: "mod",
-  description: "Próximo cumpleaños registrado",
+  description: "Muestra el próximo cumpleaños registrado",
   ownerOnly: false,
+  options: [
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: ["/nextcum", "/nextcum private:true"],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
-    _: Argument[]
+    args: Argument[]
   ) => {
     try {
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
       const response: CumUser = await getNextBirthday();
       if (!response?.discordId) {
         return interaction.reply({
@@ -34,28 +55,37 @@ const pull: ISlashCommand = {
       }
 
       const user = await client.users.fetch(response.discordId);
+      const day = response.birthdayDay!;
+      const monthIdx = (response.birthdayMonth! - 1) as Month;
+      const monthName = calendar.months[monthIdx];
+      const next = nextBirthdayDate(day, response.birthdayMonth!);
+      const relativeSeconds = Math.floor(next.getTime() / 1000);
 
-      const embed = new EmbedBuilder({
-        title: "Próximo cumpleaños 🎂",
-        color: 0x00ff00,
-        description: mentionUser(response.discordId),
-        thumbnail: { url: user.avatarURL() ?? "" },
-      }).addFields([
-        {
-          name: "Día",
-          value: `\`${response.birthdayDay!.toString()}\``,
-          inline: true,
-        },
-        {
-          name: "Mes",
-          value: `\`${calendar.months[(response.birthdayMonth! - 1) as Month]}\``,
-          inline: true,
-        },
-      ]);
+      const embed = new EmbedBuilder()
+        .setTitle("🎂 Próximo cumple")
+        .setThumbnail(user.avatarURL() ?? null)
+        .setDescription(
+          `**${response.name}** — <@${response.discordId}>`
+        )
+        .addFields(
+          {
+            name: "📅 Fecha",
+            value: `\`${day} de ${monthName}\``,
+            inline: true,
+          },
+          {
+            name: "⏳ Faltan",
+            value: `<t:${relativeSeconds}:R>`,
+            inline: true,
+          }
+        )
+        .setColor(colorForCategory("mod"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
       return interaction.reply({
         embeds: [embed],
-        allowedMentions: { repliedUser: false },
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+        allowedMentions: { parse: [] },
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/slashCommands/mod/register.test.ts
+++ b/src/slashCommands/mod/register.test.ts
@@ -4,27 +4,33 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../api/dao/user.dao");
 
 import * as userDao from "../../api/dao/user.dao";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import register from "./register";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const validArgs = [
+  arg("name", "Diego"),
+  arg("user", "user-1"),
+  arg("day", 17),
+  arg("month", 2),
+];
+
 describe("/register", () => {
-  it("calls userDao.addUser with the parsed args and replies with the result embed", async () => {
+  it("calls userDao.addUser with the parsed args and replies with a success embed", async () => {
     vi.mocked(userDao.addUser).mockResolvedValue({
       statusCode: 200,
       message: "Usuario agregado",
     } as any);
 
     const interaction = createMockInteraction();
-    await register.run(createMockClient(), interaction, [
-      arg("name", "Diego"),
-      arg("user", "user-1"),
-      arg("day", 17),
-      arg("month", 2),
-    ]);
+    await register.run(createMockClient(), interaction, validArgs);
 
     expect(userDao.addUser).toHaveBeenCalledWith({
       name: "Diego",
@@ -32,28 +38,83 @@ describe("/register", () => {
       birthdayDay: "17",
       birthdayMonth: "2",
     });
-    expect(interaction.reply).toHaveBeenCalledOnce();
-    const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.embeds).toHaveLength(1);
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("✅ Miembro registrado");
+    expect(embed.color).toBe(0xed4245); // mod red
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+  });
+
+  it("renders an error title when the DAO returns non-200", async () => {
+    vi.mocked(userDao.addUser).mockResolvedValue({
+      statusCode: 422,
+      message: "Datos insuficientes",
+    } as any);
+
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, validArgs);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("❌ Error al registrar");
+    expect(embed.description).toContain("Datos insuficientes");
   });
 
   it("rejects ephemerally when the member lacks Administrator", async () => {
-    vi.mocked(userDao.addUser).mockResolvedValue({} as any);
-
     const interaction = createMockInteraction({
       member: { permissions: { has: vi.fn().mockReturnValue(false) } },
     });
 
-    await register.run(createMockClient(), interaction, [
-      arg("name", "Diego"),
-      arg("user", "user-1"),
-      arg("day", 17),
-      arg("month", 2),
-    ]);
+    await register.run(createMockClient(), interaction, validArgs);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(userDao.addUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when day is out of range", async () => {
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, [
+      arg("name", "Diego"),
+      arg("user", "user-1"),
+      arg("day", 99),
+      arg("month", 2),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("día");
+    expect(userDao.addUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects ephemerally when month is out of range", async () => {
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, [
+      arg("name", "Diego"),
+      arg("user", "user-1"),
+      arg("day", 17),
+      arg("month", 13),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("mes");
+    expect(userDao.addUser).not.toHaveBeenCalled();
+  });
+
+  it("becomes ephemeral when private:true is passed", async () => {
+    vi.mocked(userDao.addUser).mockResolvedValue({
+      statusCode: 200,
+      message: "ok",
+    } as any);
+
+    const interaction = createMockInteraction();
+    await register.run(createMockClient(), interaction, [
+      ...validArgs,
+      arg("private", true),
+    ]);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/register.test.ts
+++ b/src/slashCommands/mod/register.test.ts
@@ -1,3 +1,4 @@
+import { MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../api/dao/user.dao");
@@ -52,7 +53,7 @@ describe("/register", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(userDao.addUser).not.toHaveBeenCalled();
   });
 });

--- a/src/slashCommands/mod/register.ts
+++ b/src/slashCommands/mod/register.ts
@@ -1,15 +1,26 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
+
+import * as userDao from "../../api/dao/user.dao";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
-import * as userDao from "../../api/dao/user.dao";
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("mod"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
 
 const pull: ISlashCommand = {
   name: "register",
@@ -42,6 +53,16 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.Integer,
       required: true,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+  examples: [
+    "/register name:Diego user:@diego day:17 month:2",
+    "/register name:Carlos user:@carlos day:5 month:11 private:true",
   ],
   run: async (
     client: ClientDiscord,
@@ -64,6 +85,25 @@ const pull: ISlashCommand = {
       const userId = args.find((a) => a.name === "user")?.value as string;
       const day = args.find((a) => a.name === "day")?.value as number;
       const month = args.find((a) => a.name === "month")?.value as number;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
+
+      // Validate ranges before hitting the DAO so we get a friendly error
+      // instead of letting bad data sneak into Mongo.
+      if (day < 1 || day > 31) {
+        return interaction.reply({
+          content: "El día debe estar entre 1 y 31.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
+      if (month < 1 || month > 12) {
+        return interaction.reply({
+          content: "El mes debe estar entre 1 y 12.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }
 
       const user = await client.users.fetch(userId);
       const data = await userDao.addUser({
@@ -73,13 +113,21 @@ const pull: ISlashCommand = {
         birthdayMonth: month.toString(),
       });
 
-      const embed = new EmbedBuilder({
-        title: `Status: ${data.statusCode}`,
-        description: data.message,
-        timestamp: new Date().toISOString(),
-      }).setColor("Random");
+      const success = data.statusCode === 200;
+      const embed = baseEmbed()
+        .setTitle(success ? "✅ Miembro registrado" : "❌ Error al registrar")
+        .setDescription(data.message)
+        .addFields(
+          { name: "👤 Miembro", value: `<@${user.id}> (**${name}**)`, inline: true },
+          { name: "🎂 Cumpleaños", value: `\`${day}/${month}\``, inline: true }
+        )
+        .setTimestamp(new Date());
 
-      return interaction.reply({ embeds: [embed] });
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+        allowedMentions: { users: [] },
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/register.ts
+++ b/src/slashCommands/mod/register.ts
@@ -55,7 +55,7 @@ const pull: ISlashCommand = {
         )?.has(PermissionFlagsBits.Administrator)
       ) {
         return interaction.reply({
-          content: "Necesitás permiso de Administrator para usar este comando.",
+          content: "Necesitas permiso de Administrator para usar este comando.",
           flags: MessageFlags.Ephemeral,
         });
       }

--- a/src/slashCommands/mod/register.ts
+++ b/src/slashCommands/mod/register.ts
@@ -1,6 +1,7 @@
 import {
   ChatInputCommandInteraction,
   EmbedBuilder,
+  MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
@@ -55,7 +56,7 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "Necesitás permiso de Administrator para usar este comando.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 

--- a/src/slashCommands/mod/say.test.ts
+++ b/src/slashCommands/mod/say.test.ts
@@ -1,4 +1,4 @@
-import { PermissionFlagsBits } from "discord.js";
+import { MessageFlags, PermissionFlagsBits } from "discord.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
@@ -11,7 +11,7 @@ describe("/say", () => {
 
     expect(interaction.reply).toHaveBeenCalledWith({
       content: "Listo.",
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     expect(interaction.channel.send).toHaveBeenCalledWith("hola mundo");
   });
@@ -37,7 +37,7 @@ describe("/say", () => {
 
     expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.ephemeral).toBe(true);
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
     expect(interaction.channel.send).not.toHaveBeenCalled();
   });
 

--- a/src/slashCommands/mod/say.test.ts
+++ b/src/slashCommands/mod/say.test.ts
@@ -5,18 +5,37 @@ import { arg, createMockClient, createMockInteraction } from "../../test-utils/d
 import say from "./say";
 
 describe("/say", () => {
-  it("relays the message as a plain channel send when as_embed is unset", async () => {
+  it("relays the message as a plain channel send when as_embed is unset, then confirms ephemerally", async () => {
     const interaction = createMockInteraction();
-    await say.run(createMockClient(), interaction, [arg("message", "hola mundo")]);
+    await say.run(createMockClient(), interaction, [
+      arg("message", "hola mundo"),
+    ]);
 
+    expect(interaction.channel.send).toHaveBeenCalledWith("hola mundo");
     expect(interaction.reply).toHaveBeenCalledWith({
-      content: "Listo.",
+      content: "✅ Mensaje enviado.",
       flags: MessageFlags.Ephemeral,
     });
-    expect(interaction.channel.send).toHaveBeenCalledWith("hola mundo");
   });
 
-  it("sends an embed when as_embed is true", async () => {
+  it("sends the channel message BEFORE the ephemeral reply (so reply can carry an error if send fails)", async () => {
+    const callOrder: string[] = [];
+    const interaction = createMockInteraction();
+    interaction.channel.send.mockImplementation(async () => {
+      callOrder.push("send");
+      return { id: "msg" };
+    });
+    interaction.reply.mockImplementation(async () => {
+      callOrder.push("reply");
+      return { id: "reply" };
+    });
+
+    await say.run(createMockClient(), interaction, [arg("message", "hola")]);
+
+    expect(callOrder).toEqual(["send", "reply"]);
+  });
+
+  it("sends a white-colored embed when as_embed is true (no brand footer — it's a moderator amplification, not a bot announcement)", async () => {
     const interaction = createMockInteraction();
     await say.run(createMockClient(), interaction, [
       arg("message", "hola"),
@@ -26,6 +45,10 @@ describe("/say", () => {
     expect(interaction.channel.send).toHaveBeenCalledOnce();
     const payload = (interaction.channel.send as any).mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    const embed = payload.embeds[0].data;
+    expect(embed.description).toBe("hola");
+    expect(embed.footer).toBeUndefined();
+    expect(embed.author).toBeUndefined();
   });
 
   it("rejects with an ephemeral notice when the member lacks ManageMessages", async () => {

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -41,7 +41,7 @@ const pull: ISlashCommand = {
         )
       ) {
         return interaction.reply({
-          content: "No tenés los permisos requeridos para usar este comando.",
+          content: "No tienes los permisos requeridos para usar este comando.",
           ephemeral: true,
         });
       }

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -1,6 +1,7 @@
 import {
   ChatInputCommandInteraction,
   EmbedBuilder,
+  MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
@@ -12,7 +13,7 @@ import { errorHandler } from "../../shared/utils/helpers";
 const pull: ISlashCommand = {
   name: "say",
   category: "mod",
-  description: "Botito repite lo que dices",
+  description: "Xiza Bot repite lo que dices",
   ownerOnly: false,
   defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [
@@ -42,14 +43,14 @@ const pull: ISlashCommand = {
       ) {
         return interaction.reply({
           content: "No tienes los permisos requeridos para usar este comando.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
       if (!interaction.channel?.isSendable()) {
         return interaction.reply({
           content: "Este canal no soporta envío de mensajes.",
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
       }
 
@@ -57,7 +58,7 @@ const pull: ISlashCommand = {
       const asEmbed =
         (args.find((a) => a.name === "as_embed")?.value as boolean) ?? false;
 
-      await interaction.reply({ content: "Listo.", ephemeral: true });
+      await interaction.reply({ content: "Listo.", flags: MessageFlags.Ephemeral });
 
       if (asEmbed) {
         const embed = new EmbedBuilder()

--- a/src/slashCommands/mod/say.ts
+++ b/src/slashCommands/mod/say.ts
@@ -1,34 +1,39 @@
 import {
+  ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   EmbedBuilder,
   MessageFlags,
   PermissionFlagsBits,
   PermissionsBitField,
 } from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
 import { Argument, ISlashCommand } from "../../shared/types";
 import { errorHandler } from "../../shared/utils/helpers";
 
 const pull: ISlashCommand = {
   name: "say",
   category: "mod",
-  description: "Xiza Bot repite lo que dices",
+  description: "Repite un mensaje en el canal",
   ownerOnly: false,
   defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
   options: [
     {
       name: "message",
-      description: "Texto a repetir",
+      description: "Texto a publicar",
       type: ApplicationCommandOptionType.String,
       required: true,
     },
     {
       name: "as_embed",
-      description: "Mandarlo como embed",
+      description: "Publicar como embed (default: false)",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     },
+  ],
+  examples: [
+    "/say message:hola a todos",
+    "/say message:Anuncio importante as_embed:true",
   ],
   run: async (
     _: ClientDiscord,
@@ -58,16 +63,22 @@ const pull: ISlashCommand = {
       const asEmbed =
         (args.find((a) => a.name === "as_embed")?.value as boolean) ?? false;
 
-      await interaction.reply({ content: "Listo.", flags: MessageFlags.Ephemeral });
-
+      // IMPORTANT: send first, confirm second. If channel.send fails (eg. bot
+      // missing Send permission), the catch fires and errorHandler can still
+      // reply because we haven't replied yet.
       if (asEmbed) {
-        const embed = new EmbedBuilder()
-          .setDescription(text)
-          .setColor("White");
+        // White color and no footer — the embed is meant to look like a
+        // moderator-amplified message, not a bot-branded announcement.
+        const embed = new EmbedBuilder().setDescription(text).setColor("White");
         await interaction.channel.send({ embeds: [embed] });
       } else {
         await interaction.channel.send(text);
       }
+
+      return interaction.reply({
+        content: "✅ Mensaje enviado.",
+        flags: MessageFlags.Ephemeral,
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/who.test.ts
+++ b/src/slashCommands/mod/who.test.ts
@@ -1,28 +1,46 @@
+import { Collection, MessageFlags } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../shared/services/user.service");
 
 import * as userService from "../../shared/services/user.service";
-import { arg, createMockClient, createMockInteraction } from "../../test-utils/discord-mocks";
+import {
+  arg,
+  createMockClient,
+  createMockInteraction,
+} from "../../test-utils/discord-mocks";
 import who from "./who";
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("/who", () => {
-  const sampleUser = {
-    name: "Diego",
-    discordId: "111",
-    birthdayDay: "17",
-    birthdayMonth: "2",
-  };
+const sampleUser = {
+  name: "Pineappletooth",
+  discordId: "111",
+  birthdayDay: "5",
+  birthdayMonth: "5",
+};
 
+const stubFetchedUser = (client: any, overrides: Partial<any> = {}) => {
+  vi.mocked(client.users.fetch).mockResolvedValue({
+    id: "111",
+    tag: "PaviCasado#0001",
+    username: "PaviCasado",
+    avatarURL: () => "https://example.com/avatar.png",
+    createdTimestamp: new Date(2020, 0, 15).getTime(),
+    ...overrides,
+  } as any);
+};
+
+describe("/who", () => {
   it("looks up by user option when provided", async () => {
     vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const interaction = createMockInteraction();
-    await who.run(createMockClient(), interaction, [arg("user", "111")]);
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("user", "111")]);
 
     expect(userService.getUserById).toHaveBeenCalledWith("111");
     expect(interaction.reply).toHaveBeenCalledOnce();
@@ -30,20 +48,117 @@ describe("/who", () => {
 
   it("looks up by name when only the name option is provided", async () => {
     vi.mocked(userService.getUserByName).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const interaction = createMockInteraction();
-    await who.run(createMockClient(), interaction, [arg("name", "Diego")]);
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("name", "Pineappletooth")]);
 
-    expect(userService.getUserByName).toHaveBeenCalledWith("Diego");
+    expect(userService.getUserByName).toHaveBeenCalledWith("Pineappletooth");
     expect(interaction.reply).toHaveBeenCalledOnce();
   });
 
   it("falls back to the caller's discordId when neither option is provided", async () => {
     vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
 
-    const interaction = createMockInteraction({ user: { id: "caller-1" } });
-    await who.run(createMockClient(), interaction, []);
+    const interaction = createMockInteraction({
+      user: { id: "caller-1" },
+      guild: null,
+    });
+    await who.run(client, interaction, []);
 
     expect(userService.getUserById).toHaveBeenCalledWith("caller-1");
+  });
+
+  it("uses the real name as the embed title (not 'CUMpleaños')", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
+
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("user", "111")]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe("Pineappletooth");
+    expect(embed.color).toBe(0xed4245);
+    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
+    expect(embed.author).toBeUndefined();
+  });
+
+  it("renders the canonical fields: Discord, birthday, next birthday, account created", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
+
+    const interaction = createMockInteraction({ guild: null });
+    await who.run(client, interaction, [arg("user", "111")]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const names = embed.fields.map((f: any) => f.name);
+    expect(names).toContain("👤 Discord");
+    expect(names).toContain("🎂 Cumpleaños");
+    expect(names).toContain("📅 Próximo cumple");
+    expect(names).toContain("📆 Cuenta creada");
+
+    const cumple = embed.fields.find((f: any) => f.name === "🎂 Cumpleaños");
+    expect(cumple.value).toContain("5 de Mayo");
+
+    // Discord relative time format used for next birthday
+    const next = embed.fields.find((f: any) => f.name === "📅 Próximo cumple");
+    expect(next.value).toMatch(/^<t:\d+:R>$/);
+  });
+
+  it("includes guild-specific fields (joined-at + top roles) when in a guild", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
+
+    const fakeRoles = new Collection<string, any>([
+      ["everyone", { id: "@e", name: "@everyone", position: 0 }],
+      ["mod", { id: "modrole", name: "Mod", position: 5 }],
+      ["fan", { id: "fanrole", name: "Fan", position: 2 }],
+    ]);
+
+    const guildMember = {
+      joinedTimestamp: new Date(2022, 5, 1).getTime(),
+      roles: { cache: fakeRoles },
+    };
+
+    const interaction = createMockInteraction({
+      guild: {
+        members: { fetch: vi.fn().mockResolvedValue(guildMember) },
+      },
+    });
+
+    await who.run(client, interaction, [arg("user", "111")]);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
+    const names = embed.fields.map((f: any) => f.name);
+    expect(names).toContain("🎉 En el servidor desde");
+    expect(names).toContain("✨ Roles principales");
+
+    // @everyone filtered out, top role first
+    const rolesField = embed.fields.find(
+      (f: any) => f.name === "✨ Roles principales"
+    );
+    expect(rolesField.value).toContain("<@&modrole>");
+    expect(rolesField.value).toContain("<@&fanrole>");
+    expect(rolesField.value).not.toContain("@everyone");
+  });
+
+  it("public by default, ephemeral when private:true", async () => {
+    vi.mocked(userService.getUserById).mockResolvedValue(sampleUser);
+    const client = createMockClient();
+    stubFetchedUser(client);
+
+    const i1 = createMockInteraction({ guild: null });
+    await who.run(client, i1, [arg("user", "111")]);
+    expect(i1.reply.mock.calls[0][0].flags).toBeUndefined();
+
+    const i2 = createMockInteraction({ guild: null });
+    await who.run(client, i2, [arg("user", "111"), arg("private", true)]);
+    expect(i2.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
   });
 });

--- a/src/slashCommands/mod/who.ts
+++ b/src/slashCommands/mod/who.ts
@@ -1,18 +1,66 @@
-import { ChatInputCommandInteraction, EmbedBuilder } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  GuildMember,
+  MessageFlags,
+} from "discord.js";
+
 import ClientDiscord from "../../shared/classes/ClientDiscord";
-import { ApplicationCommandOptionType } from "discord.js";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
 import calendar from "../../shared/constants/calendar";
-import { Argument, ISlashCommand, Month } from "../../shared/types";
-import { errorHandler, mentionUser } from "../../shared/utils/helpers";
 import {
   getUserById,
   getUserByName,
 } from "../../shared/services/user.service";
+import { Argument, ISlashCommand, Month } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+/**
+ * Returns the next occurrence of (day/month) starting from `from`. If the
+ * birthday already happened this year, jumps to next year. Doesn't try to
+ * be clever about Feb 29 in non-leap years — JS Date will roll over (Feb 30
+ * → Mar 2), which is acceptable for a friend-server bot.
+ */
+const nextBirthdayDate = (day: number, month: number, from: Date): Date => {
+  const candidate = new Date(from.getFullYear(), month - 1, day);
+  if (candidate.getTime() < from.getTime()) {
+    return new Date(from.getFullYear() + 1, month - 1, day);
+  }
+  return candidate;
+};
+
+const discordRelative = (date: Date | number) => {
+  const seconds = Math.floor(
+    (typeof date === "number" ? date : date.getTime()) / 1000
+  );
+  return `<t:${seconds}:R>`;
+};
+
+const discordDate = (date: Date | number) => {
+  const seconds = Math.floor(
+    (typeof date === "number" ? date : date.getTime()) / 1000
+  );
+  return `<t:${seconds}:D>`;
+};
+
+const formatTopRoles = (member: GuildMember): string | null => {
+  const roles = member.roles.cache
+    .filter((r) => r.name !== "@everyone")
+    .sort((a, b) => b.position - a.position)
+    .first(3);
+  if (roles.length === 0) return null;
+  return roles.map((r) => `<@&${r.id}>`).join(" ");
+};
 
 const pull: ISlashCommand = {
   name: "who",
   category: "mod",
-  description: "Leer datos de un miembro de Gmi2",
+  description: "Muestra los datos de un miembro de Gmi2",
   ownerOnly: false,
   options: [
     {
@@ -27,7 +75,14 @@ const pull: ISlashCommand = {
       type: ApplicationCommandOptionType.String,
       required: false,
     },
+    {
+      name: "private",
+      description: "Mostrar la respuesta solo a ti (default: público)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
   ],
+  examples: ["/who", "/who user:@diego", "/who name:Diego", "/who private:true"],
   run: async (
     client: ClientDiscord,
     interaction: ChatInputCommandInteraction,
@@ -40,40 +95,89 @@ const pull: ISlashCommand = {
       const name = args.find((a) => a.name === "name")?.value as
         | string
         | undefined;
+      const isPrivate =
+        (args.find((a) => a.name === "private")?.value as
+          | boolean
+          | undefined) ?? false;
 
       let res;
-      let userIdToFetch: string;
-
       if (userId) {
         res = await getUserById(userId);
-        userIdToFetch = res.discordId;
       } else if (name) {
         res = await getUserByName(name);
-        userIdToFetch = res.discordId;
       } else {
         res = await getUserById(interaction.user.id);
-        userIdToFetch = res.discordId;
       }
 
       if (!res) throw new Error("No se encontró usuario");
 
-      const user = await client.users.fetch(userIdToFetch);
+      const user = await client.users.fetch(res.discordId);
+      const guildMember = interaction.guild
+        ? await interaction.guild.members.fetch(res.discordId).catch(() => null)
+        : null;
 
-      const embed = new EmbedBuilder({
-        title: "CUMpleaños 🎂",
-        thumbnail: { url: user.avatarURL() ?? "" },
-        description: mentionUser(res.discordId),
-        fields: [
-          {
-            name: " ",
-            value: `\`${res.birthdayDay} de ${
-              calendar.months[(parseInt(res.birthdayMonth) - 1) as Month]
-            }\``,
-          },
-        ],
-      }).setColor("Random");
+      const day = parseInt(res.birthdayDay);
+      const month = parseInt(res.birthdayMonth);
+      const monthName = calendar.months[(month - 1) as Month] ?? "?";
+      const nextBday = nextBirthdayDate(day, month, new Date());
 
-      return interaction.reply({ embeds: [embed] });
+      const fields: { name: string; value: string; inline?: boolean }[] = [
+        {
+          name: "👤 Discord",
+          value: `<@${res.discordId}> (\`${user.tag ?? user.username}\`)`,
+          inline: false,
+        },
+        {
+          name: "🎂 Cumpleaños",
+          value: `\`${day} de ${monthName}\``,
+          inline: true,
+        },
+        {
+          name: "📅 Próximo cumple",
+          value: discordRelative(nextBday),
+          inline: true,
+        },
+        {
+          name: "📆 Cuenta creada",
+          value: discordDate(user.createdTimestamp),
+          inline: true,
+        },
+      ];
+
+      if (guildMember?.joinedTimestamp) {
+        fields.push({
+          name: "🎉 En el servidor desde",
+          value: discordDate(guildMember.joinedTimestamp),
+          inline: true,
+        });
+      }
+
+      if (guildMember) {
+        const topRoles = formatTopRoles(guildMember);
+        if (topRoles) {
+          fields.push({
+            name: "✨ Roles principales",
+            value: topRoles,
+            inline: false,
+          });
+        }
+      }
+
+      // No setDescription here on purpose: the '👤 Discord' field already
+      // carries the mention (and the tag), so a description with just the
+      // mention was redundant.
+      const embed = new EmbedBuilder()
+        .setTitle(res.name)
+        .setThumbnail(user.avatarURL() ?? null)
+        .addFields(fields)
+        .setColor(colorForCategory("mod"))
+        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+      return interaction.reply({
+        embeds: [embed],
+        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+        allowedMentions: { parse: [] },
+      });
     } catch (error) {
       errorHandler(interaction, error);
     }

--- a/src/slashCommands/mod/who.ts
+++ b/src/slashCommands/mod/who.ts
@@ -18,21 +18,7 @@ import {
   getUserByName,
 } from "../../shared/services/user.service";
 import { Argument, ISlashCommand, Month } from "../../shared/types";
-import { errorHandler } from "../../shared/utils/helpers";
-
-/**
- * Returns the next occurrence of (day/month) starting from `from`. If the
- * birthday already happened this year, jumps to next year. Doesn't try to
- * be clever about Feb 29 in non-leap years — JS Date will roll over (Feb 30
- * → Mar 2), which is acceptable for a friend-server bot.
- */
-const nextBirthdayDate = (day: number, month: number, from: Date): Date => {
-  const candidate = new Date(from.getFullYear(), month - 1, day);
-  if (candidate.getTime() < from.getTime()) {
-    return new Date(from.getFullYear() + 1, month - 1, day);
-  }
-  return candidate;
-};
+import { errorHandler, nextBirthdayDate } from "../../shared/utils/helpers";
 
 const discordRelative = (date: Date | number) => {
   const seconds = Math.floor(
@@ -119,7 +105,7 @@ const pull: ISlashCommand = {
       const day = parseInt(res.birthdayDay);
       const month = parseInt(res.birthdayMonth);
       const monthName = calendar.months[(month - 1) as Month] ?? "?";
-      const nextBday = nextBirthdayDate(day, month, new Date());
+      const nextBday = nextBirthdayDate(day, month);
 
       const fields: { name: string; value: string; inline?: boolean }[] = [
         {

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -14,6 +14,7 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
   const reply = vi.fn().mockResolvedValue({ id: "reply-msg" });
   const deferReply = vi.fn().mockResolvedValue(undefined);
   const editReply = vi.fn().mockResolvedValue({ id: "edited-msg" });
+  const deleteReply = vi.fn().mockResolvedValue(undefined);
   const channelSend = vi.fn().mockResolvedValue({
     id: "channel-msg",
     createdAt: new Date(),
@@ -24,10 +25,14 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
     reply,
     deferReply,
     editReply,
+    deleteReply,
     user: {
       id: "user-1",
       tag: "tester#0001",
       displayAvatarURL: () => "https://example.com/avatar.png",
+      createDM: vi.fn().mockResolvedValue({
+        send: vi.fn().mockResolvedValue({ id: "dm-msg" }),
+      }),
     },
     member: {
       permissions: {

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -77,7 +77,19 @@ export const createMockClient = (overrides: Record<string, any> = {}) =>
     slashCommands: new Collection<string, any>(),
     commands: new Collection<string, any>(),
     ws: { ping: 50 },
-    channels: { cache: new Collection<string, any>() },
+    channels: {
+      cache: new Collection<string, any>(),
+      fetch: vi.fn().mockImplementation((id: string) =>
+        Promise.resolve({
+          id,
+          name: `channel-${id}`,
+          type: 0, // ChannelType.GuildText
+          guild: { id: "guild-1", name: "TestGuild" },
+          parent: null,
+          nsfw: false,
+        })
+      ),
+    },
     guilds: { cache: new Collection<string, any>() },
     application: {
       commands: {

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -46,6 +46,7 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
       bulkDelete: vi.fn().mockResolvedValue({ size: 5 }),
     },
     createdAt: new Date(),
+    createdTimestamp: Date.now(),
     commandName: "test",
     isChatInputCommand: () => true,
     ...overrides,


### PR DESCRIPTION
## Release v0.4.0

Hito grande: los 18 slash commands originales pasaron por el facelift completo, y se agregan 6 comandos nuevos. Bot va de **18 → 24 comandos**.

## Highlights

### Branding consistente en los 18 comandos
- Paleta Discord-native: info azul (#5865F2), fun amarillo (#FEE75C), mod rojo (#ED4245)
- Sin `setAuthor` (decisión post-revisión: el header del bot ya identifica al bot, no hace falta repetirlo)
- Footer estándar `Xiza Bot vX.Y.Z`
- Convención de emojis distintos entre title y field names
- Convención `private:` opt-in (default público para casi todo, excepto info/admin commands)

### Highlights por comando
- **/help** — autocomplete, dropdown, botón "Volver al listado"
- **/love** — persistencia en Mongo + subcomandos owner para curar overrides (set/reset)
- **/clear** — DM al moderador con recap de mensajes eliminados (texto + archivos), evita duplicar con el listener `messageDelete`
- **/poke** — color por tipo del Pokémon, autocomplete, error handling
- **/shuffle** — animación de sorteo cuando se piden ganadores; helper `shuffle()` ahora es puro
- **/ahorcado** — solo play, dedup de letras repetidas, eliminación por palabra-completa errada
- **/ruleta** — embed alive branded, idle timeout, validación de duplicados

### 6 nuevos comandos
- `/about` (info) — versión, stack, link al repo
- `/uptime` (info) — tiempo activo + relative \`<t:X:R>\`
- `/changelog` (info) — hardcoded source con autocomplete por versión
- `/feedback` (info) — DM al owner con \`anonymous:\` opt-in
- `/team` (fun) — divide lista en N equipos balanceados (round-robin)
- `/cum` (mod, owner-only) — dispara manualmente el cron de cumples del día

### Otros refactors técnicos relevantes
- **Static manifests** (PR #50) — los loaders dinámicos con \`readdirSync\` + \`import()\` reemplazados por arrays estáticos. Compatible con \`tsx watch\` y file watchers.
- **Ephemeral migration** — todos los \`ephemeral: true\` migrados a \`flags: MessageFlags.Ephemeral\` (silencia el deprecation warning de discord.js v14)
- **Helper compartidos** — \`formatUptime\`, \`nextBirthdayDate\`, \`shuffle\` puro
- **i18n** — strings del bot en español neutral (tuteo)

## Métricas

- **Tests**: 284/284 passing (subió de 142)
- **Comandos**: 18 → 24
- **PRs mergeados**: 17 (#46–#62)
- **TypeScript**: 5.9, Node 22, discord.js 14, Mongoose 8

## Test plan
- [x] CI verde en cada PR del milestone
- [x] \`pnpm test\` → 284/284
- [x] \`tsc --noEmit\` → limpio
- [x] Validado en Discord comando por comando durante el desarrollo