### PR TITLE
feat: .env.example, messageUpdate log, /nextcum arrows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Discord
+TOKEN=              # Token del bot (Discord Developer Portal)
+OWNERID=            # Tu Discord ID — gate de comandos owner-only
+GMI2_CHANNEL=       # ID del canal principal del server (crons + listeners)
+
+# Database
+MONGODB=            # Connection string de MongoDB
+
+# Assets
+PHOTO_ROOT=         # Base URL de Cloudinary para GIFs/imágenes
+
+# Opcionales (tienen default)
+PORT=3000                 # Puerto Express (health-check de Railway)
+MAX_DELETE_MESSAGES=20    # Cap de /clear
+
+# Reservadas (dashboard futuro)
+API=http://localhost:3000
+API_YTB=

--- a/src/events/message/messageUpdate.test.ts
+++ b/src/events/message/messageUpdate.test.ts
@@ -27,6 +27,7 @@ const baseOldMessage = (overrides: Record<string, any> = {}) => ({
 
 const baseNewMessage = (overrides: Record<string, any> = {}) => ({
   content: "edited",
+  url: "https://discord.com/channels/1/2/3",
   ...overrides,
 });
 
@@ -95,7 +96,10 @@ describe("messageUpdate", () => {
       client
     );
     expect(send).toHaveBeenCalledOnce();
-    const payload = send.mock.calls[0][0];
-    expect(payload.embeds).toHaveLength(1);
+    const embed = send.mock.calls[0][0].embeds[0].data;
+    expect(embed.description).toBe("original"); // original as the body
+    expect(embed.fields[0].value).toBe("edited"); // new content below
+    expect(embed.fields[1].value).toContain("Ir al mensaje");
+    expect(embed.footer.text).toBe("✏️ Editado");
   });
 });

--- a/src/events/message/messageUpdate.ts
+++ b/src/events/message/messageUpdate.ts
@@ -1,52 +1,52 @@
 import { EmbedBuilder, Message } from "discord.js";
+
 import config from "../../config";
 import ClientDiscord from "../../shared/classes/ClientDiscord";
+
+const EDIT_COLOR = 0xfee75c; // yellow — signal of change (vs red for delete)
+const MAX_DESCRIPTION = 4000; // embed description ceiling (real max 4096)
+const MAX_FIELD = 1000; // embed field value ceiling (real max 1024)
+
+const trim = (s: string, max: number) =>
+  s.length > max ? s.slice(0, max) + "…" : s;
 
 export default {
   name: "messageUpdate",
   type: "message",
-  // just work on the first message update, and just in gmi2 channel
+  // Mirror of messageDelete: DM the owner a preview that reads like the
+  // original message (author + original content), with the edit details below.
   async execute(
     oldMessage: Message,
     newMessage: Message,
     client: ClientDiscord
   ) {
     if (oldMessage?.author?.bot) return;
-
-    if (oldMessage?.content === newMessage?.content) return;
-
     if (!oldMessage?.content) return;
-
+    if (oldMessage.content === newMessage?.content) return; // embed/pin updates fire this too
     if (oldMessage?.channel?.id !== config.gmi2Channel) return;
 
-    const count = 1950;
+    const owner = await client.users.fetch(config.ownerId, { cache: false });
 
-    const original =
-      oldMessage.content.slice(0, count) +
-      (oldMessage.content.length > count ? "..." : "");
-    const edited =
-      newMessage.content.slice(0, count) +
-      (newMessage.content.length > count ? "..." : "");
-
-    const log = new EmbedBuilder()
+    const embed = new EmbedBuilder()
       .setAuthor({
-        name: oldMessage.author.tag,
+        name: oldMessage.author.username || oldMessage.author.tag,
         iconURL: oldMessage.author.displayAvatarURL(),
       })
-      .setDescription(
-        `Message sent by ${oldMessage.author} **edited** in ${oldMessage.channel}`
-      )
+      .setDescription(trim(oldMessage.content, MAX_DESCRIPTION))
       .addFields(
-        { name: "Original", value: original },
-        { name: "Edited", value: edited }
+        {
+          name: "📝 Editado a",
+          value: trim(newMessage.content || "_(vacío)_", MAX_FIELD),
+        },
+        {
+          name: "🔗 Mensaje",
+          value: `[Ir al mensaje](${newMessage.url})`,
+        }
       )
-      .setTimestamp()
-      .setColor("Yellow");
+      .setColor(EDIT_COLOR)
+      .setTimestamp(oldMessage.createdTimestamp ?? new Date())
+      .setFooter({ text: "✏️ Editado" });
 
-    const user = await client.users.fetch(config.ownerId, {
-      cache: false,
-    });
-
-    await user.send({ embeds: [log] });
+    await owner.send({ embeds: [embed] });
   },
 };

--- a/src/slashCommands/mod/nextcum.test.ts
+++ b/src/slashCommands/mod/nextcum.test.ts
@@ -15,41 +15,56 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const sample = {
-  name: "Diego",
-  discordId: "111",
-  birthdayDay: 17,
-  birthdayMonth: 2,
+// One person in Febrero → single-entry, no nav buttons.
+const oneBirthday = {
+  Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+};
+
+// Two people across months → nav buttons show.
+const twoBirthdays = {
+  Febrero: [{ name: "Diego", discordId: "111", birthdayDay: 17 }],
+  Mayo: [{ name: "Ana", discordId: "222", birthdayDay: 5 }],
 };
 
 describe("/nextcum", () => {
-  it("fetches the user and replies with the upcoming-birthday embed", async () => {
-    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+  it("replies with the upcoming-birthday embed and no buttons for a single entry", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue(oneBirthday);
 
     const interaction = createMockInteraction();
     const client = createMockClient();
     await nextcum.run(client, interaction, []);
 
     expect(client.users.fetch).toHaveBeenCalledWith("111");
-    expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
     expect(payload.embeds).toHaveLength(1);
+    expect(payload.components).toEqual([]); // no nav for a single entry
     expect(payload.allowedMentions).toEqual({ parse: [] });
   });
 
-  it("replies ephemerally when no birthday is registered", async () => {
-    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue({} as any);
+  it("shows nav buttons when there is more than one birthday", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue(twoBirthdays);
 
     const interaction = createMockInteraction();
     await nextcum.run(createMockClient(), interaction, []);
 
-    expect(interaction.reply).toHaveBeenCalledOnce();
     const payload = interaction.reply.mock.calls[0][0];
-    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.components).toHaveLength(1);
+    expect(interaction.fetchReply).toHaveBeenCalled(); // collector attached
   });
 
-  it("renders the canonical fields: real name, mention, fecha, faltan", async () => {
-    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+  it("replies ephemerally when no birthday is registered", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue({});
+
+    const interaction = createMockInteraction();
+    await nextcum.run(createMockClient(), interaction, []);
+
+    const payload = interaction.reply.mock.calls[0][0];
+    expect(payload.flags).toBe(MessageFlags.Ephemeral);
+    expect(payload.content).toContain("No hay");
+  });
+
+  it("renders the canonical fields: real name, mention, fecha, faltan, position", async () => {
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue(oneBirthday);
 
     const interaction = createMockInteraction();
     await nextcum.run(createMockClient(), interaction, []);
@@ -58,28 +73,28 @@ describe("/nextcum", () => {
     expect(embed.title).toBe("🎂 Próximo cumple");
     expect(embed.description).toContain("Diego");
     expect(embed.description).toContain("<@111>");
-
-    const fechaField = embed.fields.find((f: any) => f.name === "📅 Fecha");
-    expect(fechaField.value).toContain("17 de Febrero");
-
-    const faltanField = embed.fields.find((f: any) => f.name === "⏳ Faltan");
-    expect(faltanField.value).toMatch(/^<t:\d+:R>$/);
+    expect(
+      embed.fields.find((f: any) => f.name === "📅 Fecha").value
+    ).toContain("17 de Febrero");
+    expect(
+      embed.fields.find((f: any) => f.name === "⏳ Faltan").value
+    ).toMatch(/^<t:\d+:R>$/);
+    expect(embed.footer.text).toMatch(/Xiza Bot v[\d.]+ · 1\/1/);
   });
 
   it("uses mod-red color and the brand footer (no setAuthor)", async () => {
-    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue(oneBirthday);
 
     const interaction = createMockInteraction();
     await nextcum.run(createMockClient(), interaction, []);
 
     const embed = interaction.reply.mock.calls[0][0].embeds[0].data;
     expect(embed.color).toBe(0xed4245);
-    expect(embed.footer.text).toMatch(/Xiza Bot v\d+/);
     expect(embed.author).toBeUndefined();
   });
 
   it("public by default, ephemeral when private:true", async () => {
-    vi.mocked(birthdayService.getNextBirthday).mockResolvedValue(sample);
+    vi.mocked(birthdayService.getBirthdays).mockResolvedValue(oneBirthday);
 
     const i1 = createMockInteraction();
     await nextcum.run(createMockClient(), i1, []);

--- a/src/slashCommands/mod/nextcum.ts
+++ b/src/slashCommands/mod/nextcum.ts
@@ -1,6 +1,10 @@
 import {
+  ActionRowBuilder,
   ApplicationCommandOptionType,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
+  ComponentType,
   EmbedBuilder,
   MessageFlags,
 } from "discord.js";
@@ -12,19 +16,84 @@ import {
   colorForCategory,
 } from "../../shared/constants/branding";
 import calendar from "../../shared/constants/calendar";
-import { getNextBirthday } from "../../shared/services/birthday.service";
-import {
-  Argument,
-  CumUser,
-  ISlashCommand,
-  Month,
-} from "../../shared/types";
+import { getBirthdays } from "../../shared/services/birthday.service";
+import { Argument, ISlashCommand, Month } from "../../shared/types";
 import { errorHandler, nextBirthdayDate } from "../../shared/utils/helpers";
+
+const PREV_ID = "nextcum-prev";
+const NEXT_ID = "nextcum-next";
+const NAV_TIMEOUT_MS = 60_000;
+
+type Entry = {
+  name: string;
+  discordId: string;
+  day: number;
+  month: number;
+  avatar: string | null;
+};
+
+// calendar.months is a 0-indexed map { 0: "Enero", ... }; invert it once.
+const monthNumber = (name: string): number => {
+  const entry = Object.entries(calendar.months).find(([, v]) => v === name);
+  return entry ? parseInt(entry[0]) + 1 : 1;
+};
+
+/** Flatten the month-grouped birthdays into one list sorted by next occurrence. */
+const sortedEntries = (grouped: Record<string, any[]>): Entry[] => {
+  const flat: Omit<Entry, "avatar">[] = [];
+  for (const [monthName, users] of Object.entries(grouped)) {
+    const month = monthNumber(monthName);
+    for (const u of users) {
+      flat.push({
+        name: u.name,
+        discordId: u.discordId,
+        day: parseInt(u.birthdayDay),
+        month,
+      });
+    }
+  }
+  return flat
+    .map((e) => ({ ...e, avatar: null }))
+    .sort(
+      (a, b) =>
+        nextBirthdayDate(a.day, a.month).getTime() -
+        nextBirthdayDate(b.day, b.month).getTime()
+    );
+};
+
+const renderEmbed = (e: Entry, idx: number, total: number) => {
+  const monthName = calendar.months[(e.month - 1) as Month];
+  const relative = Math.floor(
+    nextBirthdayDate(e.day, e.month).getTime() / 1000
+  );
+  return new EmbedBuilder()
+    .setTitle("🎂 Próximo cumple")
+    .setThumbnail(e.avatar)
+    .setDescription(`**${e.name}** — <@${e.discordId}>`)
+    .addFields(
+      { name: "📅 Fecha", value: `\`${e.day} de ${monthName}\``, inline: true },
+      { name: "⏳ Faltan", value: `<t:${relative}:R>`, inline: true }
+    )
+    .setColor(colorForCategory("mod"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION} · ${idx + 1}/${total}` });
+};
+
+const navRow = () =>
+  new ActionRowBuilder<ButtonBuilder>().setComponents(
+    new ButtonBuilder()
+      .setCustomId(PREV_ID)
+      .setEmoji("⬅️")
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(NEXT_ID)
+      .setEmoji("➡️")
+      .setStyle(ButtonStyle.Secondary)
+  );
 
 const pull: ISlashCommand = {
   name: "nextcum",
   category: "mod",
-  description: "Muestra el próximo cumpleaños registrado",
+  description: "Muestra el próximo cumpleaños registrado (con flechas para navegar)",
   ownerOnly: false,
   options: [
     {
@@ -45,47 +114,58 @@ const pull: ISlashCommand = {
         (args.find((a) => a.name === "private")?.value as
           | boolean
           | undefined) ?? false;
+      const flags = isPrivate ? MessageFlags.Ephemeral : undefined;
 
-      const response: CumUser = await getNextBirthday();
-      if (!response?.discordId) {
+      const entries = sortedEntries(await getBirthdays());
+      if (entries.length === 0) {
         return interaction.reply({
           content: "No hay cumpleaños próximos registrados.",
           flags: MessageFlags.Ephemeral,
         });
       }
 
-      const user = await client.users.fetch(response.discordId);
-      const day = response.birthdayDay!;
-      const monthIdx = (response.birthdayMonth! - 1) as Month;
-      const monthName = calendar.months[monthIdx];
-      const next = nextBirthdayDate(day, response.birthdayMonth!);
-      const relativeSeconds = Math.floor(next.getTime() / 1000);
+      // ponytail: pre-fetch every avatar so navigation is sync; fine for a
+      // friend server, switch to per-click fetch if the list ever grows big.
+      await Promise.all(
+        entries.map(async (e) => {
+          const u = await client.users.fetch(e.discordId).catch(() => null);
+          e.avatar = u?.avatarURL() ?? null;
+        })
+      );
 
-      const embed = new EmbedBuilder()
-        .setTitle("🎂 Próximo cumple")
-        .setThumbnail(user.avatarURL() ?? null)
-        .setDescription(
-          `**${response.name}** — <@${response.discordId}>`
-        )
-        .addFields(
-          {
-            name: "📅 Fecha",
-            value: `\`${day} de ${monthName}\``,
-            inline: true,
-          },
-          {
-            name: "⏳ Faltan",
-            value: `<t:${relativeSeconds}:R>`,
-            inline: true,
-          }
-        )
-        .setColor(colorForCategory("mod"))
-        .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+      let idx = 0;
+      const total = entries.length;
+      const single = total === 1;
 
-      return interaction.reply({
-        embeds: [embed],
-        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+      await interaction.reply({
+        embeds: [renderEmbed(entries[idx], idx, total)],
+        components: single ? [] : [navRow()],
+        flags,
         allowedMentions: { parse: [] },
+      });
+
+      if (single) return;
+
+      const message = await interaction.fetchReply();
+      const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        time: NAV_TIMEOUT_MS,
+        filter: (i) => i.user.id === interaction.user.id,
+      });
+
+      collector.on("collect", async (i) => {
+        idx =
+          i.customId === NEXT_ID
+            ? (idx + 1) % total
+            : (idx - 1 + total) % total;
+        await i.update({
+          embeds: [renderEmbed(entries[idx], idx, total)],
+          components: [navRow()],
+        });
+      });
+
+      collector.on("end", async () => {
+        await interaction.editReply({ components: [] }).catch(() => {});
       });
     } catch (error) {
       errorHandler(interaction, error);

--- a/src/test-utils/discord-mocks.ts
+++ b/src/test-utils/discord-mocks.ts
@@ -15,6 +15,10 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
   const deferReply = vi.fn().mockResolvedValue(undefined);
   const editReply = vi.fn().mockResolvedValue({ id: "edited-msg" });
   const deleteReply = vi.fn().mockResolvedValue(undefined);
+  const fetchReply = vi.fn().mockResolvedValue({
+    id: "reply-msg",
+    createMessageComponentCollector: vi.fn(() => ({ on: vi.fn() })),
+  });
   const channelSend = vi.fn().mockResolvedValue({
     id: "channel-msg",
     createdAt: new Date(),
@@ -26,6 +30,7 @@ export const createMockInteraction = (overrides: Record<string, any> = {}) => {
     deferReply,
     editReply,
     deleteReply,
+    fetchReply,
     user: {
       id: "user-1",
       tag: "tester#0001",


### PR DESCRIPTION
Batch de items chicos e independientes de la lista de features.

## 1. `.env.example`
Copia comentada de las env vars de `src/config/index.ts` (requeridas + opcionales + reservadas).

## 3. Log de mensajes editados (`messageUpdate`)
Espejo del `messageDelete`: DM al owner con layout que lee como el mensaje original — autor arriba, **contenido original** como cuerpo, y abajo los detalles del edit (nuevo contenido + link al mensaje). Footer `✏️ Editado`, amarillo. Skip si el content no cambió (Discord dispara el evento por embeds/pins también).

## 4. Flechas en `/nextcum`
`⬅️`/`➡️` para navegar entre cumpleaños ordenados por próxima fecha. Reusa `getBirthdays()` (sin DAO nuevo), aplana + ordena. Con 1 solo cumple no muestra botones. Collector del invocador, 60s, strippea al expirar. Footer muestra posición (N/M).

## Notas
- Item #2 (\"1 mensajes borrados\") ya estaba resuelto en el código actual (`Se eliminó 1 mensaje` / `Se eliminaron N mensajes`); era el string viejo pre-facelift, se corrige en prod al deployar v0.4.1.
- Item #7 (log solo al owner) omitido por ahora a pedido tuyo — el listener ya DMea solo a `config.ownerId`.

## Tests
285/285 (+1 nextcum). tsc limpio.

- [ ] `/nextcum` con 2+ cumples → flechas navegan con wrap
- [ ] `/nextcum` con 1 cumple → sin flechas
- [ ] Editar un mensaje en gmi2 → DM con original arriba, nuevo abajo, link
- [ ] Editar sin cambiar texto → no DM