### PR TITLE
feat(bet): parimutuel betting with gmicoins

### DIFF
--- a/src/api/dao/bet.dao.test.ts
+++ b/src/api/dao/bet.dao.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { setupInMemoryMongo } from "../../test-utils/setup-mongo";
+import { Wager, WagerBet, Wallet } from "../models/Bet";
+import * as bet from "./bet.dao";
+
+setupInMemoryMongo();
+
+describe("computePayouts (pure parimutuel math)", () => {
+  it("winner takes the whole pool proportional to stake", () => {
+    const { credits, refunded } = bet.computePayouts(
+      [
+        { userId: "a", option: "X", amount: 100 },
+        { userId: "b", option: "Y", amount: 100 },
+      ],
+      "X"
+    );
+    expect(refunded).toBe(false);
+    expect(credits).toEqual([{ userId: "a", amount: 200 }]);
+  });
+
+  it("splits the pool across multiple winners by stake", () => {
+    const { credits } = bet.computePayouts(
+      [
+        { userId: "a", option: "X", amount: 100 },
+        { userId: "b", option: "X", amount: 100 },
+        { userId: "c", option: "Y", amount: 200 },
+      ],
+      "X"
+    );
+    // total 400, winnerPool 200 → each X-bettor doubles
+    expect(credits).toEqual([
+      { userId: "a", amount: 200 },
+      { userId: "b", amount: 200 },
+    ]);
+  });
+
+  it("floors payouts (house keeps the dust)", () => {
+    const { credits } = bet.computePayouts(
+      [
+        { userId: "a", option: "X", amount: 100 },
+        { userId: "b", option: "Y", amount: 50 },
+      ],
+      "X"
+    );
+    // total 150, winnerPool 100 → 100*150/100 = 150
+    expect(credits[0].amount).toBe(150);
+  });
+
+  it("refunds everyone when nobody backed the winner", () => {
+    const { credits, refunded } = bet.computePayouts(
+      [{ userId: "a", option: "X", amount: 100 }],
+      "Y"
+    );
+    expect(refunded).toBe(true);
+    expect(credits).toEqual([{ userId: "a", amount: 100 }]);
+  });
+});
+
+describe("bet.dao (in-memory mongo)", () => {
+  it("seeds INITIAL_BALANCE on first wallet touch", async () => {
+    expect(await bet.getBalance("u1")).toBe(bet.INITIAL_BALANCE);
+  });
+
+  it("grant adds coins (and creates the wallet)", async () => {
+    const balance = await bet.grant("u2", 500);
+    expect(balance).toBe(bet.INITIAL_BALANCE + 500);
+  });
+
+  it("placeBet deducts the stake atomically", async () => {
+    const w = await bet.createWager("t", ["X", "Y"], "owner");
+    const res = await bet.placeBet(
+      (w._id as any).toString(),
+      "u3",
+      "X",
+      100
+    );
+    expect(res).toEqual({ ok: true, balance: bet.INITIAL_BALANCE - 100 });
+    expect((await Wallet.findOne({ userId: "u3" }))!.balance).toBe(900);
+  });
+
+  it("rejects a bet the user can't afford, leaving the balance untouched", async () => {
+    const w = await bet.createWager("t", ["X", "Y"], "owner");
+    const res = await bet.placeBet(
+      (w._id as any).toString(),
+      "u4",
+      "X",
+      99999
+    );
+    expect(res).toEqual({ ok: false, reason: "insufficient" });
+    expect(await bet.getBalance("u4")).toBe(bet.INITIAL_BALANCE);
+  });
+
+  it("rejects a second bet on the same wager and refunds the deduction", async () => {
+    const w = await bet.createWager("t", ["X", "Y"], "owner");
+    const id = (w._id as any).toString();
+    await bet.placeBet(id, "u5", "X", 100);
+    const second = await bet.placeBet(id, "u5", "Y", 100);
+    expect(second).toEqual({ ok: false, reason: "already-bet" });
+    // only one deduction stuck
+    expect(await bet.getBalance("u5")).toBe(bet.INITIAL_BALANCE - 100);
+    expect(await WagerBet.countDocuments({ wagerId: id, userId: "u5" })).toBe(1);
+  });
+
+  it("resolveWager credits winners and marks the wager resolved", async () => {
+    const w = await bet.createWager("final", ["X", "Y"], "owner");
+    const id = (w._id as any).toString();
+    await bet.placeBet(id, "winner", "X", 100);
+    await bet.placeBet(id, "loser", "Y", 100);
+
+    const { credits } = await bet.resolveWager(id, "X");
+    expect(credits).toEqual([{ userId: "winner", amount: 200 }]);
+    // winner: 1000 - 100 + 200 = 1100 ; loser: 1000 - 100 = 900
+    expect(await bet.getBalance("winner")).toBe(1100);
+    expect(await bet.getBalance("loser")).toBe(900);
+    expect((await Wager.findById(id))!.status).toBe("resolved");
+  });
+
+  it("getCoinName falls back to gmicoins with no setting", async () => {
+    expect(await bet.getCoinName()).toBe("gmicoins");
+  });
+});

--- a/src/api/dao/bet.dao.ts
+++ b/src/api/dao/bet.dao.ts
@@ -1,0 +1,136 @@
+// ponytail: no ResponseData/service layer here — /bet has no HTTP/API surface,
+// it's pure bot-internal logic. DAO returns plain domain values / throws.
+import Setting from "../models/Settings";
+import { IWagerBet, Wager, WagerBet, Wallet } from "../models/Bet";
+
+export const INITIAL_BALANCE = 1000;
+const DEFAULT_COIN_NAME = "gmicoins";
+
+export const getCoinName = async (): Promise<string> => {
+  const doc = await Setting.findOne({ key: "coinName" });
+  return doc?.value || DEFAULT_COIN_NAME;
+};
+
+/** Get-or-create the user's wallet, seeding INITIAL_BALANCE on first touch. */
+export const getBalance = async (userId: string): Promise<number> => {
+  const w = await Wallet.findOneAndUpdate(
+    { userId },
+    { $setOnInsert: { balance: INITIAL_BALANCE } },
+    { new: true, upsert: true }
+  );
+  return w!.balance;
+};
+
+export const grant = async (
+  userId: string,
+  amount: number
+): Promise<number> => {
+  await getBalance(userId); // ensure wallet exists
+  const w = await Wallet.findOneAndUpdate(
+    { userId },
+    { $inc: { balance: amount } },
+    { new: true }
+  );
+  return w!.balance;
+};
+
+export const createWager = (
+  title: string,
+  options: string[],
+  createdBy: string
+) => Wager.create({ title, options, createdBy });
+
+export const listOpenWagers = () =>
+  Wager.find({ status: "open" }).sort({ createdAt: -1 }).limit(25);
+
+export const getWager = (id: string) => Wager.findById(id).catch(() => null);
+
+export const getBets = (wagerId: string) => WagerBet.find({ wagerId });
+
+type PlaceResult =
+  | { ok: true; balance: number }
+  | { ok: false; reason: "insufficient" | "already-bet" };
+
+/**
+ * Deduct the stake and record the bet. One bet per (wager, user) — a second
+ * attempt is rejected. Atomic on the balance; a lost double-insert race is
+ * refunded.
+ * ponytail: check-then-insert has a tiny race; the unique index + refund
+ * closes it. Move to a transaction if this ever runs at real scale.
+ */
+export const placeBet = async (
+  wagerId: string,
+  userId: string,
+  option: string,
+  amount: number
+): Promise<PlaceResult> => {
+  await getBalance(userId); // ensure wallet exists
+
+  const deducted = await Wallet.findOneAndUpdate(
+    { userId, balance: { $gte: amount } },
+    { $inc: { balance: -amount } },
+    { new: true }
+  );
+  if (!deducted) return { ok: false, reason: "insufficient" };
+
+  try {
+    await WagerBet.create({ wagerId, userId, option, amount });
+  } catch {
+    // duplicate (already bet) — refund the deduction
+    await Wallet.updateOne({ userId }, { $inc: { balance: amount } });
+    return { ok: false, reason: "already-bet" };
+  }
+  return { ok: true, balance: deducted.balance };
+};
+
+export type Credit = { userId: string; amount: number };
+export type PayoutResult = { credits: Credit[]; refunded: boolean };
+
+/**
+ * Parimutuel payout: winners split the whole pool in proportion to their
+ * stake. If nobody backed the winner, everyone is refunded their stake.
+ * Payouts floored to whole coins (house keeps the rounding dust).
+ */
+export const computePayouts = (
+  bets: Pick<IWagerBet, "userId" | "option" | "amount">[],
+  winnerOption: string
+): PayoutResult => {
+  const total = bets.reduce((s, b) => s + b.amount, 0);
+  const winnerPool = bets
+    .filter((b) => b.option === winnerOption)
+    .reduce((s, b) => s + b.amount, 0);
+
+  if (winnerPool === 0) {
+    return {
+      credits: bets.map((b) => ({ userId: b.userId, amount: b.amount })),
+      refunded: true,
+    };
+  }
+
+  const credits = bets
+    .filter((b) => b.option === winnerOption)
+    .map((b) => ({
+      userId: b.userId,
+      amount: Math.floor((b.amount * total) / winnerPool),
+    }));
+  return { credits, refunded: false };
+};
+
+export const resolveWager = async (
+  wagerId: string,
+  winnerOption: string
+): Promise<PayoutResult> => {
+  const bets = await getBets(wagerId);
+  const result = computePayouts(bets, winnerOption);
+
+  await Promise.all(
+    result.credits.map((c) =>
+      Wallet.updateOne({ userId: c.userId }, { $inc: { balance: c.amount } })
+    )
+  );
+  await Wager.updateOne(
+    { _id: wagerId },
+    { status: "resolved", winnerOption }
+  );
+  return result;
+};

--- a/src/api/models/Bet.ts
+++ b/src/api/models/Bet.ts
@@ -1,0 +1,60 @@
+import { Document, Schema, model } from "mongoose";
+
+// ── Wager: one betting event with discrete options ──────────────────────────
+export interface IWager extends Document {
+  title: string;
+  options: string[];
+  createdBy: string; // discordId
+  status: "open" | "resolved";
+  winnerOption: string | null;
+}
+
+const WagerSchema = new Schema<IWager>(
+  {
+    title: { type: String, required: true },
+    options: { type: [String], required: true },
+    createdBy: { type: String, required: true },
+    status: { type: String, enum: ["open", "resolved"], default: "open" },
+    winnerOption: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+export const Wager = model<IWager>("Wager", WagerSchema);
+
+// ── WagerBet: one user's stake on one option. One bet per (wager, user). ─────
+export interface IWagerBet extends Document {
+  wagerId: string;
+  userId: string;
+  option: string;
+  amount: number;
+}
+
+const WagerBetSchema = new Schema<IWagerBet>(
+  {
+    wagerId: { type: String, required: true, index: true },
+    userId: { type: String, required: true },
+    option: { type: String, required: true },
+    amount: { type: Number, required: true, min: 1 },
+  },
+  { timestamps: true }
+);
+WagerBetSchema.index({ wagerId: 1, userId: 1 }, { unique: true });
+
+export const WagerBet = model<IWagerBet>("WagerBet", WagerBetSchema);
+
+// ── Wallet: per-user gmicoin balance ────────────────────────────────────────
+export interface IWallet extends Document {
+  userId: string;
+  balance: number;
+}
+
+const WalletSchema = new Schema<IWallet>(
+  {
+    userId: { type: String, required: true, unique: true, index: true },
+    balance: { type: Number, required: true, min: 0 },
+  },
+  { timestamps: true }
+);
+
+export const Wallet = model<IWallet>("Wallet", WalletSchema);

--- a/src/api/models/Settings.ts
+++ b/src/api/models/Settings.ts
@@ -1,0 +1,14 @@
+import { Document, Schema, model } from "mongoose";
+
+// Generic key/value settings. Edited directly in the DB (no command).
+export interface ISetting extends Document {
+  key: string;
+  value: string;
+}
+
+const SettingSchema = new Schema<ISetting>({
+  key: { type: String, required: true, unique: true, index: true },
+  value: { type: String, required: true },
+});
+
+export default model<ISetting>("Setting", SettingSchema);

--- a/src/slashCommands/fun/bet.test.ts
+++ b/src/slashCommands/fun/bet.test.ts
@@ -1,0 +1,130 @@
+import { MessageFlags } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api/dao/bet.dao");
+
+import * as betDao from "../../api/dao/bet.dao";
+import {
+  createMockClient,
+  createMockInteraction,
+  subCommandArg,
+} from "../../test-utils/discord-mocks";
+import bet from "./bet";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(betDao.getCoinName).mockResolvedValue("gmicoins");
+});
+
+describe("/bet", () => {
+  it("create rejects fewer than 2 options", async () => {
+    const i = createMockInteraction();
+    await bet.run(createMockClient(), i, [
+      subCommandArg("create", [
+        { name: "title", value: "solo" },
+        { name: "options", value: "uno" },
+      ]),
+    ]);
+    expect(i.reply.mock.calls[0][0].flags).toBe(MessageFlags.Ephemeral);
+    expect(betDao.createWager).not.toHaveBeenCalled();
+  });
+
+  it("create makes a wager with parsed options", async () => {
+    vi.mocked(betDao.createWager).mockResolvedValue({} as any);
+    const i = createMockInteraction();
+    await bet.run(createMockClient(), i, [
+      subCommandArg("create", [
+        { name: "title", value: "Boca vs River" },
+        { name: "options", value: "Boca, River, Empate" },
+      ]),
+    ]);
+    expect(betDao.createWager).toHaveBeenCalledWith(
+      "Boca vs River",
+      ["Boca", "River", "Empate"],
+      "user-1"
+    );
+  });
+
+  it("balance shows the caller's balance", async () => {
+    vi.mocked(betDao.getBalance).mockResolvedValue(1234);
+    const i = createMockInteraction();
+    await bet.run(createMockClient(), i, [subCommandArg("balance")]);
+    const p = i.reply.mock.calls[0][0];
+    expect(p.flags).toBe(MessageFlags.Ephemeral);
+    expect(p.content).toContain("1234");
+  });
+
+  it("place confirms a successful bet", async () => {
+    vi.mocked(betDao.getWager).mockResolvedValue({
+      status: "open",
+      options: ["Boca", "River"],
+    } as any);
+    vi.mocked(betDao.placeBet).mockResolvedValue({ ok: true, balance: 900 });
+    const i = createMockInteraction();
+    await bet.run(createMockClient(), i, [
+      subCommandArg("place", [
+        { name: "wager", value: "wid" },
+        { name: "option", value: "Boca" },
+        { name: "amount", value: 100 },
+      ]),
+    ]);
+    expect(i.reply.mock.calls[0][0].content).toContain("900");
+  });
+
+  it("place rejects an invalid option before touching the wallet", async () => {
+    vi.mocked(betDao.getWager).mockResolvedValue({
+      status: "open",
+      options: ["Boca", "River"],
+    } as any);
+    const i = createMockInteraction();
+    await bet.run(createMockClient(), i, [
+      subCommandArg("place", [
+        { name: "wager", value: "wid" },
+        { name: "option", value: "Nope" },
+        { name: "amount", value: 100 },
+      ]),
+    ]);
+    expect(i.reply.mock.calls[0][0].content).toContain("inválida");
+    expect(betDao.placeBet).not.toHaveBeenCalled();
+  });
+
+  it("resolve is owner-only", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const i = createMockInteraction({ user: { id: "intruder" } });
+    await bet.run(client, i, [
+      subCommandArg("resolve", [
+        { name: "wager", value: "wid" },
+        { name: "winner", value: "Boca" },
+      ]),
+    ]);
+    expect(i.reply.mock.calls[0][0].content).toContain("owner");
+    expect(betDao.resolveWager).not.toHaveBeenCalled();
+  });
+
+  it("grant is owner-only", async () => {
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const i = createMockInteraction({ user: { id: "intruder" } });
+    await bet.run(client, i, [
+      subCommandArg("grant", [
+        { name: "user", value: "u1" },
+        { name: "amount", value: 500 },
+      ]),
+    ]);
+    expect(i.reply.mock.calls[0][0].content).toContain("owner");
+    expect(betDao.grant).not.toHaveBeenCalled();
+  });
+
+  it("grant by the owner credits the target", async () => {
+    vi.mocked(betDao.grant).mockResolvedValue(1500);
+    const client = createMockClient({ config: { ownerId: "owner-1" } });
+    const i = createMockInteraction({ user: { id: "owner-1" } });
+    await bet.run(client, i, [
+      subCommandArg("grant", [
+        { name: "user", value: "u1" },
+        { name: "amount", value: 500 },
+      ]),
+    ]);
+    expect(betDao.grant).toHaveBeenCalledWith("u1", 500);
+    expect(i.reply.mock.calls[0][0].content).toContain("1500");
+  });
+});

--- a/src/slashCommands/fun/bet.ts
+++ b/src/slashCommands/fun/bet.ts
@@ -1,0 +1,432 @@
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import * as betDao from "../../api/dao/bet.dao";
+import ClientDiscord from "../../shared/classes/ClientDiscord";
+import {
+  BOT_BRAND_NAME,
+  BOT_VERSION,
+  colorForCategory,
+} from "../../shared/constants/branding";
+import { Argument, ISlashCommand } from "../../shared/types";
+import { errorHandler } from "../../shared/utils/helpers";
+
+const SUB = {
+  create: "create",
+  place: "place",
+  status: "status",
+  resolve: "resolve",
+  balance: "balance",
+  grant: "grant",
+} as const;
+
+const OPT = {
+  title: "title",
+  options: "options",
+  wager: "wager",
+  option: "option",
+  amount: "amount",
+  winner: "winner",
+  user: "user",
+} as const;
+
+const MAX_OPTIONS = 10;
+
+type SubArg = NonNullable<Argument["args"]>[number];
+const findArg = (args: SubArg[] | undefined, name: string) =>
+  args?.find((a) => a.name === name)?.value;
+const isOwner = (i: ChatInputCommandInteraction, c: ClientDiscord) =>
+  i.user.id === c.config.ownerId;
+
+const baseEmbed = () =>
+  new EmbedBuilder()
+    .setColor(colorForCategory("fun"))
+    .setFooter({ text: `${BOT_BRAND_NAME} ${BOT_VERSION}` });
+
+const parseOptions = (raw: string): string[] => {
+  const seen = new Set<string>();
+  return raw
+    .split(/[,;]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !seen.has(s.toLowerCase()) && seen.add(s.toLowerCase()));
+};
+
+const eph = (content: string) =>
+  ({ content, flags: MessageFlags.Ephemeral }) as const;
+
+// ── create ──────────────────────────────────────────────────────────────────
+const handleCreate = async (
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  const title = (findArg(subArgs, OPT.title) as string).trim();
+  const options = parseOptions(findArg(subArgs, OPT.options) as string);
+
+  if (options.length < 2) {
+    return interaction.reply(
+      eph("Necesitas al menos 2 opciones separadas por coma.")
+    );
+  }
+  if (options.length > MAX_OPTIONS) {
+    return interaction.reply(eph(`Máximo ${MAX_OPTIONS} opciones.`));
+  }
+
+  const wager = await betDao.createWager(title, options, interaction.user.id);
+  const coin = await betDao.getCoinName();
+
+  const embed = baseEmbed()
+    .setTitle(`🎲 ${title}`)
+    .setDescription(
+      `Apuesta abierta. Usa \`/bet place\` para apostar tus ${coin}.`
+    )
+    .addFields({
+      name: "Opciones",
+      value: options.map((o) => `• ${o}`).join("\n"),
+    });
+
+  return interaction.reply({
+    embeds: [embed],
+    allowedMentions: { parse: [] },
+  });
+};
+
+// ── place ───────────────────────────────────────────────────────────────────
+const handlePlace = async (
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  const wagerId = findArg(subArgs, OPT.wager) as string;
+  const option = findArg(subArgs, OPT.option) as string;
+  const amount = findArg(subArgs, OPT.amount) as number;
+  const coin = await betDao.getCoinName();
+
+  if (amount < 1) return interaction.reply(eph("El monto debe ser al menos 1."));
+
+  const wager = await betDao.getWager(wagerId);
+  if (!wager || wager.status !== "open") {
+    return interaction.reply(eph("Esa apuesta no existe o ya cerró."));
+  }
+  if (!wager.options.includes(option)) {
+    return interaction.reply(
+      eph(`Opción inválida. Elegí una de: ${wager.options.join(", ")}.`)
+    );
+  }
+
+  const res = await betDao.placeBet(
+    wagerId,
+    interaction.user.id,
+    option,
+    amount
+  );
+  if (!res.ok) {
+    return interaction.reply(
+      eph(
+        res.reason === "insufficient"
+          ? `No te alcanzan los ${coin}.`
+          : "Ya apostaste en esta apuesta."
+      )
+    );
+  }
+
+  return interaction.reply(
+    eph(
+      `✅ Apostaste **${amount}** ${coin} en **${option}**. Saldo: **${res.balance}**.`
+    )
+  );
+};
+
+// ── status ──────────────────────────────────────────────────────────────────
+const handleStatus = async (
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  const wagerId = findArg(subArgs, OPT.wager) as string;
+  const wager = await betDao.getWager(wagerId);
+  if (!wager) return interaction.reply(eph("Esa apuesta no existe."));
+
+  const bets = await betDao.getBets(wagerId);
+  const total = bets.reduce((s, b) => s + b.amount, 0);
+  const coin = await betDao.getCoinName();
+
+  const fields = wager.options.map((opt) => {
+    const forOpt = bets.filter((b) => b.option === opt);
+    const pool = forOpt.reduce((s, b) => s + b.amount, 0);
+    const mult = pool > 0 ? (total / pool).toFixed(2) : "—";
+    return {
+      name: opt,
+      value: `Pozo: **${pool}** ${coin}\nApostaron: **${forOpt.length}**\nPaga: **x${mult}**`,
+      inline: true,
+    };
+  });
+
+  const embed = baseEmbed()
+    .setTitle(`🎲 ${wager.title}`)
+    .setDescription(
+      wager.status === "resolved"
+        ? `✅ Resuelta — ganó **${wager.winnerOption}**.`
+        : `Pozo total: **${total}** ${coin}.`
+    )
+    .addFields(fields);
+
+  return interaction.reply({ embeds: [embed] });
+};
+
+// ── resolve (owner) ─────────────────────────────────────────────────────────
+const handleResolve = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  if (!isOwner(interaction, client)) {
+    return interaction.reply(eph("Solo el owner puede resolver apuestas."));
+  }
+  const wagerId = findArg(subArgs, OPT.wager) as string;
+  const winner = findArg(subArgs, OPT.winner) as string;
+
+  const wager = await betDao.getWager(wagerId);
+  if (!wager) return interaction.reply(eph("Esa apuesta no existe."));
+  if (wager.status === "resolved") {
+    return interaction.reply(eph("Esa apuesta ya estaba resuelta."));
+  }
+  if (!wager.options.includes(winner)) {
+    return interaction.reply(
+      eph(`Opción inválida. Elegí una de: ${wager.options.join(", ")}.`)
+    );
+  }
+
+  const { credits, refunded } = await betDao.resolveWager(wagerId, winner);
+  const coin = await betDao.getCoinName();
+  const paid = credits.reduce((s, c) => s + c.amount, 0);
+
+  const embed = baseEmbed()
+    .setTitle(`🏆 ${wager.title}`)
+    .setDescription(
+      refunded
+        ? `Nadie le apostó a **${winner}** — se devolvieron las apuestas.`
+        : `Ganó **${winner}**. Se repartieron **${paid}** ${coin} entre **${credits.length}** ${credits.length === 1 ? "ganador" : "ganadores"}.`
+    );
+
+  return interaction.reply({ embeds: [embed], allowedMentions: { parse: [] } });
+};
+
+// ── balance ─────────────────────────────────────────────────────────────────
+const handleBalance = async (interaction: ChatInputCommandInteraction) => {
+  const balance = await betDao.getBalance(interaction.user.id);
+  const coin = await betDao.getCoinName();
+  return interaction.reply(eph(`💰 Tienes **${balance}** ${coin}.`));
+};
+
+// ── grant (owner) ───────────────────────────────────────────────────────────
+const handleGrant = async (
+  client: ClientDiscord,
+  interaction: ChatInputCommandInteraction,
+  subArgs: SubArg[]
+) => {
+  if (!isOwner(interaction, client)) {
+    return interaction.reply(eph("Solo el owner puede dar monedas."));
+  }
+  const userId = findArg(subArgs, OPT.user) as string;
+  const amount = findArg(subArgs, OPT.amount) as number;
+  if (amount === 0) return interaction.reply(eph("El monto no puede ser 0."));
+
+  const balance = await betDao.grant(userId, amount);
+  const coin = await betDao.getCoinName();
+  return interaction.reply(
+    eph(`✅ <@${userId}> ahora tiene **${balance}** ${coin}.`)
+  );
+};
+
+const pull: ISlashCommand = {
+  name: "bet",
+  category: "fun",
+  description: "Apuestas con gmicoins (pozo compartido)",
+  ownerOnly: false,
+  options: [
+    {
+      name: SUB.create,
+      description: "Crear una apuesta",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.title,
+          description: "Título de la apuesta",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+        },
+        {
+          name: OPT.options,
+          description: "Opciones separadas por coma (mín. 2)",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+        },
+      ],
+    },
+    {
+      name: SUB.place,
+      description: "Apostar en una opción",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.wager,
+          description: "Apuesta",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+        {
+          name: OPT.option,
+          description: "Opción a la que apostás",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+        {
+          name: OPT.amount,
+          description: "Cantidad de gmicoins",
+          type: ApplicationCommandOptionType.Integer,
+          required: true,
+        },
+      ],
+    },
+    {
+      name: SUB.status,
+      description: "Ver el estado y los pagos de una apuesta",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.wager,
+          description: "Apuesta",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+      ],
+    },
+    {
+      name: SUB.resolve,
+      description: "[Owner] Resolver una apuesta",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.wager,
+          description: "Apuesta",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+        {
+          name: OPT.winner,
+          description: "Opción ganadora",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+      ],
+    },
+    {
+      name: SUB.balance,
+      description: "Ver tu saldo de gmicoins",
+      type: ApplicationCommandOptionType.Subcommand,
+    },
+    {
+      name: SUB.grant,
+      description: "[Owner] Dar gmicoins a alguien",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: OPT.user,
+          description: "Usuario",
+          type: ApplicationCommandOptionType.User,
+          required: true,
+        },
+        {
+          name: OPT.amount,
+          description: "Cantidad (negativo para restar)",
+          type: ApplicationCommandOptionType.Integer,
+          required: true,
+        },
+      ],
+    },
+  ],
+  examples: [
+    "/bet create title:Boca vs River options:Boca, River, Empate",
+    "/bet place wager:... option:Boca amount:100",
+    "/bet status wager:...",
+    "/bet balance",
+  ],
+  autocomplete: async (
+    _: ClientDiscord,
+    interaction: AutocompleteInteraction
+  ) => {
+    const focused = interaction.options.getFocused(true);
+
+    if (focused.name === OPT.wager) {
+      const wagers = await betDao.listOpenWagers();
+      const q = String(focused.value ?? "").toLowerCase();
+      await interaction.respond(
+        wagers
+          .filter((w) => w.title.toLowerCase().includes(q))
+          .slice(0, 25)
+          .map((w) => ({
+            name: w.title.slice(0, 100),
+            value: (w._id as any).toString(),
+          }))
+      );
+      return;
+    }
+
+    // option / winner autocomplete depends on the selected wager
+    if (focused.name === OPT.option || focused.name === OPT.winner) {
+      const wagerId = interaction.options.getString(OPT.wager);
+      if (!wagerId) return interaction.respond([]);
+      const wager = await betDao.getWager(wagerId);
+      const q = String(focused.value ?? "").toLowerCase();
+      await interaction.respond(
+        (wager?.options ?? [])
+          .filter((o) => o.toLowerCase().includes(q))
+          .slice(0, 25)
+          .map((o) => ({ name: o, value: o }))
+      );
+      return;
+    }
+
+    await interaction.respond([]);
+  },
+  run: async (
+    client: ClientDiscord,
+    interaction: ChatInputCommandInteraction,
+    args: Argument[]
+  ) => {
+    try {
+      const sub = args[0];
+      if (!sub) return;
+      const subArgs = sub.args ?? [];
+
+      switch (sub.name) {
+        case SUB.create:
+          return handleCreate(interaction, subArgs);
+        case SUB.place:
+          return handlePlace(interaction, subArgs);
+        case SUB.status:
+          return handleStatus(interaction, subArgs);
+        case SUB.resolve:
+          return handleResolve(client, interaction, subArgs);
+        case SUB.balance:
+          return handleBalance(interaction);
+        case SUB.grant:
+          return handleGrant(client, interaction, subArgs);
+        default:
+          return;
+      }
+    } catch (error) {
+      errorHandler(interaction, error);
+    }
+  },
+};
+
+export default pull;

--- a/src/slashCommands/index.ts
+++ b/src/slashCommands/index.ts
@@ -12,6 +12,7 @@
 import { ISlashCommand } from "../shared/types";
 
 import ahorcado from "./fun/ahorcado";
+import bet from "./fun/bet";
 import flip from "./fun/flip";
 import imc from "./fun/imc";
 import love from "./fun/love";
@@ -41,6 +42,7 @@ import who from "./mod/who";
 const slashCommands: ISlashCommand[] = [
   // fun
   ahorcado,
+  bet,
   flip,
   imc,
   love,


### PR DESCRIPTION
Sistema de apuestas de pozo compartido (parimutuel). Moneda **gmicoins**.

## Subcomandos
| Sub | Quién | Qué |
|---|---|---|
| `create title options` | todos | Abre apuesta (2–10 opciones por coma) |
| `place wager option amount` | todos | Apuesta (autocomplete de wager + opción) |
| `status wager` | todos | Pozo por opción, nº de apostadores, **multiplicador de pago** |
| `resolve wager winner` | owner | Paga a ganadores proporcional al pozo |
| `balance` | todos | Tu saldo |
| `grant user amount` | owner | Da/quita monedas |

## Cómo paga (parimutuel)
Los ganadores se reparten **todo el pozo** en proporción a lo apostado. Multiplicador de una opción = pozo_total / pozo_opción. Si nadie le apostó al ganador → se devuelven las apuestas. Pagos redondeados hacia abajo (la casa se queda el resto).

- Stake se descuenta al apostar, se acredita al resolver.
- Una apuesta por (wager, usuario).
- Wallets arrancan en **1000** al primer uso.
- Nombre de la moneda en un doc `Settings` (`key: coinName`, default `gmicoins`), editable en la BD sin comando.

## Notas de scope (lazy)
- Sin `duration`/auto-cierre: la apuesta cierra cuando el owner la resuelve. Se agrega scheduler si hace falta.
- Sin modal para el monto: va como opción del comando. Modal queda para v2.
- El DAO no usa la capa ResponseData/service porque `/bet` no tiene superficie HTTP.

## Tests — 304/304 (+19)
- `computePayouts` puro: split proporcional, múltiples ganadores, floor, refund.
- `bet.dao` contra mongo en memoria: seed 1000, grant, deduct atómico, insuficiente, doble apuesta con refund, resolve end-to-end.
- Comando: gates de owner (resolve/grant), validación de opciones.

### Smoke en Discord
- [ ] `/bet create title:Boca vs River options:Boca, River, Empate`
- [ ] `/bet place` → autocomplete de la apuesta y de la opción
- [ ] `/bet status` → multiplicadores por opción
- [ ] `/bet balance`
- [ ] `/bet grant` (owner) y rechazo a no-owner
- [ ] `/bet resolve` (owner) → ganadores cobran, saldo actualizado
- [ ] Resolver con nadie en el ganador → refund